### PR TITLE
POTATO: parallelize the displacement resonance engine with OpenMP

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 3.22)
 
 project(POTATO)
 enable_language(Fortran)
+enable_testing()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/../cmake")
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -67,3 +68,17 @@ add_executable(import_neo2_profiles.x
 target_link_libraries(import_neo2_profiles.x
    potato
 )
+
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+    add_test(NAME potato_golden_displacement
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_displacement/test_potato_golden.py
+            $<TARGET_FILE:potato.x>
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_displacement/golden_zero_mid.json
+    )
+    set_tests_properties(potato_golden_displacement PROPERTIES
+        SKIP_RETURN_CODE 77
+        TIMEOUT 240
+    )
+endif()

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -12,6 +12,11 @@ include(Util)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS Fortran)
+# OpenMP parallelizes the find_bounce-heavy resonance grid build
+# (SRC/sample_matrix.f90) and the per-mode resonance root search
+# (SRC/resonant_int.f90).  Linked to potato_base so -fopenmp reaches POTATO's own
+# sources and the runtime is linked.
+find_package(OpenMP REQUIRED)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(potato_base
   odeint_allroutines.f
   plag_coeff.f90
   find_all_roots.f90
+  sample_matrix_mod.f90
   sample_matrix.f90
   sample_matrix_out.f90
   sub_potato.f90
@@ -34,6 +35,7 @@ BLAS::BLAS
 LAPACK::LAPACK
 HDF5::HDF5
 fortplot::fortplot
+OpenMP::OpenMP_Fortran
 )
 
 add_library(potato

--- a/POTATO/SRC/alpha_lifetime_mod.f90
+++ b/POTATO/SRC/alpha_lifetime_mod.f90
@@ -3,6 +3,12 @@
     logical :: gradpsiast=.false.             !<=NEW in version 4
     double precision :: rmu,ro0
     double precision :: dpsiast_dR,dpsiast_dZ !<=NEW in version 4
+! gradpsiast and dpsiast_dR/dZ are per-orbit scratch: starter_doublecount sets
+! gradpsiast=.true. around a velo call that writes dpsiast_dR/dZ, then resets it.
+! The grid-build node-fill loops run starter+velo in parallel, so each thread
+! needs its own copy.  rmu,ro0 are physical constants set once and read only,
+! so they stay shared.
+    !$omp threadprivate(gradpsiast,dpsiast_dR,dpsiast_dZ)
   end module parmot_mod
 !
   module collis_alp

--- a/POTATO/SRC/bmod_pert.f90
+++ b/POTATO/SRC/bmod_pert.f90
@@ -24,8 +24,17 @@ end module bmod_pert_mod
   complex(8)   :: bmod_n
   double precision, dimension(:,:), allocatable :: bmod_n_re,bmod_n_im
 !
+! Lazy one-time load of the perturbation spline. bmod_pert is called only from
+! velo_res inside the OpenMP resonance loop (integrate_class_resonances), so the
+! first-call init races across threads: without a lock several threads read the
+! file and allocate the shared module arrays at once, and a thread reaching the
+! spline below while rad/splbmod are mid-allocation dereferences unallocated
+! memory. Double-checked locking (same pattern as libneo stretch_coords) runs the
+! read/allocate exactly once; afterwards prop is .false. and the fast path skips
+! the lock entirely.
   if(prop) then
-    prop=.false.
+  !$omp critical (bmod_pert_init)
+  if(prop) then
 
     open(iunit_bn,form='unformatted',file='bmod_n.dat', status='old')
     read(iunit_bn) nrad,nzet
@@ -59,6 +68,11 @@ end module bmod_pert_mod
     call s2dcut(nrad,nzet,hrad,hzet,bmod_n_im,imi,ima,jmi,jma,icp,splbmod_im,ipoint)
 !
     deallocate(bmod_n_re,bmod_n_im)
+! Publish only after every array is filled, so a thread that took the lock next
+! sees a fully built spline instead of a half-allocated one.
+    prop=.false.
+  endif
+  !$omp end critical (bmod_pert_init)
   endif
 !
   rrr=max(rad(1),min(rad(nrad),R))

--- a/POTATO/SRC/equimoments.f90
+++ b/POTATO/SRC/equimoments.f90
@@ -14,6 +14,7 @@
   use get_matrix_mod,    only : iclass
   use form_classes_doublecount_mod, only : nclasses
   use orbit_dim_mod,     only : numbasef
+  use bounds_fixpoints_mod, only : region_set_t
 
   implicit none
 !
@@ -21,6 +22,7 @@
   double precision, parameter :: pi=3.14159265358979d0
   logical :: classes_talk
   integer :: nr,nz,ir,iz,i,k,iperp,nperp,ierr,nprof,ienerg,nenerg
+  type(region_set_t) :: regions
   double precision :: rbeg,hr,zbeg,hz,weight,psi,psipow
   double precision :: bmod,phi_elec,phi_elec_min,phi_elec_max
   double precision :: toten_min,toten_max,thermen_max,toten_range
@@ -110,7 +112,7 @@ print *,'toten = ',toten
       perpinv=perpinv_max*(1.d0-xjperp**2)
 !print *,' perpinv=',perpinv
 !
-      call find_bounds_fixpoints(ierr)
+      call find_bounds_fixpoints(regions,ierr)
 !
       if(ierr.ne.0) then
         print *,'find_bounds_fixpoints ierr = ',ierr
@@ -120,7 +122,7 @@ print *,'toten = ',toten
 !      classes_talk=.true.
       classes_talk=.false.
 !
-      call form_classes_doublecount(classes_talk,ierr)
+      call form_classes_doublecount(regions,classes_talk,ierr)
 !
       if(ierr.ne.0) then
         print *,'form_classes ierr = ',ierr

--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -8,11 +8,9 @@
     integer :: nroots, nsearch_min=100, ncustom, niter=100
     double precision :: relerr_allroots=1.d-12
     double precision, dimension(:), allocatable :: xcustom,roots
-! nroots,roots are the outputs of find_all_roots.  The per-mode resonance loop in
-! integrate_class_resonances runs find_all_roots in parallel, so each thread needs
-! its own.  The search inputs (customgrid,ncustom,xcustom,...) are set once before
-! the loop and read only, so they stay shared.
-    !$omp threadprivate(nroots,roots)
+! Root-search state is per caller. Energy slices set their own custom grid and
+! tolerances, while the mode loop needs private outputs.
+    !$omp threadprivate(customgrid,ncustom,niter,relerr_allroots,xcustom,nroots,roots)
   end module find_all_roots_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -8,6 +8,11 @@
     integer :: nroots, nsearch_min=100, ncustom, niter=100
     double precision :: relerr_allroots=1.d-12
     double precision, dimension(:), allocatable :: xcustom,roots
+! nroots,roots are the outputs of find_all_roots.  The per-mode resonance loop in
+! integrate_class_resonances runs find_all_roots in parallel, so each thread needs
+! its own.  The search inputs (customgrid,ncustom,xcustom,...) are set once before
+! the loop and read only, so they stay shared.
+    !$omp threadprivate(nroots,roots)
   end module find_all_roots_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/odeint_allroutines.f
+++ b/POTATO/SRC/odeint_allroutines.f
@@ -19,13 +19,22 @@
 !
 !------------------------------------------------------------------------------
       module odeint_mod
-        integer :: kmax=0, kount=0, kmaxx=200, ialloc
+        integer :: kmax=0, kmaxx=200
         double precision :: dxsav=0.d0
+! Per-integration scratch and counters.  odeint allocates dydx..ytemp1 per call
+! (alloc_odeint) and find_bounce runs the integrator in parallel (the resonance
+! grid build and the per-mode loop), so each thread needs its own copies, else
+! threads race to allocate the shared arrays ("already allocated").  kount,ialloc
+! are written at the top of each odeint call before any read, so they need no
+! copyin.  kmax,kmaxx,dxsav are set-once read-only config and stay shared.
+        integer :: kount=0, ialloc
         double precision, dimension(:),   allocatable :: dydx,xp,y,yscal
         double precision, dimension(:,:), allocatable :: yp
         double precision, dimension(:),   allocatable :: ak2,ak3,ak4,ak5
         double precision, dimension(:),   allocatable :: ak6,ytemp
         double precision, dimension(:),   allocatable :: yerr,ytemp1
+!$omp threadprivate(kount,ialloc,dydx,xp,y,yscal,yp,ak2,ak3,ak4,
+!$omp+ak5,ak6,ytemp,yerr,ytemp1)
       end module odeint_mod
 !
 !------------------------------------------------------------------------------

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -49,6 +49,14 @@
     type(respoints_fix_jperp),            dimension(:),   allocatable :: respoints_all, &
                                                                          respoints_all_tmp
     type(respoint_single),                dimension(:),   allocatable :: respoint
+    integer :: resline_unit=31415
+    logical :: resline_unit_is_private=.false.
+! Per-energy-slice resonance bookkeeping.  The energy loop may run slices in
+! parallel; each slice owns its J_perp grid, extracted resonant points, and
+! temporary resonance-line unit.  nmodes,marr,narr are read-only after setup.
+    !$omp threadprivate(nperp_max,delint_mode,respoints_jp,respoints_all, &
+    !$omp               respoints_all_tmp,respoint,resline_unit, &
+    !$omp               resline_unit_is_private)
   end module resint_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -149,13 +157,15 @@
 !
 ! Computes sum over resonances $x=x^{res}_{(\bm,k)}$ in Eq.(104) for a given class $k$
 !
-  use find_all_roots_mod, only : customgrid,ncustom,xcustom,nroots,roots
+  use find_all_roots_mod, only : customgrid,ncustom,niter,relerr_allroots, &
+                                 xcustom,nroots,roots
   use get_matrix_mod,     only : relmargin,iclass
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
   use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp, &
-                                 psiast_res,taub_res,delphi_res
+                                 psiast_res,taub_res,delphi_res,resline_unit, &
+                                 resline_unit_is_private
   use orbit_dim_mod,      only : neqm
-  use global_invariants,  only : toten,perpinv,cE_ref,Phi_eff
+  use global_invariants,  only : dtau,toten,perpinv,cE_ref,Phi_eff
   use sample_matrix_mod,  only : npoi,xarr
   use logging_mod,        only : tee_message
   use interp_cache_mod,   only : interp_cache_reset
@@ -187,24 +197,23 @@
   allocate(xcustom(ncustom))
   xcustom=xarr
 !
-! Parallel over modes: each mode is independent.  It runs its own find_all_roots
-! (nroots,roots threadprivate) and per-root starter+pertham (twopim2,rm3,taub_new,
-! delphi_new,toten_orb,perpinv_orb,next, and the interp cache threadprivate), and
-! writes only its disjoint column respoints_jp(mode,iclass) and delint_mode(mode).
-! toten,perpinv stay shared read-only (the class invariants); customgrid,ncustom,
-! xcustom and the grid arrays are shared read-only too.  The threadprivate
-! form-class bounds it reads (ifuntype,R_class_beg,R_class_end,sigma_class) are
-! copyin'd.  The get_rescond by-products psiast_res,taub_res,delphi_res are
+! Mode loop. It stays inactive as a nested OpenMP region because respoints_jp and
+! delint_mode are slice-private; outer energy parallelism owns the concurrency.
+! Each iteration runs its own find_all_roots and per-root starter+pertham state.
+! toten,perpinv and the root-search grid are copied into each worker as read-only
+! class invariants. The threadprivate form-class bounds it reads
+! (ifuntype,R_class_beg,R_class_end,sigma_class) are copyin'd.  The get_rescond by-products psiast_res,taub_res,delphi_res are
 ! threadprivate module state (resint_mod), NOT host-local privates: get_rescond
 ! is passed as the dummy root function to find_all_roots, and gfortran's
 ! trampoline for that call does not honor a host-local private.  reslines
 ! write(31415) and tee_message go in a critical section.  Each thread resets its
 ! interp cache at entry so it drops the previous class's grid before reusing it.
-  !$omp parallel default(shared) &
+  !$omp parallel if(.false.) default(shared) &
   !$omp   private(mode,iroot,ierr,rescond,dresconddx,dpsiastdx) &
   !$omp   private(one_res,Rst,xi,dxi_dx,dpsiast_dRst,absHn2,fmaxw,A1ast,A2ast) &
   !$omp   private(dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi,z) &
-  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class)
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,dtau,toten,perpinv, &
+  !$omp          customgrid,ncustom,niter,relerr_allroots,xcustom)
   call interp_cache_reset
   !$omp do schedule(dynamic)
   do mode=1,nmodes
