### PR TITLE
Fetch fortnum and link it into neo_rt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
-        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
         GIT_TAG a7faa3c
     )
     FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,16 @@ find_or_fetch(spline)
 find_or_fetch(vode)
 
 include(FetchContent)
+
+if(NOT TARGET fortnum)
+    FetchContent_Declare(
+        fortnum
+        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_TAG a7faa3c
+    )
+    FetchContent_MakeAvailable(fortnum)
+endif()
+
 FetchContent_Declare(
     fortplot
     GIT_REPOSITORY https://github.com/lazy-fortran/fortplot.git
@@ -156,6 +166,7 @@ find_package(LAPACK)
 
 target_link_libraries(neo_rt PUBLIC
     vode
+    fortnum
     spline
     BLAS::BLAS
     LAPACK::LAPACK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG a7faa3c
+        GIT_TAG v0.1.0
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG v0.1.0
+        GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
     )
     FetchContent_MakeAvailable(fortnum)
 endif()


### PR DESCRIPTION
## Merge order

This PR is part of the fortnum ODE migration stack. Each PR is now based on
`main` individually, but they must be merged in this sequence:

    #45 -> #46 -> #47

- #45 Fetch fortnum and link it into neo_rt
- #46 Move non-event orbit integrations onto the fortnum ODE solver
- #47 Move bounce_integral event search onto fortnum and drop vode

Because all three are based on `main`, each later PR's diff is currently
cumulative (it contains its predecessors' changes). Merge in the order above:
once a predecessor merges into `main`, the next PR's diff shrinks to its own
increment.

Base of the NEO-RT migration off the external DVODE solver onto fortnum.

Declares fortnum via FetchContent pinned at a7faa3c and links it into the
neo_rt target. No source behaviour changes here; this only makes the
fortnum ODE modules available to the later commits in the stack.

Stack:
1. migrate/fortnum-ode-cmake (this PR, base main)
2. migrate/fortnum-ode-nonevent (base cmake)
3. migrate/fortnum-ode-events-drop-vode (base nonevent)

## Verification

Configured and built on top of the full stack; see the head PR for the
combined build and test output. This PR alone adds the dependency wiring.


Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.
