### PR TITLE
freq: stop trapped bounce-frequency spline ringing at the tp boundary

### DIFF
--- a/src/freq.f90
+++ b/src/freq.f90
@@ -85,7 +85,11 @@ contains
         OmtB1 = 0.0_dp
 
         v = vth
-        etamin = (1.0_dp + epst) * etatp
+        ! Start the spline knots where the spline is actually evaluated
+        ! (eta > etatp*(1+epst_spl)); knots closer to the trapped-passing
+        ! boundary sit in the logarithmic taub singularity and make the global
+        ! cubic spline ring. The region below is covered by the log extrapolation.
+        etamin = (1.0_dp + epst_spl) * etatp
         etamax = etatp + (etadt - etatp) * (1.0_dp - epsst_spl)
      ! Allocate coefficient arrays for trapped region splines (safe for undefined allocation status)
         if (.not. freq_trapped_initialized) then


### PR DESCRIPTION
Fixes #56.

## What

The trapped canonical-frequency spline built its knots from
`etamin=(1+epst)*etatp` (`epst=1e-8`, on the trapped-passing boundary) but is
only evaluated for `eta>etatp*(1+epst_spl)` (`epst_spl=1e-6`). The knots in
between sit in the logarithmic `taub` singularity and feed the global natural
cubic spline, which then rings, producing an unphysical dip in `omega_b(eta)`
just above the boundary (worst near the edge).

One-line fix: start the grid where the spline is used,
`etamin=(1+epst_spl)*etatp`. The log extrapolation already covers below.

## Verification

Build clean; `test_timestep`, `test_parallel`, `test_neort_lib` pass.

Before/after `omega_b(eta)`, AUG #30835 s=0.85 (red dip = before, blue = after):
https://box.sloppy.at/71a22f3509e20b32/neort_spline_fix_aug30835.png

Reproduce the bug on `main`: `test_frequencies.x` at `s=0.85` -> dip + ~8 slope
reversals in `canonical_freqs_vs_eta_t.dat`. After this change: smooth,
monotonic-to-peak, roughness 1.76e-4 -> 1.09e-4.

AUG #30835 NTV golden-record cases, total resonant torque: unchanged to <0.3%
on most surfaces; localized ~14% change at `s=0.7` where a resonance samples the
previously-corrupted region (intended correction). The golden record is the
bit-exact regenerated-from-main change gate, so it flags this for review.

Independent of the POTATO edge work (touches only `src/freq.f90`). Deeper
follow-ups (resolution convergence, passing-side, end condition) noted in #56.

@phizenz please review; if it looks right, merge to `main`.