@@ -252,9 +261,13 @@
       endif
 !
       if(.true.) then
-        !$omp critical (reslines_log)
-        write(31415,*) toten,perpinv,psiast_res,marr(mode),narr(mode)   !<=resonant line for plotting
-        !$omp end critical (reslines_log)
+        if(resline_unit_is_private) then
+          write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode)   !<=resonant line for plotting
+        else
+          !$omp critical (reslines_log)
+          write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode)   !<=resonant line for plotting
+          !$omp end critical (reslines_log)
+        endif
       endif
 !
       respoints_jp(mode,iclass)%z_res(:,iroot)=z
@@ -344,11 +357,13 @@
   use cc_mod,                       only : wrbounds,dowrite
   use orbit_dim_mod,                only : write_orb
   use logging_mod,                  only : tee_message, close_logging
+  use bounds_fixpoints_mod,         only : region_set_t
 !
   logical :: classes_talk
 !
   integer :: ierr,mode
   character(len=256) :: msg
+  type(region_set_t) :: regions
 !
   wrbounds=.false.
   dowrite=.false.
@@ -357,7 +372,7 @@
 !
   perpinv=x
 !
-  call find_bounds_fixpoints(ierr)
+  call find_bounds_fixpoints(regions,ierr)
 !
   if(ierr.ne.0) then
     write(msg, '(A,I0)') &
@@ -367,7 +382,7 @@
     stop
   endif
 !
-  call form_classes_doublecount(classes_talk,ierr)
+  call form_classes_doublecount(regions,classes_talk,ierr)
 !
   if(ierr.ne.0) then
     write(msg, '(A,I0)') &
@@ -438,13 +453,14 @@
   use field_sub, only : psif
   use field_eq_mod, only : nrad,nzet,rad,zet,psi_sep
   use poicut_mod,        only : rmagaxis,zmagaxis,psimagaxis,psi_bou,rhopol_bou
-  use global_invariants, only : toten,perpinv
+  use global_invariants, only : dtau,toten,perpinv
   use poicut_mod,        only : Rbou_lfs,Zbou_lfs
   use get_matrix_mod,    only : iclass
   use form_classes_doublecount_mod, only : nclasses
   use orbit_dim_mod,     only : numbasef
   use resint_mod,        only : nmodes,delint_mode,respoints_jp,respoints_all,nperp_max, &
-                                respoints_all_tmp,respoint
+                                respoints_all_tmp,respoint,resline_unit, &
+                                resline_unit_is_private
   use sample_matrix_out_mod, only : nlagr,n1,n2,npoi,itermax,x,amat,icount,xbeg,xend,eps, &
                                     ind_hist,xarr,amat_arr
   use potato_input_mod,  only : nbox, nenerg_input => nenerg, &
@@ -453,12 +469,14 @@
                                 adaptive_jperp, npoi_init, nlagr_sampling, &
                                 eps_sampling, itermax_sampling
   use logging_mod,       only : tee_message
+  !$ use omp_lib, only : omp_set_max_active_levels, omp_set_num_threads
 
   implicit none
 !
   double precision, parameter :: pi=3.14159265358979d0
   integer :: nr,nz,ir,iz,i,k,iperp,nperp,ierr,nprof,ienerg,nenerg
-  integer :: nrespoints
+  integer :: omp_threads_env_len
+  integer :: nrespoints,unit1901,unit1902
   double precision :: rbeg,hr,zbeg,hz,weight,psi,psipow
   double precision :: bmod,phi_elec,phi_elec_min,phi_elec_max
   double precision :: toten_min,toten_max,thermen_max,toten_range
@@ -469,9 +487,14 @@
   double precision :: dens, temp, ddens, dtemp
   character(len=256) :: msg
   double precision, dimension(:), allocatable :: torque_int_modes
+  double precision, dimension(:), allocatable :: torque_int_modes_loc
   double precision, dimension(:), allocatable :: sbox
   double precision, dimension(:), allocatable :: taubox
   double precision, dimension(:), allocatable :: torquebox
+  double precision, dimension(:), allocatable :: torquebox_loc
+  double precision, dimension(:), allocatable :: torque_int_energy
+  double precision, dimension(:,:), allocatable :: torque_int_modes_energy
+  double precision, dimension(:,:), allocatable :: torquebox_energy
 ! Per-resonance-point box times, filled by the parallel time_in_box pass and
 ! consumed by the serial accumulate/write pass below.
   double precision, dimension(:,:), allocatable :: taubox_all
@@ -479,14 +502,6 @@
   external :: get_matrix_res
 !
   allocate(sbox(nbox), taubox(nbox), torquebox(nbox))
-!
-! size of result matrix in get_matrix_res:
-  n1=nmodes
-  n2=1
-! Set adaptive sampling parameters from input:
-  nlagr=nlagr_sampling
-  eps=eps_sampling
-  itermax=itermax_sampling
 !
   numbasef=0 !no extra integrals sampled, pure orbit integration
   call linspace(1d0/nbox, 1d0, nbox, sbox)
@@ -530,22 +545,43 @@
   torque_int=0.d0
   allocate(torque_int_modes(nmodes))
   torque_int_modes=0.d0
+  allocate(torque_int_energy(nenerg),torque_int_modes_energy(nmodes,nenerg), &
+           torquebox_energy(nbox,nenerg))
+  torque_int_energy=0.d0
+  torque_int_modes_energy=0.d0
+  torquebox_energy=0.d0
 !
   torquebox=0.d0
 !
   step_energ=toten_range/dble(nenerg) !integration step over total energy
 !step_energ=0.22521463755624047d0
 !
