### PR TITLE
Fix plasma input units in documentation

### DIFF
--- a/doc/running.md
+++ b/doc/running.md
@@ -61,12 +61,12 @@ Required when `nonlin=.true.` or `comptorque=.true.`. The file format matches th
 2. `nflux  am1  am2  Z1  Z2` – number of flux surfaces, ion masses (amu), and charges.
 3. Comment line (ignored).
 4. `nflux` data rows with six columns:
-   - `s` – Normalised toroidal flux.
-   - `n₁` – Density of species 1 (`1/m³`).
-   - `n₂` – Density of species 2 (`1/m³`).
-   - `T₁` – Temperature of species 1 (`eV`).
-   - `T₂` – Temperature of species 2 (`eV`).
-   - `T_e` – Electron temperature (`eV`).
+   - $s$ – Normalised toroidal flux.
+   - $n_1$ – Density of species 1 (1/cm³).
+   - $n_2$ – Density of species 2 (1/cm³).
+   - $T_1$ – Temperature of species 1 (eV).
+   - $T_2$ – Temperature of species 2 (eV).
+   - $T_e$ – Electron temperature (eV).
 
 The solver creates spline coefficients from these values to evaluate densities, temperatures, and their radial derivatives at the requested flux surface.
 


### PR DESCRIPTION
### **User description**
Density should be in 1/cm^3, not 1/m^3.
Use math for nicer display of variables.


___

### **PR Type**
Documentation


___

### **Description**
- Fix plasma density units from 1/m³ to 1/cm³

- Use LaTeX math notation for variable display

- Improve documentation clarity and consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation file"] -- "Update density units" --> B["1/cm³ instead of 1/m³"]
  A -- "Apply LaTeX formatting" --> C["Math notation for variables"]
  B --> D["Corrected plasma input docs"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>running.md</strong><dd><code>Fix density units and apply LaTeX formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

doc/running.md

<ul><li>Corrected plasma density units from <code>1/m³</code> to <code>1/cm³</code> for species 1 and 2<br> <li> Converted variable names to LaTeX math notation using <code>$...$</code> syntax<br> <li> Applied consistent formatting to all plasma parameter descriptions<br> <li> Maintained temperature units in eV for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/NEO-RT/pull/21/files#diff-eee3e0232b7307423cf1511db9015698cdfbd80506ccc52a850d5761ffeb49ab">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

