### PR TITLE
Allow external libneo_ref trigger in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,21 @@ on:
   pull_request:
     branches: [ "main" ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually, and lets an upstream libneo
+  # release dispatch it against a candidate ref.
   workflow_dispatch:
+    inputs:
+      libneo_ref:
+        description: libneo branch, tag or commit to build against
+        required: false
+        default: ''
 
 permissions:
   contents: read
+
+env:
+  # Propagates through the NEO-2 dependency to the transitive libneo fetch.
+  LIBNEO_REF: ${{ inputs.libneo_ref }}
 
 jobs:
   build:


### PR DESCRIPTION
**Merge after #41 (the resolver PR).** The `LIBNEO_REF` env added here is inert until that resolver PR lands and reads it; merging this first is harmless but does nothing.

Adds a `libneo_ref` `workflow_dispatch` input mapped to `LIBNEO_REF`, so an upstream libneo release can dispatch this CI to build NEO-RT against a candidate ref (branch, tag or commit). Empty on push/PR, so normal builds keep the committed default. NEO-RT consumes libneo transitively through NEO-2, so the env propagates to that fetch.