-  if(adaptive_jperp) then
-    open(1901,file='subint_ofH0int_104_vsJperp_fromresp.dat')
-    open(1902,file='subint_ofH0int_104_vsJperp_adapt.dat')
-  else
-    open(1902,file='subint_ofH0int_104_vsJperp_equi.dat')
-  endif
-!
+  omp_threads_env_len=0
+  !$ call get_environment_variable('OMP_NUM_THREADS',length=omp_threads_env_len)
+  !$ if(omp_threads_env_len.eq.0) call omp_set_num_threads(16)
+  !$ call omp_set_max_active_levels(1)
+  !$omp parallel do default(shared) schedule(dynamic) &
+  !$omp   private(xenerg,perpinv_max,trapez_fac,nrespoints,i,k,iperp,ierr,nperp) &
+  !$omp   private(time_beg,time_end,xjperp,torque_int_loc,msg,taubox_all) &
+  !$omp   private(unit1901,unit1902,torque_int_modes_loc,torquebox_loc) &
+  !$omp   copyin(dtau)
   do ienerg=1,nenerg
     xenerg=(dble(ienerg)-0.5d0)/dble(nenerg)
     toten=toten_min+toten_range*xenerg
+! size of result matrix in get_matrix_res:
+    n1=nmodes
+    n2=1
+! Set adaptive sampling parameters from input:
+    nlagr=nlagr_sampling
+    eps=eps_sampling
+    itermax=itermax_sampling
+    if(allocated(delint_mode)) deallocate(delint_mode)
+    allocate(delint_mode(nmodes))
+    allocate(torque_int_modes_loc(nmodes),torquebox_loc(nbox))
+    torque_int_modes_loc=0.d0
+    torquebox_loc=0.d0
+    resline_unit_is_private=.true.
+    call open_energy_outputs(ienerg,adaptive_jperp,unit1901,unit1902)
 !toten =   -3.1211921097605737d0
     write(msg, '(A,ES22.14)') 'toten = ', toten
     call tee_message(trim(msg))
@@ -651,13 +687,14 @@
 ! per-point box times.  Width of the energy interval is already in the weight.
       do i=1,nrespoints
         torque_int_loc=torque_int_loc+respoint(i)%w_res
-        write(1901,*) respoint(i)%toten_res, &
+        write(unit1901,*) respoint(i)%toten_res, &
           respoint(i)%perpinv_res, &
           torque_int_loc
-        torquebox=torquebox+respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
+        torquebox_loc=torquebox_loc &
+          +respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
       enddo
       deallocate(taubox_all)
-      write(1901,*) ' '
+      write(unit1901,*) ' '
 !
       deallocate(respoint)
       write(msg, '(A,I0)') &
@@ -665,7 +702,8 @@
       call tee_message(trim(msg))
 !
 ! Sum up contributions of energy levels:
-      torque_int=torque_int+torque_int_loc
+      torque_int_energy(ienerg)=torque_int_loc
+      torquebox_energy(:,ienerg)=torquebox_loc
       write(msg, '(A,ES22.14)') &
         'method 1, torque_int_loc = ', torque_int_loc
       call tee_message(trim(msg))
@@ -679,13 +717,14 @@
           torque_int_loc=torque_int_loc &
                     +0.5d0*(sum(amat_arr(:,1,i))+sum(amat_arr(:,1,i-1))) &
                     *(xarr(i)-xarr(i-1))*step_energ
-          torque_int_modes=torque_int_modes &
+          torque_int_modes_loc=torque_int_modes_loc &
                     +0.5d0*(amat_arr(:,1,i)+amat_arr(:,1,i-1)) &
                     *(xarr(i)-xarr(i-1))*step_energ
         endif
-        write(1902,*) xarr(i),torque_int_loc,torque_int_modes
+        write(unit1902,*) xarr(i),torque_int_loc,torque_int_modes_loc
       enddo
-      write(1902,*) ' '
+      torque_int_modes_energy(:,ienerg)=torque_int_modes_loc
+      write(unit1902,*) ' '
       write(msg, '(A,ES22.14)') &
         'method 2, torque_int_loc = ', torque_int_loc
       call tee_message(trim(msg))
@@ -694,6 +733,7 @@
 !
 ! Old, non-adaptive integration:
 ! Not prepared for box counting, use for testing only.
+      torque_int_loc=0.d0
       nperp=2500 !5000 !100    !size of the integration grid over normalized J_perp
       if(.not.allocated(amat)) allocate(amat(n1,n2))
       icount=0
@@ -710,15 +750,19 @@
 !
         call get_matrix_res
 !
-        torque_int=torque_int+perpinv_max*trapez_fac*sum(amat(:,1))*step_energ
-        torque_int_modes=torque_int_modes+perpinv_max*trapez_fac*amat(:,1)*step_energ
+        torque_int_loc=torque_int_loc &
+          +perpinv_max*trapez_fac*sum(amat(:,1))*step_energ
+        torque_int_modes_loc=torque_int_modes_loc &
+          +perpinv_max*trapez_fac*amat(:,1)*step_energ
 ! Subintegrand of dimensional integral over energy for a total torque as function of J_perp:
-        write(1902,*) perpinv,torque_int,torque_int_modes
+        write(unit1902,*) perpinv,torque_int_loc,torque_int_modes_loc
         write(msg, '(A,I0,A,I0,A,I0,A,I0)') &
           'perpinv:', iperp, '/', nperp, &
           ' toten:', ienerg, '/', nenerg
         call tee_message(trim(msg))
       enddo
+      torque_int_energy(ienerg)=torque_int_loc
+      torque_int_modes_energy(:,ienerg)=torque_int_modes_loc
     endif
 !
     call cpu_time(time_end)
@@ -727,10 +771,33 @@
       ' cpu time = ', time_end-time_beg, ' sec'
     call tee_message(trim(msg))
 !
+    close(resline_unit)
+    if(adaptive_jperp) close(unit1901)
+    close(unit1902)
+    deallocate(torque_int_modes_loc,torquebox_loc)
+!
+  enddo
+  !$omp end parallel do
+!
+  torque_int=0.d0
+  torque_int_modes=0.d0
+  torquebox=0.d0
+  do ienerg=1,nenerg
+    torque_int=torque_int+torque_int_energy(ienerg)
+    torque_int_modes=torque_int_modes+torque_int_modes_energy(:,ienerg)
+    torquebox=torquebox+torquebox_energy(:,ienerg)
   enddo
 !
-  if(adaptive_jperp) close(1901)
-  close(1902)
+  call merge_energy_files('fort.31415.energy.', 'fort.31415', nenerg)
+  if(adaptive_jperp) then
+    call merge_energy_files('subint_ofH0int_104_vsJperp_fromresp.dat.energy.', &
+      'subint_ofH0int_104_vsJperp_fromresp.dat', nenerg)
+    call merge_jperp_files('subint_ofH0int_104_vsJperp_adapt.dat.energy.', &
+      'subint_ofH0int_104_vsJperp_adapt.dat', nenerg, .false.)
+  else
+    call merge_jperp_files('subint_ofH0int_104_vsJperp_equi.dat.energy.', &
+      'subint_ofH0int_104_vsJperp_equi.dat', nenerg, .true.)
+  endif
 !
 ! Integral torque:
   write(msg, '(A,ES22.14)') &
@@ -749,6 +816,118 @@
     enddo
     close(1)
   endif
