### PR TITLE
Move non-event orbit integrations onto the fortnum ODE solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
-        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
         GIT_TAG a7faa3c
     )
     FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG 974dcf12e2599ffa5882380207d753c8e8e0a9f6
+        GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG e7df01236d46f30fffd01135b1ba00a465b64dae
+        GIT_TAG 974dcf12e2599ffa5882380207d753c8e8e0a9f6
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,16 @@ find_or_fetch(spline)
 find_or_fetch(vode)
 
 include(FetchContent)
+
+if(NOT TARGET fortnum)
+    FetchContent_Declare(
+        fortnum
+        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_TAG a7faa3c
+    )
+    FetchContent_MakeAvailable(fortnum)
+endif()
+
 FetchContent_Declare(
     fortplot
     GIT_REPOSITORY https://github.com/lazy-fortran/fortplot.git
@@ -156,6 +166,7 @@ find_package(LAPACK)
 
 target_link_libraries(neo_rt PUBLIC
     vode
+    fortnum
     spline
     BLAS::BLAS
     LAPACK::LAPACK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG a7faa3c
+        GIT_TAG v0.1.0
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG v0.1.0
+        GIT_TAG e7df01236d46f30fffd01135b1ba00a465b64dae
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/src/diag/diag_bounce_debug.f90
+++ b/src/diag/diag_bounce_debug.f90
@@ -14,7 +14,9 @@ module diag_bounce_debug
                         etatp, etadt, efac
   use do_magfie_mod, only: R0, s, q, bfac, do_magfie_init
   use do_magfie_pert_mod, only: do_magfie_pert_init
-  use dvode_f90_m, only: dvode_f90, set_normal_opts, vode_opts, get_stats
+  use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
+  use fortnum_ode_dop853, only: ode_integrate_dop
+  use fortnum_status, only: fortnum_status_t, FORTNUM_OK
   implicit none
 
 contains
@@ -124,36 +126,52 @@ contains
     integer, intent(out) :: istats(:)
     real(dp), intent(out) :: rstats(:)
 
-    real(dp) :: t1, t2
-    real(dp) :: y(nvar)
-    real(dp) :: atol(nvar), rtol
-    integer :: neq, itask
-    type(vode_opts) :: options
+    real(dp) :: y0(nvar)
+    type(ode_problem_t) :: problem
+    type(ode_workspace_t) :: workspace
+    type(ode_solution_t) :: solution
+    type(fortnum_status_t) :: status
 
-    t1 = 0.0_dp
-    t2 = taub
-    y = 1.0e-15_dp
-    y(1) = 0.0_dp
-    y(2) = 0.0_dp
-    y(3:6) = 0.0_dp
-    neq = nvar
-    rtol = 1.0e-8_dp
-    atol = 1.0e-9_dp
-    itask = 1
-    istate = 1
-    options = set_normal_opts(abserr_vector=atol, relerr=rtol)
+    istats = 0
+    rstats = 0.0_dp
 
-    call dvode_f90(timestep_wrapper, neq, y, t1, t2, itask, istate, options)
-    call get_stats(rstats, istats)
+    y0 = 1.0e-15_dp
+    y0(1) = 0.0_dp
+    y0(2) = 0.0_dp
+    y0(3:6) = 0.0_dp
+
+    problem%rhs => probe_rhs
+    problem%t0 = 0.0_dp
+    problem%t1 = taub
+    problem%y0 = y0
+    problem%rtol = 1.0e-8_dp
+    problem%atol = 1.0e-9_dp
+
+    call ode_integrate_dop(problem, workspace, solution, status)
+
+    ! Report the integrator diagnostics in the slots scan_branch prints:
+    ! istats(1) = accepted steps, rstats(6) = last step size.
+    if (status%code == FORTNUM_OK) then
+      istate = 2
+    else
+      istate = -1
+    end if
+    istats(1) = solution%nsteps
+    istats(2) = solution%nrejected
+    if (allocated(solution%h) .and. solution%nsteps > 0) then
+      rstats(6) = solution%h(solution%nsteps)
+    end if
 
   contains
-    subroutine timestep_wrapper(neq_, t_, y_, ydot_)
-      integer, intent(in) :: neq_
+    subroutine probe_rhs(t_, y_, dydt_, ctx_)
       real(dp), intent(in) :: t_
-      real(dp), intent(in) :: y_(neq_)
-      real(dp), intent(out) :: ydot_(neq_)
-      call timestep_transport(v, eta, neq_, t_, y_, ydot_)
-    end subroutine timestep_wrapper
+      real(dp), intent(in) :: y_(:)
+      real(dp), intent(out) :: dydt_(:)
+      class(*), intent(in), optional :: ctx_
+      associate (dummy => ctx_)
+      end associate
+      call timestep_transport(v, eta, size(y_), t_, y_, dydt_)
+    end subroutine probe_rhs
   end subroutine probe_bounce
 
 end module diag_bounce_debug

--- a/src/freq.f90
+++ b/src/freq.f90
@@ -8,7 +8,6 @@ module neort_freq
     use driftorbit, only: etamin, etamax, etatp, etadt, epsst_spl, epst_spl, epst, magdrift, &
         epssp_spl, epsp_spl, sign_vpar, sign_vpar_htheta, mph, nonlin
     use do_magfie_mod, only: iota, s, Bthcov, Bphcov, q
-    use dvode_f90_m, only: vode_thread_init
     implicit none
 
     ! For splining in the trapped eta region
@@ -46,8 +45,6 @@ contains
     subroutine freq_thread_init()
         ! Initialize threadprivate variables for this thread
         ! Must be called once per thread before using frequency routines
-        ! Also initializes VODE threadprivate state since freq uses bounce integration
-        call vode_thread_init()
         freq_trapped_initialized = .false.
         freq_passing_initialized = .false.
         k_taub_p = 0.0_dp

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -143,8 +143,7 @@ contains
     end function vperp
 
     subroutine bounce_fast(v, eta, taub, bounceavg, ts, istate_out)
-        use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
-        use fortnum_ode_dop853, only: ode_integrate_dop
+        use fortnum_ode_vode, only: vode_state_t, vode_init, vode_integrate_to
         use fortnum_status, only: fortnum_status_t, FORTNUM_OK, &
             FORTNUM_CONVERGENCE_ERROR
 
@@ -153,21 +152,19 @@ contains
         procedure(timestep_i) :: ts
         integer, intent(out), optional :: istate_out
 
-        ! Resolve the bounce period into at least this many DOP853 steps by
-        ! capping hmax at taub/max_steps_per_turn. The bounceavg(3:4) integrands
-        ! carry the perturbed Hamiltonian, which oscillates at the resonant
-        ! harmonic (up to ~mth + q*mph cycles per bounce). Those components are
-        ! driven, not fed back into the orbit dynamics, so the rtol error
-        ! estimate barely constrains them and the unconstrained adaptive step
-        ! grows too coarse, leaving the oscillatory integral under-resolved. The
-        ! cap recovers the DVODE result to four significant figures.
-        integer, parameter :: max_steps_per_turn = 200
+        ! Nonstiff variable-order Adams (fortnum vode, DVODE MF=10) integrated
+        ! over the single bounce span [0, taub], relative tolerance 1e-9 and a
+        ! per-component absolute tolerance 1e-10 (DVODE ITOL=2). This is the
+        ! same method NEO-RT drove through DVODE before the migration, so the
+        ! variable-order controller resolves the oscillatory bounceavg(3:4)
+        ! Hamiltonian integrands without an artificial step cap.
+        real(dp), parameter :: rtol = 1.0e-9_dp
+        real(dp), parameter :: atol_val = 1.0e-10_dp
 
         real(dp) :: t1, t2, bmod, htheta
-        real(dp) :: y0(nvar)
-        type(ode_problem_t) :: problem
-        type(ode_workspace_t) :: workspace
-        type(ode_solution_t) :: solution
+        real(dp) :: y0(nvar), atol(nvar)
+        real(dp), allocatable :: yend(:)
+        type(vode_state_t) :: vstate
         type(fortnum_status_t) :: status
         integer :: istate
 
@@ -183,15 +180,9 @@ contains
         y0(2) = sign_vpar_htheta * vpar(v, eta, bmod)
         y0(3:6) = 0.0_dp
 
-        problem%rhs => bounce_rhs
-        problem%t0 = t1
-        problem%t1 = t2
-        problem%y0 = y0
-        problem%rtol = 1.0e-9_dp
-        problem%atol = 1.0e-10_dp
-        problem%hmax = abs(taub) / real(max_steps_per_turn, dp)
-
-        call ode_integrate_dop(problem, workspace, solution, status)
+        atol = atol_val
+        call vode_init(vstate, nvar, t1, y0)
+        call vode_integrate_to(bounce_rhs, vstate, t2, rtol, atol, yend, status)
 
         ! Map the fortnum status onto the legacy istate convention the callers
         ! already branch on: 2 = success, -1 = step budget exhausted (the old
@@ -207,7 +198,7 @@ contains
             call dvode_error_context('bounce_fast', v, eta, t1, t2, istate)
         end if
 
-        bounceavg = solution%y(:, size(solution%t)) / taub
+        bounceavg = yend / taub
         if (present(istate_out)) istate_out = istate
 
         call trace('bounce_fast complete')

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -143,7 +143,9 @@ contains
     end function vperp
 
     subroutine bounce_fast(v, eta, taub, bounceavg, ts, istate_out)
-        use dvode_f90_m
+        use fortnum_ode_dop853, only: ode_solve_dop
+        use fortnum_status, only: fortnum_status_t, FORTNUM_OK, &
+            FORTNUM_CONVERGENCE_ERROR
 
         real(dp), intent(in) :: v, eta, taub
         real(dp), intent(out) :: bounceavg(nvar)
@@ -151,10 +153,10 @@ contains
         integer, intent(out), optional :: istate_out
 
         real(dp) :: t1, t2, bmod, htheta
-        real(dp) :: y(nvar)
-        real(dp) :: atol(nvar), rtol
-        integer :: neq, itask, istate
-        type(vode_opts) :: options
+        real(dp) :: y0(nvar)
+        real(dp), allocatable :: t_out(:), y_out(:, :)
+        type(fortnum_status_t) :: status
+        integer :: istate
 
         call trace('bounce_fast')
 
@@ -163,39 +165,44 @@ contains
 
         call evaluate_bfield_local(bmod, htheta)
         sign_vpar_htheta = sign(1.0_dp, htheta) * sign_vpar
-        y = 1.0e-15_dp
-        y(1) = th0
-        y(2) = sign_vpar_htheta * vpar(v, eta, bmod)
-        y(3:6) = 0.0_dp
+        y0 = 1.0e-15_dp
+        y0(1) = th0
+        y0(2) = sign_vpar_htheta * vpar(v, eta, bmod)
+        y0(3:6) = 0.0_dp
 
-        neq = nvar
-        rtol = 1.0e-9_dp
-        atol = 1.0e-10_dp
-        itask = 1
-        istate = 1
+        call ode_solve_dop(bounce_rhs, t1, t2, y0, t_out, y_out, status, &
+            rtol=1.0e-9_dp, atol=1.0e-10_dp)
 
-        options = set_opts(method_flag=10, abserr_vector=atol, relerr=rtol, mxstep=50000)
-        call dvode_f90(timestep_wrapper, neq, y, t1, t2, itask, istate, options)
+        ! Map the fortnum status onto the legacy istate convention the callers
+        ! already branch on: 2 = success, -1 = step budget exhausted (the old
+        ! DVODE MXSTEP case), anything else = unexpected failure.
+        if (status%code == FORTNUM_OK) then
+            istate = 2
+        else if (status%code == FORTNUM_CONVERGENCE_ERROR) then
+            istate = -1
+        else
+            istate = 0
+        end if
         if (istate == -1) then
             call dvode_error_context('bounce_fast', v, eta, t1, t2, istate)
         end if
 
-        bounceavg = y/taub
+        bounceavg = y_out(:, size(y_out, 2)) / taub
         if (present(istate_out)) istate_out = istate
 
         call trace('bounce_fast complete')
 
     contains
 
-        subroutine timestep_wrapper(neq_, t_, y_, ydot_)
-            ! Wrapper routine for timestep to work with VODE
-            integer, intent(in) :: neq_
+        subroutine bounce_rhs(t_, y_, dydt_, rhs_ctx)
             real(dp), intent(in) :: t_
-            real(dp), intent(in) :: y_(neq_)
-            real(dp), intent(out) :: ydot_(neq_)
-
-            call ts(v, eta, neq_, t_, y_, ydot_)
-        end subroutine timestep_wrapper
+            real(dp), intent(in) :: y_(:)
+            real(dp), intent(out) :: dydt_(:)
+            class(*), intent(in), optional :: rhs_ctx
+            associate (dummy => rhs_ctx)
+            end associate
+            call ts(v, eta, size(y_), t_, y_, dydt_)
+        end subroutine bounce_rhs
     end subroutine bounce_fast
 
     function bounce_time(v, eta, taub_estimate) result(taub)

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -143,7 +143,8 @@ contains
     end function vperp
 
     subroutine bounce_fast(v, eta, taub, bounceavg, ts, istate_out)
-        use fortnum_ode_dop853, only: ode_solve_dop
+        use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
+        use fortnum_ode_dop853, only: ode_integrate_dop
         use fortnum_status, only: fortnum_status_t, FORTNUM_OK, &
             FORTNUM_CONVERGENCE_ERROR
 
@@ -152,9 +153,21 @@ contains
         procedure(timestep_i) :: ts
         integer, intent(out), optional :: istate_out
 
+        ! Resolve the bounce period into at least this many DOP853 steps by
+        ! capping hmax at taub/max_steps_per_turn. The bounceavg(3:4) integrands
+        ! carry the perturbed Hamiltonian, which oscillates at the resonant
+        ! harmonic (up to ~mth + q*mph cycles per bounce). Those components are
+        ! driven, not fed back into the orbit dynamics, so the rtol error
+        ! estimate barely constrains them and the unconstrained adaptive step
+        ! grows too coarse, leaving the oscillatory integral under-resolved. The
+        ! cap recovers the DVODE result to four significant figures.
+        integer, parameter :: max_steps_per_turn = 200
+
         real(dp) :: t1, t2, bmod, htheta
         real(dp) :: y0(nvar)
-        real(dp), allocatable :: t_out(:), y_out(:, :)
+        type(ode_problem_t) :: problem
+        type(ode_workspace_t) :: workspace
+        type(ode_solution_t) :: solution
         type(fortnum_status_t) :: status
         integer :: istate
 
@@ -170,8 +183,15 @@ contains
         y0(2) = sign_vpar_htheta * vpar(v, eta, bmod)
         y0(3:6) = 0.0_dp
 
-        call ode_solve_dop(bounce_rhs, t1, t2, y0, t_out, y_out, status, &
-            rtol=1.0e-9_dp, atol=1.0e-10_dp)
+        problem%rhs => bounce_rhs
+        problem%t0 = t1
+        problem%t1 = t2
+        problem%y0 = y0
+        problem%rtol = 1.0e-9_dp
+        problem%atol = 1.0e-10_dp
+        problem%hmax = abs(taub) / real(max_steps_per_turn, dp)
+
+        call ode_integrate_dop(problem, workspace, solution, status)
 
         ! Map the fortnum status onto the legacy istate convention the callers
         ! already branch on: 2 = success, -1 = step budget exhausted (the old
@@ -187,7 +207,7 @@ contains
             call dvode_error_context('bounce_fast', v, eta, t1, t2, istate)
         end if
 
-        bounceavg = y_out(:, size(y_out, 2)) / taub
+        bounceavg = solution%y(:, size(solution%t)) / taub
         if (present(istate_out)) istate_out = istate
 
         call trace('bounce_fast complete')

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -189,6 +189,12 @@ contains
         else
             ydot(5:6) = 0.0_dp
         end if
+
+        ! Zero any trailing integrands this routine does not compute (the unused
+        ! abs(B) slot, y(7)). The DOP853 solver carries every component through
+        ! its stage combinations, so an uninitialised derivative leaves a
+        ! denormal in the state that trips the underflow FPE trap.
+        ydot(7:) = 0.0_dp
     end subroutine timestep_transport
 
 end module neort_transport


### PR DESCRIPTION
Move the non-event orbit integrations (`bounce_fast`) from DVODE_F90 onto the
fortnum nonstiff variable-order Adams integrator (`fortnum_ode_vode`, DVODE
MF=10 equivalent): single span `[0, taub]`, scalar relerr 1e-9, per-component
abserr 1e-10 (ITOL=2). Re-pins the fortnum dependency from v0.1.0 to fortnum
main 974dcf1.

## Call sites
- `src/orbit.f90` `bounce_fast`: replaces the `dvode_f90` MF=10 call with
  `vode_init` + `vode_integrate_to` over the single bounce span; maps the
  fortnum status onto the legacy `istate` convention (2 success, -1 step
  budget, 0 failure).
- `CMakeLists.txt`: `FetchContent` `GIT_TAG` -> `974dcf12e2599ffa5882380207d753c8e8e0a9f6`.

## Verification

Golden record `test/golden_record/test_golden_record.py` against the
DVODE_F90-generated `golden.h5` (bar rtol=1e-8, atol=1e-15), CONFIG=Fast,
worst relative deviation per output:

The `bounce_fast` path on fortnum vode agrees with the DVODE reference far
better than the prior DOP853 substitution (which was ~1e-4 to ~15% on
`output`):

| case  | output rel | output abs |
|-------|-----------|-----------|
| 0p100 | 2.9e-9    | 7.5e-13   |
| 0p200 | 5.3e-9    | 5.6e-12   |
| 0p300 | 9.9e-9    | 3.7e-12   |
| 0p400 | 9.3e-9    | 1.2e-12   |
| 0p500 | 2.5e-7    | 3.1e-12   |
| 0p600 | 3.6e-7    | 1.1e-11   |
| 0p700 | 1.7e-7    | 2.9e-10   |
| 0p800 | 5.8e-8    | 1.5e-10   |
| 0p900 | 4.7e-8    | 2.2e-10   |

`magfie` matches exactly (rel 0). The bounce-averaged `output` (D11/D12)
agrees to 1e-9..3.5e-7.

The golden test still reports 9 failed on this branch, for two reasons:
1. The remaining `integral` / `torque_integral` failures (rel ~1e-4) come from
   the event-path `bounce_integral`, which on this branch still uses the
   DOP853 chunked scan; its taub is not the DVODE root. That path is migrated
   in the stacked PR #47.
2. Even the `bounce_fast` agreement tops out at ~3.6e-7 (worst case 0p600),
   above the 1e-8 bar. fortnum vode matches DVODE_F90 to about its requested
   tolerance, not bit-for-bit (the fortnum suite asserts accuracy versus the
   analytic solution, not bit-identity with DVODE_F90), so the
   DVODE-generated golden cannot be reproduced at rtol=1e-8.

The golden record is regenerated and RK4-validated in the stacked #47, where the event-path `bounce_integral` moves onto fortnum and its taub stops latching onto multiple-period bounce returns at the near-separatrix trapped spline nodes (see `test/golden_record/REGENERATION.md`). This branch keeps the DVODE/DOP853 event path, so the regenerated golden lands with #47, not here. The `bounce_fast` change on this branch shifts only the bounce-averaged Om_tB/D11/D12 at the ~1e-7 level; an independent 2e6-substep RK4 of the orbit ODE confirms the fortnum Om_tB bounce average to <1e-6 across the trapped grid. No tolerances were weakened.



Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.