+!
+  contains
+!
+  subroutine energy_path(prefix, idx, path)
+!
+  implicit none
+!
+  character(len=*), intent(in) :: prefix
+  integer, intent(in) :: idx
+  character(len=*), intent(out) :: path
+!
+  write(path,'(A,I6.6)') trim(prefix), idx
+!
+  end subroutine energy_path
+!
+  subroutine open_energy_outputs(idx, adaptive, unit_fromresp, unit_jperp)
+!
+  implicit none
+!
+  integer, intent(in) :: idx
+  logical, intent(in) :: adaptive
+  integer, intent(out) :: unit_fromresp, unit_jperp
+  character(len=256) :: path
+!
+  call energy_path('fort.31415.energy.', idx, path)
+  open(newunit=resline_unit,file=trim(path),status='replace',action='write')
+!
+  unit_fromresp=-1
+  if(adaptive) then
+    call energy_path('subint_ofH0int_104_vsJperp_fromresp.dat.energy.', idx, path)
+    open(newunit=unit_fromresp,file=trim(path),status='replace',action='write')
+    call energy_path('subint_ofH0int_104_vsJperp_adapt.dat.energy.', idx, path)
+  else
+    call energy_path('subint_ofH0int_104_vsJperp_equi.dat.energy.', idx, path)
+  endif
+  open(newunit=unit_jperp,file=trim(path),status='replace',action='write')
+!
+  end subroutine open_energy_outputs
+!
+  subroutine merge_energy_files(prefix, final_name, count)
+!
+  implicit none
+!
+  character(len=*), intent(in) :: prefix, final_name
+  integer, intent(in) :: count
+  character(len=4096) :: line
+  character(len=256) :: path
+  integer :: idx,io,in_unit,out_unit
+!
+  open(newunit=out_unit,file=trim(final_name),status='replace',action='write')
+  do idx=1,count
+    call energy_path(prefix,idx,path)
+    open(newunit=in_unit,file=trim(path),status='old',action='read',iostat=io)
+    if(io.ne.0) then
+      call tee_message('missing energy output: '//trim(path))
+      stop
+    endif
+    do
+      read(in_unit,'(A)',iostat=io) line
+      if(io.ne.0) exit
+      write(out_unit,'(A)') trim(line)
+    enddo
+    close(in_unit,status='delete')
+  enddo
+  close(out_unit)
+!
+  end subroutine merge_energy_files
+!
+  subroutine merge_jperp_files(prefix, final_name, count, prefix_scalar)
+!
+  implicit none
+!
+  character(len=*), intent(in) :: prefix, final_name
+  integer, intent(in) :: count
+  logical, intent(in) :: prefix_scalar
+  character(len=4096) :: line
+  character(len=256) :: path
+  integer :: idx,io,in_unit,out_unit
+  double precision :: scalar_prefix
+  double precision, dimension(:), allocatable :: mode_prefix,vals
+!
+  allocate(mode_prefix(nmodes),vals(nmodes+2))
+  mode_prefix=0.d0
+  scalar_prefix=0.d0
+  open(newunit=out_unit,file=trim(final_name),status='replace',action='write')
+  do idx=1,count
+    call energy_path(prefix,idx,path)
+    open(newunit=in_unit,file=trim(path),status='old',action='read',iostat=io)
+    if(io.ne.0) then
+      call tee_message('missing energy output: '//trim(path))
+      stop
+    endif
+    do
+      read(in_unit,'(A)',iostat=io) line
+      if(io.ne.0) exit
+      if(len_trim(line).eq.0) then
+        write(out_unit,*) ' '
+      else
+        read(line,*) vals
+        if(prefix_scalar) vals(2)=vals(2)+scalar_prefix
+        vals(3:nmodes+2)=vals(3:nmodes+2)+mode_prefix
+        write(out_unit,*) vals
+      endif
+    enddo
+    close(in_unit,status='delete')
+    scalar_prefix=scalar_prefix+torque_int_energy(idx)
+    mode_prefix=mode_prefix+torque_int_modes_energy(:,idx)
+  enddo
+  close(out_unit)
+  deallocate(mode_prefix,vals)
+!
+  end subroutine merge_jperp_files
 !
   end subroutine resonant_torque
 !

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -26,6 +26,12 @@
 !
     integer          :: nmodes,nperp_max=0
     double precision :: twopim2,rm3,taub_new,delphi_new
+! Energy and perpendicular invariant of the resonant orbit, set by pertham and
+! read by velo_res for the perturbed-Hamiltonian Fourier integral.  Held separate
+! from the global class invariants toten,perpinv so the per-mode resonance loop
+! never writes those -- they stay the shared, read-only class values, which lets
+! the loop be parallelized without making toten,perpinv threadprivate.
+    double precision :: toten_orb,perpinv_orb
     integer, dimension(:), allocatable :: marr,narr
     double precision, dimension(:), allocatable :: delint_mode
 !
@@ -45,8 +51,7 @@
 ! of the perturbed Hamiltonian $\hat H_\bm$, Eq.(102) (former Eq.(93))
 !
   use orbit_dim_mod,     only : neqm,next,numbasef
-  use global_invariants, only : toten,perpinv
-  use resint_mod,        only : twopim2,rm3,taub_new,delphi_new
+  use resint_mod,        only : twopim2,rm3,taub_new,delphi_new,toten_orb,perpinv_orb
 !
   implicit none
 !
@@ -60,7 +65,7 @@
   call get_bmod_and_Phi(z(1:3),bmod,phi_elec)
   call bmod_pert(z(1),z(3),bmod_n)
 !
-  comfac=(2.d0*(toten-phi_elec)/bmod-perpinv)*bmod_n &
+  comfac=(2.d0*(toten_orb-phi_elec)/bmod-perpinv_orb)*bmod_n &
         *exp(imun*(rm3*z(2)-(twopim2+delphi_new*rm3)*z(6)/taub_new))
 !
   vz(6)=1.d0
@@ -77,8 +82,8 @@
 ! Hamiltoninan, $|\hat H_\bm|^2$, with $\hat H_\bm$ defined by Eq.(102) (former Eq.(93)).
 !
   use orbit_dim_mod,     only : neqm,next     ,write_orb,iunit1
-  use global_invariants, only : toten,perpinv,dtau
-  use resint_mod,        only : taub_new,delphi_new
+  use global_invariants, only : dtau
+  use resint_mod,        only : taub_new,delphi_new,toten_orb,perpinv_orb
 !
 !
   implicit none
@@ -94,8 +99,8 @@
 !
   call get_bmod_and_Phi(z(1:3),bmod,phi_elec)
 !
-  toten=z(4)**2+phi_elec
-  perpinv=z(4)**2*(1.d0-z(5)**2)/bmod
+  toten_orb=z(4)**2+phi_elec
+  perpinv_orb=z(4)**2*(1.d0-z(5)**2)/bmod
 !
   next=0
   allocate(extraset(next))
@@ -152,12 +157,9 @@
   double precision :: relmargin_loc,widthclass,xbeg,xend
   double precision :: rescond,dresconddx,psiast,dpsiastdx,taub,delphi
   double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
-  double precision :: toten_loc,perpinv_loc,fmaxw,A1ast,A2ast
+  double precision :: fmaxw,A1ast,A2ast
   double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
   double precision, dimension(neqm) :: z
-!
-  toten_loc=toten
-  perpinv_loc=perpinv
 !
   sigma=sigma_class(iclass)
   delta_R=R_class_end(iclass)-R_class_beg(iclass)
@@ -226,8 +228,9 @@
       call denstemp_of_psi(psiast,dens,temp,ddens,dtemp)
       call phielec_of_psi(psiast,phi_elec,dPhi_dpsi)
 !
-      toten=toten_loc
-      perpinv=perpinv_loc
+! toten,perpinv are never written in this loop (pertham writes toten_orb,
+! perpinv_orb instead), so they still hold the class invariants set on entry --
+! no save/restore needed.
 !
 ! Non-local thermodynamic forces Eq.(95) (former Eq.(87)):
       A2ast=dtemp/temp

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -26,12 +26,22 @@
 !
     integer          :: nmodes,nperp_max=0
     double precision :: twopim2,rm3,taub_new,delphi_new
+    !$omp threadprivate(twopim2,rm3,taub_new,delphi_new)
 ! Energy and perpendicular invariant of the resonant orbit, set by pertham and
 ! read by velo_res for the perturbed-Hamiltonian Fourier integral.  Held separate
 ! from the global class invariants toten,perpinv so the per-mode resonance loop
 ! never writes those -- they stay the shared, read-only class values, which lets
 ! the loop be parallelized without making toten,perpinv threadprivate.
     double precision :: toten_orb,perpinv_orb
+    !$omp threadprivate(toten_orb,perpinv_orb)
+! By-products of the resonance condition get_rescond ($\psi^\ast$, bounce time,
+! toroidal shift), recovered for the orbit weight.  get_rescond is an internal
+! procedure of integrate_class_resonances that is also passed as the dummy root
+! function to find_all_roots; with gfortran's trampoline for that dummy-procedure
+! call, a host-local PRIVATE variable written through it is not seen as private,
+! so these must be threadprivate module state instead of privatized host locals.
+    double precision :: psiast_res,taub_res,delphi_res
+    !$omp threadprivate(psiast_res,taub_res,delphi_res)
     integer, dimension(:), allocatable :: marr,narr
     double precision, dimension(:), allocatable :: delint_mode
 !
@@ -142,11 +152,13 @@
   use find_all_roots_mod, only : customgrid,ncustom,xcustom,nroots,roots
   use get_matrix_mod,     only : relmargin,iclass
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
-  use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp
+  use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp, &
+                                 psiast_res,taub_res,delphi_res
   use orbit_dim_mod,      only : neqm
   use global_invariants,  only : toten,perpinv,cE_ref,Phi_eff
   use sample_matrix_mod,  only : npoi,xarr
   use logging_mod,        only : tee_message
+  use interp_cache_mod,   only : interp_cache_reset
 !
   implicit none
 !
@@ -155,7 +167,7 @@
 !
   integer          :: mode,iroot,ierr
   double precision :: relmargin_loc,widthclass,xbeg,xend
-  double precision :: rescond,dresconddx,psiast,dpsiastdx,taub,delphi
+  double precision :: rescond,dresconddx,dpsiastdx
   double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
   double precision :: fmaxw,A1ast,A2ast
   double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
@@ -175,7 +187,26 @@
   allocate(xcustom(ncustom))
   xcustom=xarr
 !
-!
+! Parallel over modes: each mode is independent.  It runs its own find_all_roots
+! (nroots,roots threadprivate) and per-root starter+pertham (twopim2,rm3,taub_new,
+! delphi_new,toten_orb,perpinv_orb,next, and the interp cache threadprivate), and
+! writes only its disjoint column respoints_jp(mode,iclass) and delint_mode(mode).
+! toten,perpinv stay shared read-only (the class invariants); customgrid,ncustom,
+! xcustom and the grid arrays are shared read-only too.  The threadprivate
+! form-class bounds it reads (ifuntype,R_class_beg,R_class_end,sigma_class) are
+! copyin'd.  The get_rescond by-products psiast_res,taub_res,delphi_res are
+! threadprivate module state (resint_mod), NOT host-local privates: get_rescond
+! is passed as the dummy root function to find_all_roots, and gfortran's
+! trampoline for that call does not honor a host-local private.  reslines
+! write(31415) and tee_message go in a critical section.  Each thread resets its
+! interp cache at entry so it drops the previous class's grid before reusing it.
+  !$omp parallel default(shared) &
+  !$omp   private(mode,iroot,ierr,rescond,dresconddx,dpsiastdx) &
+  !$omp   private(one_res,Rst,xi,dxi_dx,dpsiast_dRst,absHn2,fmaxw,A1ast,A2ast) &
+  !$omp   private(dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi,z) &
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class)
+  call interp_cache_reset
+  !$omp do schedule(dynamic)
   do mode=1,nmodes
     twopim2=twopi*dble(marr(mode))
     rm3=dble(narr(mode))
@@ -184,11 +215,14 @@
     call find_all_roots(get_rescond,xbeg,xend,ierr)
 !
     if(ierr.ne.0) then
+      !$omp critical (reslines_log)
       call tee_message( &
         'integrate_class_resonances: error in find_all_roots')
-      customgrid=.false.
-      deallocate(xcustom)
-      return
+      !$omp end critical (reslines_log)
+      respoints_jp(mode,iclass)%nrespoi=0
+      respoints_jp(mode,iclass)%toten_res=toten
+      respoints_jp(mode,iclass)%perpinv_res=perpinv
+      cycle
     endif
 !
     respoints_jp(mode,iclass)%nrespoi=nroots
@@ -207,16 +241,20 @@
       Rst=R_class_beg(iclass)+delta_R*xi
 !
       call starter_doublecount(toten,perpinv,sigma,Rst,   &
-                               psiast,dpsiast_dRst,z,ierr)
+                               psiast_res,dpsiast_dRst,z,ierr)
 !
       if(ierr.ne.0) then
+        !$omp critical (reslines_log)
         call tee_message( &
           'integrate_class_resonances: error in starter_doublecount')
+        !$omp end critical (reslines_log)
         cycle
       endif
 !
       if(.true.) then
-        write(31415,*) toten,perpinv,psiast,marr(mode),narr(mode)   !<=resonant line for plotting
+        !$omp critical (reslines_log)
+        write(31415,*) toten,perpinv,psiast_res,marr(mode),narr(mode)   !<=resonant line for plotting
+        !$omp end critical (reslines_log)
       endif
 !
       respoints_jp(mode,iclass)%z_res(:,iroot)=z
@@ -224,9 +262,9 @@
       dpsiastdx=dpsiast_dRst*delta_R*dxi_dx     !$\difp{\psi^\ast}{x}$
 !
       call pertham(z,absHn2)
-      call equilmaxw(psiast,fmaxw)
-      call denstemp_of_psi(psiast,dens,temp,ddens,dtemp)
-      call phielec_of_psi(psiast,phi_elec,dPhi_dpsi)
+      call equilmaxw(psiast_res,fmaxw)
+      call denstemp_of_psi(psiast_res,dens,temp,ddens,dtemp)
+      call phielec_of_psi(psiast_res,phi_elec,dPhi_dpsi)
 !
 ! toten,perpinv are never written in this loop (pertham writes toten_orb,
 ! perpinv_orb instead), so they still hold the class invariants set on entry --
@@ -238,12 +276,12 @@
 !
 ! Expression under summation signs except the last line in Eq.(104) (former Eq.(94)):
       one_res=abs(dpsiastdx/dresconddx)*absHn2*fmaxw            &
-!ERROR, SEE in RED=>             *(Phi_eff*taub*(A1ast+A2ast*(toten-phi_elec)/temp)+delphi/temp)
-             *Phi_eff*taub*(A1ast+A2ast*(toten-phi_elec)/temp)  !<=ERROR CORRECTED
+!ERROR, SEE in RED=>             *(Phi_eff*taub_res*(A1ast+A2ast*(toten-phi_elec)/temp)+delphi_res/temp)
+             *Phi_eff*taub_res*(A1ast+A2ast*(toten-phi_elec)/temp)  !<=ERROR CORRECTED
 !
 ! emulator of box average (Heaviside function replaced with one in (104) - result is integral torque in
 ! the whole volume normalized by the reference energy $\cE_{ref}$):
-      one_res=one_res*taub
+      one_res=one_res*taub_res
 ! end emulator of box average
 !
 ! multiply expression under summation over modes with toroidal mode number, with factor $-\pi^{3/2}/4$
@@ -251,10 +289,12 @@
       one_res=one_res*rm3*pi32_over4m*cE_ref
 !
       respoints_jp(mode,iclass)%w_res(iroot)=one_res
-      respoints_jp(mode,iclass)%taub(iroot)=taub
+      respoints_jp(mode,iclass)%taub(iroot)=taub_res
       delint_mode(mode)=delint_mode(mode)+one_res
     enddo
   enddo
+  !$omp end do
+  !$omp end parallel
 !
   customgrid=.false.
   deallocate(xcustom)
@@ -279,10 +319,10 @@
 !
   call interpolate_class_doublecount(x,vec,dvec)
 !
-  psiast=vec(1)               ! $\psi^\ast$
-  taub=vec(2)                 ! $\tau_b$
-  delphi=vec(3)               ! $\Delta\varphi_b$
-  rescond=delphi+twopim2/rm3
+  psiast_res=vec(1)           ! $\psi^\ast$
+  taub_res=vec(2)             ! $\tau_b$
+  delphi_res=vec(3)           ! $\Delta\varphi_b$
+  rescond=delphi_res+twopim2/rm3
   dresconddx=dvec(3)
 !
   end subroutine get_rescond
@@ -432,6 +472,9 @@
   double precision, dimension(:), allocatable :: sbox
   double precision, dimension(:), allocatable :: taubox
   double precision, dimension(:), allocatable :: torquebox
+! Per-resonance-point box times, filled by the parallel time_in_box pass and
+! consumed by the serial accumulate/write pass below.
+  double precision, dimension(:,:), allocatable :: taubox_all
 !
   external :: get_matrix_res
 !
@@ -591,30 +634,29 @@
 ! Computation of the integral torque:
       torque_int_loc=0.d0
 !
+! Box counter (time_in_box) integrates each resonant orbit through the radial
+! boxes via dvode -- the dominant per-point cost.  Points are independent and
+! dvode_f90_m is threadprivate/thread-safe, so run them in parallel into the
+! per-point taubox_all.  z_res(1:5) is the orbit start at the Poincare cut.
+      allocate(taubox_all(nbox,nrespoints))
+      !$omp parallel do default(shared) private(i) schedule(dynamic)
       do i=1,nrespoints
-! Here box counter should be used. Below we compute an integral torque as a sum of orbit weights:
-        torque_int_loc=torque_int_loc+respoint(i)%w_res
-! Quantity torque_int_loc is a contribution of one energy level to the integral torque. Width of energy
-! interval is already included in the weight.
-! For box counter use the starting coordinates of the orbit at the Poincare cut. They are stored in
-! respoint(i)%z_res(1:5)
-! Weight of the orbit is stored in
-! respoint(i)%w_res
-! If needed, there are also total energy and perpendicular invariant available in
-! respoint(i)%toten_res
-! and
-! respoint(i)%perpinv_res
-! respectively
         call time_in_box(respoint(i)%z_res(1:5), nbox, sbox, &
-          respoint(i)%taub, taubox)
+          respoint(i)%taub, taubox_all(:,i))
+      enddo
+      !$omp end parallel do
+!
+! Serial accumulate/write pass: torque_int_loc is a running prefix sum written
+! per row to fort.1901, so it stays serial and in order; torquebox sums the
+! per-point box times.  Width of the energy interval is already in the weight.
+      do i=1,nrespoints
+        torque_int_loc=torque_int_loc+respoint(i)%w_res
         write(1901,*) respoint(i)%toten_res, &
           respoint(i)%perpinv_res, &
-          ! tormom_of_RZ(respoint(i)%toten_res, respoint(i)%perpinv_res, TODO ), &
-          torque_int_loc    !,taubox/respoint(i)%taub
-!
-        torquebox=torquebox+respoint(i)%w_res*taubox/respoint(i)%taub   !<=sum up resonances in boxes
-!
+          torque_int_loc
+        torquebox=torquebox+respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
       enddo
+      deallocate(taubox_all)
       write(1901,*) ' '
 !
       deallocate(respoint)

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -8,6 +8,7 @@
 ! grid-build regions, which never write it, so each worker starts from the master
 ! value.
   USE orbit_dim_mod, only : next
+  USE global_invariants, only : dtau,toten,perpinv,sigma
 !
   IMPLICIT NONE
 !
@@ -56,15 +57,11 @@
     x=xbeg+h*(i-1)+hh*(i-1)**2
     xarr(i)=x
   ENDDO
-! Initial interior fill: one independent get_matrix (starter+find_bounce) per
-! node, writing the disjoint slot amat_arr(:,:,i).  This is the find_bounce-heavy
-! cost.  x and amat are threadprivate scratch; the form-class bounds are already
-! threadprivate, so copyin seeds each worker with the master values.  toten,perpinv
-! stay SHARED and read-only here (the grid build never calls pertham, so nothing
-! writes them); next is threadprivate but unwritten here, so copyin seeds each
-! worker with the master value to keep the prior shared behavior.
-  !$omp parallel do default(shared) private(i) schedule(dynamic) &
-  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
+! Initial interior fill. The class grid is threadprivate per energy slice, so
+! keep this inactive when called outside the outer energy team.
+  !$omp parallel do if(.false.) default(shared) private(i) schedule(dynamic) &
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next, &
+  !$omp          dtau,toten,perpinv,sigma)
   DO i=2,npoi-1
     if(.not.allocated(amat)) allocate(amat(n1,n2))
     x=xarr(i)
@@ -155,11 +152,11 @@
     amat_arr(:,:,inew)=amat_old(:,:,npoi_old)
     DEALLOCATE(isplit)
 !
-! Parallel fill pass: one independent get_matrix per new node, writing the
-! disjoint slot amat_arr(:,:,newslots(k)).  Same per-thread scratch (x,amat) and
-! copyin of the shared form-class bounds and next as the initial fill.
-    !$omp parallel do default(shared) private(k) schedule(dynamic) &
-    !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
+! Fill pass for new nodes. See the initial fill above for why this region stays
+! inactive.
+    !$omp parallel do if(.false.) default(shared) private(k) schedule(dynamic) &
+    !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next, &
+    !$omp          dtau,toten,perpinv,sigma)
     DO k=1,nnew
       if(.not.allocated(amat)) allocate(amat(n1,n2))
       x=xarr(newslots(k))

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -1,23 +1,20 @@
-  module sample_matrix_mod
-    integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
-    double precision :: x,xbeg,xend,eps
-    double precision, dimension(:),     allocatable :: xarr
-    double precision, dimension(:,:),   allocatable :: amat
-    double precision, dimension(:,:,:), allocatable :: amat_arr
-  end module sample_matrix_mod
-!
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
   SUBROUTINE sample_matrix(get_matrix,ierr)
 !
   USE sample_matrix_mod
+  USE form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
+! next is threadprivate (the resonance mode loop writes it); copyin it into the
+! grid-build regions, which never write it, so each worker starts from the master
+! value.
+  USE orbit_dim_mod, only : next
 !
   IMPLICIT NONE
 !
   INTEGER, PARAMETER :: nder=0
   DOUBLE PRECISION, PARAMETER :: symm_break=0.01d0
-  INTEGER :: i,j,iter,npoi_old,iold,inew,ibeg,iend,nshift,npoilag,ierr
-  INTEGER,          DIMENSION(:),     ALLOCATABLE :: isplit
+  INTEGER :: i,j,iter,npoi_old,iold,inew,ibeg,iend,nshift,npoilag,ierr,nnew,k
+  INTEGER,          DIMENSION(:),     ALLOCATABLE :: isplit,newslots
 !
   DOUBLE PRECISION :: h,hh
   DOUBLE PRECISION, DIMENSION(:),     ALLOCATABLE :: xold
@@ -59,11 +56,22 @@
     x=xbeg+h*(i-1)+hh*(i-1)**2
     xarr(i)=x
   ENDDO
+! Initial interior fill: one independent get_matrix (starter+find_bounce) per
+! node, writing the disjoint slot amat_arr(:,:,i).  This is the find_bounce-heavy
+! cost.  x and amat are threadprivate scratch; the form-class bounds are already
+! threadprivate, so copyin seeds each worker with the master values.  toten,perpinv
+! stay SHARED and read-only here (the grid build never calls pertham, so nothing
+! writes them); next is threadprivate but unwritten here, so copyin seeds each
+! worker with the master value to keep the prior shared behavior.
+  !$omp parallel do default(shared) private(i) schedule(dynamic) &
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
   DO i=2,npoi-1
+    if(.not.allocated(amat)) allocate(amat(n1,n2))
     x=xarr(i)
     CALL get_matrix
     amat_arr(:,:,i)=amat
   ENDDO
+  !$omp end parallel do
 !
   ALLOCATE(amat1(n1,n2),amat2(n1,n2),amat_maxmod(n1,n2))
 !
@@ -123,7 +131,13 @@
     ENDIF
     ALLOCATE(xarr(npoi),amat_arr(n1,n2,npoi))
 !
-! fill new arrays:
+! Serial layout pass: copy the retained old nodes into their new slots and, for
+! each split interval, reserve the new node's slot inew with its midpoint xarr.
+! Record the new-node slots in newslots so the find_bounce-heavy get_matrix calls
+! run in the parallel fill below instead of here.  Layout (slot assignment, array
+! re-allocation, the isplit decision) stays serial.
+    ALLOCATE(newslots(npoi))
+    nnew=0
     inew=0
     DO iold=1,npoi_old-1
       inew=inew+1
@@ -131,16 +145,29 @@
       amat_arr(:,:,inew)=amat_old(:,:,iold)
       IF(isplit(iold).EQ.1) THEN
         inew=inew+1
-        x=0.5d0*(xold(iold)+xold(iold+1))
-        CALL get_matrix
-        xarr(inew)=x
-        amat_arr(:,:,inew)=amat
+        xarr(inew)=0.5d0*(xold(iold)+xold(iold+1))
+        nnew=nnew+1
+        newslots(nnew)=inew
       ENDIF
     ENDDO
     inew=inew+1
     xarr(inew)=xold(npoi_old)
     amat_arr(:,:,inew)=amat_old(:,:,npoi_old)
     DEALLOCATE(isplit)
+!
+! Parallel fill pass: one independent get_matrix per new node, writing the
+! disjoint slot amat_arr(:,:,newslots(k)).  Same per-thread scratch (x,amat) and
+! copyin of the shared form-class bounds and next as the initial fill.
+    !$omp parallel do default(shared) private(k) schedule(dynamic) &
+    !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
+    DO k=1,nnew
+      if(.not.allocated(amat)) allocate(amat(n1,n2))
+      x=xarr(newslots(k))
+      CALL get_matrix
+      amat_arr(:,:,newslots(k))=amat
+    ENDDO
+    !$omp end parallel do
+    DEALLOCATE(newslots)
 !
 ! check which intervals should be splitted
     ALLOCATE(isplit(npoi))

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -1,0 +1,14 @@
+  module sample_matrix_mod
+    integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
+    double precision :: x,xbeg,xend,eps
+    double precision, dimension(:),     allocatable :: xarr
+    double precision, dimension(:,:),   allocatable :: amat
+    double precision, dimension(:,:,:), allocatable :: amat_arr
+! x and amat are the per-node input/output of get_matrix_doublecount: each call
+! reads x and writes amat for one grid node.  The grid-build node-fill loops in
+! sample_matrix run those calls in parallel over disjoint nodes, so x and amat
+! are genuine per-thread scratch and must be threadprivate.  The grid layout
+! (npoi,xarr,amat_arr,n1,n2,...) stays shared: the adaptive split/iter logic is
+! serial and amat_arr(:,:,i) writes are to disjoint slots.
+    !$omp threadprivate(x,amat)
+  end module sample_matrix_mod

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -4,11 +4,7 @@
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
-! x and amat are the per-node input/output of get_matrix_doublecount: each call
-! reads x and writes amat for one grid node.  The grid-build node-fill loops in
-! sample_matrix run those calls in parallel over disjoint nodes, so x and amat
-! are genuine per-thread scratch and must be threadprivate.  The grid layout
-! (npoi,xarr,amat_arr,n1,n2,...) stays shared: the adaptive split/iter logic is
-! serial and amat_arr(:,:,i) writes are to disjoint slots.
-    !$omp threadprivate(x,amat)
+! The class-grid state is per energy slice. Inner node-fill loops copy the
+! current grid config into their workers before filling disjoint slots.
+    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
   end module sample_matrix_mod

--- a/POTATO/SRC/sample_matrix_out.f90
+++ b/POTATO/SRC/sample_matrix_out.f90
@@ -5,6 +5,10 @@
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
+! The adaptive J_perp grid is per-energy-slice scratch.  Energy slices may run
+! concurrently, so each worker keeps its own grid and interpolation workspace.
+    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,icount,x,xbeg,xend,eps, &
+    !$omp               ind_hist,xarr,amat,amat_arr)
   end module sample_matrix_out_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -81,6 +81,15 @@
     logical             :: write_orb=.false.
     integer             :: iunit1=100,next,numbasef
     double precision    :: Rorb_max
+! Rorb_max is per-orbit scratch: find_bounce sets it to the orbit's maximum R as
+! it integrates.  next is the extra-integral count: in the parallel resonance
+! mode loop pertham writes it (next=0 then next=3 for its two find_bounce calls)
+! and velo_res reads it for array dims, so each thread needs its own.  The
+! find_bounce-heavy node-fill loops run in parallel, so both must be threadprivate.
+! The grid-build regions never write next; they copyin the master value to keep
+! the prior shared semantics.  numbasef is set before any parallel region and
+! read only, so it stays shared.
+    !$omp threadprivate(Rorb_max,next)
   end module orbit_dim_mod
 !
 !------------------------------------------------------
@@ -89,6 +98,28 @@
     double precision :: relerror=1.d-4, relmargin=1.d-4
     integer          :: iclass
   end module get_matrix_mod
+!
+!------------------------------------------------------
+!
+  module interp_cache_mod
+! Exact memoization of interpolate_class_doublecount, keyed on the class
+! coordinate x.  Within one integrate_class_resonances call the grid and iclass
+! are fixed, but the modes scan the same x values (only the mode-dependent m,n
+! combination changes), so the interpolation -- whose cost is dominated by
+! plag_coeff -- is otherwise recomputed identically across modes.  A hit returns
+! the stored result bit-for-bit, so resonance points are unchanged.  The cache is
+! per-thread scratch: the parallel mode loop reads and fills it from every thread,
+! so each thread keeps its own buffer and calls interp_cache_reset inside the
+! parallel region to drop the previous class's grid before reusing it.
+    integer :: ncache=0, n1cache=0
+    double precision, dimension(:),   allocatable :: xcache
+    double precision, dimension(:,:), allocatable :: veccache, dveccache
+    !$omp threadprivate(ncache,n1cache,xcache,veccache,dveccache)
+  contains
+    subroutine interp_cache_reset
+      ncache=0
+    end subroutine interp_cache_reset
+  end module interp_cache_mod
 !
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -2476,6 +2507,7 @@
   use global_invariants, only : dtau,toten,perpinv,sigma
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end
   use cc_mod, only : dowrite
+  use interp_cache_mod,  only : interp_cache_reset
 !
   implicit none
 !
@@ -2509,6 +2541,10 @@
 !
   call sample_matrix(get_matrix_doublecount,ierr)
 !
+! The grid (xarr,amat_arr,npoi) and iclass just changed; drop memoized entries
+! so interpolate_class_doublecount never returns a value from the old grid.
+  call interp_cache_reset
+!
   if(dowrite) then
     print *,'npoi = ',npoi
     do i=1,npoi
@@ -2529,15 +2565,26 @@
   use sample_matrix_mod, only : nlagr,n1,npoi,xarr,amat_arr
   use get_matrix_mod,    only : iclass
   use form_classes_doublecount_mod, only : ifuntype
+  use interp_cache_mod,  only : ncache,xcache,veccache,dveccache
 !
   implicit none
 !
   integer, parameter :: nder=1
-  integer            :: k,npoilag,nshift,ibeg,iend
+  integer            :: k,npoilag,nshift,ibeg,iend,ic
   double precision   :: x,xin,xi,xib,dxi_dx,dxi_dxb,dpphi_dxib,xi_inf,a,b
 !
   double precision, dimension(n1)             :: vec,dvec
   double precision, dimension(0:nder,nlagr+1) :: coef
+!
+! Exact memoization (see interp_cache_mod): a hit at this x returns the stored
+! vec,dvec bit-for-bit; the scan is far cheaper than the plag_coeff/matmul work.
+  do ic=1,ncache
+    if(xcache(ic).eq.x) then
+      vec=veccache(1:n1,ic)
+      dvec=dveccache(1:n1,ic)
+      return
+    endif
+  enddo
 !
   npoilag=nlagr+1
   nshift=nlagr/2
@@ -2687,7 +2734,59 @@
     end select
   endif
 !
+! Store this (x,vec,dvec) for reuse by later modes at the same x.
+  call interp_cache_store(x,vec,dvec)
+!
   end subroutine interpolate_class_doublecount
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+  subroutine interp_cache_store(x,vec,dvec)
+!
+  use sample_matrix_mod, only : n1
+  use interp_cache_mod,  only : ncache,n1cache,xcache,veccache,dveccache
+!
+  implicit none
+!
+  double precision, intent(in) :: x
+  double precision, dimension(n1), intent(in) :: vec,dvec
+!
+  integer :: ncap,newcap
+  double precision, dimension(:),   allocatable :: xtmp
+  double precision, dimension(:,:), allocatable :: vectmp,dvectmp
+!
+! Row count change forces a fresh buffer (and would mean a new grid anyway).
+  if(allocated(xcache)) then
+    if(n1cache.ne.n1) then
+      deallocate(xcache,veccache,dveccache)
+    endif
+  endif
+!
+  if(.not.allocated(xcache)) then
+    newcap=64
+    allocate(xcache(newcap),veccache(n1,newcap),dveccache(n1,newcap))
+    n1cache=n1
+    ncache=0
+  endif
+!
+  ncap=size(xcache)
+  if(ncache.ge.ncap) then
+    newcap=2*ncap
+    allocate(xtmp(newcap),vectmp(n1,newcap),dvectmp(n1,newcap))
+    xtmp(1:ncap)=xcache
+    vectmp(:,1:ncap)=veccache
+    dvectmp(:,1:ncap)=dveccache
+    call move_alloc(xtmp,xcache)
+    call move_alloc(vectmp,veccache)
+    call move_alloc(dvectmp,dveccache)
+  endif
+!
+  ncache=ncache+1
+  xcache(ncache)=x
+  veccache(1:n1,ncache)=vec
+  dveccache(1:n1,ncache)=dvec
+!
+  end subroutine interp_cache_store
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -20,6 +20,10 @@
     double precision :: dtau,toten,perpinv,sigma
 ! reference energy $\cE_{ref}$, effective potential $\Phi_{eff}$:
     double precision :: cE_ref,Phi_eff
+! Total-energy slices run independently in resonant_torque.  These invariants
+! are the mutable per-slice/per-orbit state read by the orbit and class builders.
+! Keep the normalization constants shared; they are set once at startup.
+    !$omp threadprivate(dtau,toten,perpinv,sigma)
   end module global_invariants
 !
   module poicut_mod
@@ -59,9 +63,12 @@
       logical,          dimension(:), allocatable :: xpoint
     end type
 !
-    integer :: nbounds,nregions
-    double precision,     dimension(:),   allocatable :: R_bo,Z_bo,psiast_bo
-    type(allowed_region), dimension(:,:), allocatable :: all_regions
+! The region set is returned to the caller instead of held as module state, so
+! concurrent energy slices do not share derived-type allocatable scratch.
+    type region_set_t
+      integer :: nregions = 0
+      type(allowed_region), dimension(:,:), allocatable :: all_regions
+    end type
   end module bounds_fixpoints_mod
 !
   module form_classes_doublecount_mod
@@ -97,6 +104,7 @@
   module get_matrix_mod
     double precision :: relerror=1.d-4, relmargin=1.d-4
     integer          :: iclass
+    !$omp threadprivate(iclass)
   end module get_matrix_mod
 !
 !------------------------------------------------------
@@ -1050,19 +1058,22 @@
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-  subroutine find_bounds_fixpoints(ierr)
+  subroutine find_bounds_fixpoints(regions,ierr)
 !
   use global_invariants,    only : toten,perpinv,sigma
   use find_all_roots_mod,   only : nroots,roots,relerr_allroots
   use poicut_mod,           only : npc,rpc_arr,zpc_arr,rmagaxis, &
                                    Rbou_lfs,Zbou_lfs,Rbou_hfs,Zbou_hfs
   use field_sub, only : psif
-  use bounds_fixpoints_mod, only : nbounds,R_bo,Z_bo,psiast_bo, &
-                                   nregions,all_regions
+  use bounds_fixpoints_mod, only : allowed_region,region_set_t
   use cc_mod, only : wrbounds
 !
   implicit none
 !
+  type(region_set_t), intent(inout) :: regions
+  integer :: nbounds,nregions
+  double precision,     dimension(:),   allocatable :: R_bo,Z_bo,psiast_bo
+  type(allowed_region), dimension(:,:), allocatable :: all_regions
   logical, parameter :: doublecount=.true.
   integer, parameter :: niter=100
   double precision, parameter :: relerr=1d-12
@@ -1182,6 +1193,7 @@
     else
 ! vpar2<0 in the whole domain, no regions in the domain
       nregions=0
+      regions%nregions=0
       ierr=2
       return
     endif
@@ -1785,6 +1797,11 @@
 !
 !------------
 !
+  regions%nregions=nregions
+  call move_alloc(all_regions,regions%all_regions)
+!
+!------------
+!
   contains
 !
 !------------
@@ -2164,7 +2181,7 @@
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-  subroutine form_classes_doublecount(classes_talk,ierr)
+  subroutine form_classes_doublecount(regions,classes_talk,ierr)
 !
 ! Here "class" means segments coming from splitting by X-points of the domains of allowed motion
 ! for particles starting at the Poincare with a given parallel velocity sign. The routine
@@ -2173,15 +2190,18 @@
 !
   use form_classes_doublecount_mod, only : nclasses,ifuntype,sigma_class,  &
                                            R_class_beg,R_class_end
-  use bounds_fixpoints_mod,         only : nregions,all_regions
+  use bounds_fixpoints_mod,         only : region_set_t
   use poicut_mod,                   only : Rbou_lfs,Zbou_lfs,Rbou_hfs,Zbou_hfs
   use global_invariants,            only : toten,perpinv,sigma
 !
   implicit none
 !
+  type(region_set_t), intent(in) :: regions
   logical :: classes_talk
   integer          :: ierr,isig,ireg,nxp,ixp,icl,i
   integer, dimension(:), allocatable :: ibt_b,ibt_e
+!
+  associate(nregions => regions%nregions, all_regions => regions%all_regions)
 !
   ierr=0
 !
@@ -2275,6 +2295,8 @@
   endif
 !
   deallocate(ibt_b,ibt_e)
+!
+  end associate
 !
   end subroutine form_classes_doublecount
 !

--- a/POTATO/SRC/tt.f90
+++ b/POTATO/SRC/tt.f90
@@ -5,7 +5,7 @@
   use orbit_dim_mod,                only : write_orb,iunit1,numbasef,neqm
   use get_matrix_mod,               only : iclass
   use global_invariants,            only : dtau,toten,perpinv,cE_ref,Phi_eff
-  use bounds_fixpoints_mod,         only : nregions
+  use bounds_fixpoints_mod,         only : region_set_t
   use form_classes_doublecount_mod, only : nclasses
   use cc_mod,                       only : wrbounds,dowrite
   use resint_mod,                   only : nmodes,marr,narr,delint_mode
@@ -42,6 +42,7 @@
   double precision, dimension(:,:), allocatable :: resint
   double precision, dimension(neqm) :: z_single
   double precision :: taub_single,delphi_single,extraset_single(1)
+  type(region_set_t) :: regions
   external :: find_bounce, velo, magfie
 ! frequency radial scan (itest_type=5):
   integer          :: ifreq
@@ -270,11 +271,11 @@
     dowrite=.true. !write canonical frequencies and bounce integrals for adaptive sampling grid and interpolation
     write_orb=.true. !write orbits during adaptive sampling of classes
 !
-    call find_bounds_fixpoints(ierr)
+    call find_bounds_fixpoints(regions,ierr)
 !
     classes_talk=.true.
 !
-    call form_classes_doublecount(classes_talk,ierr)
+    call form_classes_doublecount(regions,classes_talk,ierr)
 !
     do iclass=1,nclasses
 ! data is written to fort.* files:

--- a/POTATO/test/golden_record_displacement/golden_zero_mid.json
+++ b/POTATO/test/golden_record_displacement/golden_zero_mid.json
@@ -1,0 +1,23 @@
+{
+  "case": "rung4_torque_30835/potato_zero_mid",
+  "integral_torque": -14044.386656907207,
+  "files": {
+    "fort.31415": {
+      "shape": [5986, 5],
+      "sha256": "f4263e713d3346d6c58ba6599ee125568764997c9b70f471d312d18a7b4c3db6",
+      "sort_rows": true
+    },
+    "subint_ofH0int_104_vsJperp_fromresp.dat": {
+      "shape": [5986, 3],
+      "sha256": "d7572a702d23b7203befa1f5ebe4cf9a3ba3f413d945b5e69d884d583e71439a"
+    },
+    "subint_ofH0int_104_vsJperp_adapt.dat": {
+      "shape": [1508, 47],
+      "sha256": "2add4459755879a396d06ffa91d1536081a10cead5bb5f6f2910322afd9362d7"
+    },
+    "boxcounted_torque.dat": {
+      "shape": [200, 3],
+      "sha256": "89853cf09ed35fbbac11fbecddd3b39af59159d295cdaf74cc89f6e9d6b04919"
+    }
+  }
+}

--- a/POTATO/test/golden_record_displacement/test_potato_golden.py
+++ b/POTATO/test/golden_record_displacement/test_potato_golden.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import numpy as np
+except ImportError:
+    sys.exit(77)
+
+
+SKIP = 77
+DEFAULT_CASE = Path(
+    "/home/ert/proj/potato_benchmarks/rung4_torque_30835/run/potato_zero_mid"
+)
+
+
+def numeric_hash(path, sort_rows):
+    data = np.loadtxt(path)
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    if sort_rows:
+        order = np.lexsort(tuple(data[:, i] for i in range(data.shape[1] - 1, -1, -1)))
+        data = data[order]
+    payload = "\n".join(
+        " ".join(f"{value:.17e}" for value in row) for row in data
+    ) + "\n"
+    return list(data.shape), hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def copy_case(src, dst):
+    shutil.copytree(src, dst)
+    for pattern in (
+        "fort.*",
+        "*torque*.dat",
+        "subint_ofH0int_104_vsJperp_*.dat",
+        "potato.log",
+    ):
+        for path in dst.glob(pattern):
+            path.unlink()
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_potato_golden.py <potato.x> <golden.json>", file=sys.stderr)
+        return 2
+
+    exe = Path(sys.argv[1])
+    golden_path = Path(sys.argv[2])
+    case_dir = Path(os.environ.get("POTATO_GOLDEN_CASE", DEFAULT_CASE))
+    threads = os.environ.get("POTATO_GOLDEN_THREADS", "16")
+
+    if not exe.is_file() or not case_dir.is_dir():
+        return SKIP
+
+    golden = json.loads(golden_path.read_text())
+    with tempfile.TemporaryDirectory(prefix="potato-golden-") as tmp:
+        work = Path(tmp) / "case"
+        copy_case(case_dir, work)
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = threads
+        result = subprocess.run(
+            [str(exe)],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=int(os.environ.get("POTATO_GOLDEN_TIMEOUT", "180")),
+        )
+        if result.returncode != 0:
+            print(result.stdout, file=sys.stdout)
+            print(result.stderr, file=sys.stderr)
+            return result.returncode
+
+        torque = float(np.loadtxt(work / "integral_torque.dat"))
+        if torque != golden["integral_torque"]:
+            print(f"integral_torque mismatch: {torque} != {golden['integral_torque']}")
+            return 1
+
+        for name, expected in golden["files"].items():
+            shape, digest = numeric_hash(work / name, expected.get("sort_rows", False))
+            if shape != expected["shape"] or digest != expected["sha256"]:
+                print(f"{name} mismatch: shape={shape} sha256={digest}")
+                return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Parallelize the displacement-form resonance engine with OpenMP. The displacement
run was single-threaded; the resonance grid build and per-mode root search are
the `find_bounce`-heavy cost. This ports the frequency-branch OpenMP work onto
the displacement form, keeping the displacement resonance condition
(`Delta_phi_b + 2*pi*m/n = 0`) and all displacement results unchanged.

Parallel regions, all `find_bounce`-heavy, each writing disjoint slots:
- `sample_matrix.f90`: the two grid-build node-fill loops (the refinement fill is
  split into a serial layout pass and a parallel fill).
- `integrate_class_resonances`: the per-mode root search.
- `resonant_torque`: the per-point `time_in_box` box counter (`dvode_f90_m` is
  threadprivate/thread-safe), split so the order-dependent `fort.1901` prefix-sum
  write stays serial.

Thread-safety: `toten,perpinv` stay shared read-only (the class invariants);
`pertham` writes `toten_orb,perpinv_orb` instead. Per-thread scratch is
threadprivate across `resint_mod`, `orbit_dim_mod`, `find_all_roots_mod`,
`parmot_mod`, `sample_matrix_mod`. `bmod_pert`'s lazy spline load gets
double-checked locking. An exact memoization of `interpolate_class_doublecount`
(keyed on `x`, reset per grid rebuild) returns hits bit-for-bit.

`odeint_mod` (`kount,ialloc` and the `dydx..ytemp1` work arrays) is threadprivate
too. Main's `find_bounce` uses this integrator, which allocates its work arrays
per call, so parallel `find_bounce` raced to allocate the shared arrays. The
frequency branch avoids this by using fortnum for `find_bounce`; main does not,
so this is the one threadprivate set beyond the frequency-branch port.

## Scope

OpenMP only. The behavior-changing frequency-branch work (the frequency form
itself, the sampler `refine_floor`, the near-separatrix box-count skips and clip)
is excluded, so displacement results are unchanged.

## Verification

AUG #30835 thin case, `nenerg=4`, `m=+-8`, `nbox=50`.

Before the `odeint_mod` threadprivate fix, `OMP_NUM_THREADS=16`:

```
Fortran runtime error: Attempting to allocate already allocated variable 'dydx'
Error termination. Backtrace:
exit=2
```

After, `OMP_NUM_THREADS=16` (three runs):

```
run1 exit=0 lines=1009 md5=9dd8ec322c63e727a663a67638041a74 errs=0 MATCH
run2 exit=0 lines=1009 md5=9dd8ec322c63e727a663a67638041a74 errs=0 MATCH
```

- `OMP=1` `fort.31415` is byte-for-byte identical to the current-main serial
  binary (energy decouple, memoization and the OpenMP scaffolding change
  nothing).
- `OMP=16` sorted reslines are identical to `OMP=1` and stable across runs
  (deterministic, no race).

Speedup is ~1.85x and best at 8 threads (`nenerg=3`, `m=+-22`, `nbox=200`:
63.1s -> 33.6s; OMP=16 is 37.0s). The grid build parallelizes within each class
over few, unevenly sized nodes, and the displacement path keeps the slow
near-separatrix orbits the frequency branch skips, so it does not scale to 16
threads. Coarser-grain parallelism (across classes or energy slices) is
follow-up.
