### PR TITLE
POTATO: coarse-grain energy-slice OpenMP parallelism (WIP, blocked on #60)

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -12,6 +12,11 @@ include(Util)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS Fortran)
+# OpenMP parallelizes the find_bounce-heavy resonance grid build
+# (SRC/sample_matrix.f90) and the per-mode resonance root search
+# (SRC/resonant_int.f90).  Linked to potato_base so -fopenmp reaches POTATO's own
+# sources and the runtime is linked.
+find_package(OpenMP REQUIRED)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(potato_base
   odeint_allroutines.f
   plag_coeff.f90
   find_all_roots.f90
+  sample_matrix_mod.f90
   sample_matrix.f90
   sample_matrix_out.f90
   sub_potato.f90
@@ -34,6 +35,7 @@ BLAS::BLAS
 LAPACK::LAPACK
 HDF5::HDF5
 fortplot::fortplot
+OpenMP::OpenMP_Fortran
 )
 
 add_library(potato

--- a/POTATO/SRC/alpha_lifetime_mod.f90
+++ b/POTATO/SRC/alpha_lifetime_mod.f90
@@ -3,6 +3,12 @@
     logical :: gradpsiast=.false.             !<=NEW in version 4
     double precision :: rmu,ro0
     double precision :: dpsiast_dR,dpsiast_dZ !<=NEW in version 4
+! gradpsiast and dpsiast_dR/dZ are per-orbit scratch: starter_doublecount sets
+! gradpsiast=.true. around a velo call that writes dpsiast_dR/dZ, then resets it.
+! The grid-build node-fill loops run starter+velo in parallel, so each thread
+! needs its own copy.  rmu,ro0 are physical constants set once and read only,
+! so they stay shared.
+    !$omp threadprivate(gradpsiast,dpsiast_dR,dpsiast_dZ)
   end module parmot_mod
 !
   module collis_alp

--- a/POTATO/SRC/bmod_pert.f90
+++ b/POTATO/SRC/bmod_pert.f90
@@ -24,8 +24,17 @@ end module bmod_pert_mod
   complex(8)   :: bmod_n
   double precision, dimension(:,:), allocatable :: bmod_n_re,bmod_n_im
 !
+! Lazy one-time load of the perturbation spline. bmod_pert is called only from
+! velo_res inside the OpenMP resonance loop (integrate_class_resonances), so the
+! first-call init races across threads: without a lock several threads read the
+! file and allocate the shared module arrays at once, and a thread reaching the
+! spline below while rad/splbmod are mid-allocation dereferences unallocated
+! memory. Double-checked locking (same pattern as libneo stretch_coords) runs the
+! read/allocate exactly once; afterwards prop is .false. and the fast path skips
+! the lock entirely.
   if(prop) then
-    prop=.false.
+  !$omp critical (bmod_pert_init)
+  if(prop) then
 
     open(iunit_bn,form='unformatted',file='bmod_n.dat', status='old')
     read(iunit_bn) nrad,nzet
@@ -59,6 +68,11 @@ end module bmod_pert_mod
     call s2dcut(nrad,nzet,hrad,hzet,bmod_n_im,imi,ima,jmi,jma,icp,splbmod_im,ipoint)
 !
     deallocate(bmod_n_re,bmod_n_im)
+! Publish only after every array is filled, so a thread that took the lock next
+! sees a fully built spline instead of a half-allocated one.
+    prop=.false.
+  endif
+  !$omp end critical (bmod_pert_init)
   endif
 !
   rrr=max(rad(1),min(rad(nrad),R))

--- a/POTATO/SRC/equimoments.f90
+++ b/POTATO/SRC/equimoments.f90
@@ -14,12 +14,14 @@
   use get_matrix_mod,    only : iclass
   use form_classes_doublecount_mod, only : nclasses
   use orbit_dim_mod,     only : numbasef
+  use bounds_fixpoints_mod, only : region_set_t
 
   implicit none
 !
   integer,          parameter :: numbasef_fix=8 !6 !5
   double precision, parameter :: pi=3.14159265358979d0
   logical :: classes_talk
+  type(region_set_t) :: regions
   integer :: nr,nz,ir,iz,i,k,iperp,nperp,ierr,nprof,ienerg,nenerg
   double precision :: rbeg,hr,zbeg,hz,weight,psi,psipow
   double precision :: bmod,phi_elec,phi_elec_min,phi_elec_max
@@ -110,7 +112,7 @@ print *,'toten = ',toten
       perpinv=perpinv_max*(1.d0-xjperp**2)
 !print *,' perpinv=',perpinv
 !
-      call find_bounds_fixpoints(ierr)
+      call find_bounds_fixpoints(regions,ierr)
 !
       if(ierr.ne.0) then
         print *,'find_bounds_fixpoints ierr = ',ierr
@@ -120,7 +122,7 @@ print *,'toten = ',toten
 !      classes_talk=.true.
       classes_talk=.false.
 !
-      call form_classes_doublecount(classes_talk,ierr)
+      call form_classes_doublecount(regions,classes_talk,ierr)
 !
       if(ierr.ne.0) then
         print *,'form_classes ierr = ',ierr

--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -8,11 +8,11 @@
     integer :: nroots, nsearch_min=100, ncustom, niter=100
     double precision :: relerr_allroots=1.d-12
     double precision, dimension(:), allocatable :: xcustom,roots
-! nroots,roots are the outputs of find_all_roots.  The per-mode resonance loop in
-! integrate_class_resonances runs find_all_roots in parallel, so each thread needs
-! its own.  The search inputs (customgrid,ncustom,xcustom,...) are set once before
-! the loop and read only, so they stay shared.
-    !$omp threadprivate(nroots,roots)
+! Per-energy-slice/per-class search state: the energy loop runs slices in parallel
+! and each class sets its own merged grid (customgrid,ncustom,xcustom) and gets its
+! own outputs (nroots,roots), so all are threadprivate.  nsearch_min,niter,
+! relerr_allroots are read-only config and stay shared.
+    !$omp threadprivate(customgrid,ncustom,xcustom,nroots,roots)
   end module find_all_roots_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -8,6 +8,11 @@
     integer :: nroots, nsearch_min=100, ncustom, niter=100
     double precision :: relerr_allroots=1.d-12
     double precision, dimension(:), allocatable :: xcustom,roots
+! nroots,roots are the outputs of find_all_roots.  The per-mode resonance loop in
+! integrate_class_resonances runs find_all_roots in parallel, so each thread needs
+! its own.  The search inputs (customgrid,ncustom,xcustom,...) are set once before
+! the loop and read only, so they stay shared.
+    !$omp threadprivate(nroots,roots)
   end module find_all_roots_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/odeint_allroutines.f
+++ b/POTATO/SRC/odeint_allroutines.f
@@ -19,13 +19,22 @@
 !
 !------------------------------------------------------------------------------
       module odeint_mod
-        integer :: kmax=0, kount=0, kmaxx=200, ialloc
+        integer :: kmax=0, kmaxx=200
         double precision :: dxsav=0.d0
+! Per-integration scratch and counters.  odeint allocates dydx..ytemp1 per call
+! (alloc_odeint) and find_bounce runs the integrator in parallel (the resonance
+! grid build and the per-mode loop), so each thread needs its own copies, else
+! threads race to allocate the shared arrays ("already allocated").  kount,ialloc
+! are written at the top of each odeint call before any read, so they need no
+! copyin.  kmax,kmaxx,dxsav are set-once read-only config and stay shared.
+        integer :: kount=0, ialloc
         double precision, dimension(:),   allocatable :: dydx,xp,y,yscal
         double precision, dimension(:,:), allocatable :: yp
         double precision, dimension(:),   allocatable :: ak2,ak3,ak4,ak5
         double precision, dimension(:),   allocatable :: ak6,ytemp
         double precision, dimension(:),   allocatable :: yerr,ytemp1
+!$omp threadprivate(kount,ialloc,dydx,xp,y,yscal,yp,ak2,ak3,ak4,
+!$omp+ak5,ak6,ytemp,yerr,ytemp1)
       end module odeint_mod
 !
 !------------------------------------------------------------------------------

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -351,11 +351,14 @@
   use cc_mod,                       only : wrbounds,dowrite
   use orbit_dim_mod,                only : write_orb
   use logging_mod,                  only : tee_message, close_logging
+  use bounds_fixpoints_mod,         only : region_set_t
 !
   logical :: classes_talk
 !
   integer :: ierr,mode
   character(len=256) :: msg
+! Region set owned per J_perp node (hence per energy slice, hence per thread).
+  type(region_set_t) :: regions
 !
   wrbounds=.false.
   dowrite=.false.
@@ -364,7 +367,7 @@
 !
   perpinv=x
 !
-  call find_bounds_fixpoints(ierr)
+  call find_bounds_fixpoints(regions,ierr)
 !
   if(ierr.ne.0) then
     write(msg, '(A,I0)') &
@@ -374,7 +377,7 @@
     stop
   endif
 !
-  call form_classes_doublecount(classes_talk,ierr)
+  call form_classes_doublecount(regions,classes_talk,ierr)
 !
   if(ierr.ne.0) then
     write(msg, '(A,I0)') &

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -26,6 +26,12 @@
 !
     integer          :: nmodes,nperp_max=0
     double precision :: twopim2,rm3,taub_new,delphi_new
+! Energy and perpendicular invariant of the resonant orbit, set by pertham and
+! read by velo_res for the perturbed-Hamiltonian Fourier integral.  Held separate
+! from the global class invariants toten,perpinv so the per-mode resonance loop
+! never writes those -- they stay the shared, read-only class values, which lets
+! the loop be parallelized without making toten,perpinv threadprivate.
+    double precision :: toten_orb,perpinv_orb
     integer, dimension(:), allocatable :: marr,narr
     double precision, dimension(:), allocatable :: delint_mode
 !
@@ -45,8 +51,7 @@
 ! of the perturbed Hamiltonian $\hat H_\bm$, Eq.(102) (former Eq.(93))
 !
   use orbit_dim_mod,     only : neqm,next,numbasef
-  use global_invariants, only : toten,perpinv
-  use resint_mod,        only : twopim2,rm3,taub_new,delphi_new
+  use resint_mod,        only : twopim2,rm3,taub_new,delphi_new,toten_orb,perpinv_orb
 !
   implicit none
 !
@@ -60,7 +65,7 @@
   call get_bmod_and_Phi(z(1:3),bmod,phi_elec)
   call bmod_pert(z(1),z(3),bmod_n)
 !
-  comfac=(2.d0*(toten-phi_elec)/bmod-perpinv)*bmod_n &
+  comfac=(2.d0*(toten_orb-phi_elec)/bmod-perpinv_orb)*bmod_n &
         *exp(imun*(rm3*z(2)-(twopim2+delphi_new*rm3)*z(6)/taub_new))
 !
   vz(6)=1.d0
@@ -77,8 +82,8 @@
 ! Hamiltoninan, $|\hat H_\bm|^2$, with $\hat H_\bm$ defined by Eq.(102) (former Eq.(93)).
 !
   use orbit_dim_mod,     only : neqm,next     ,write_orb,iunit1
-  use global_invariants, only : toten,perpinv,dtau
-  use resint_mod,        only : taub_new,delphi_new
+  use global_invariants, only : dtau
+  use resint_mod,        only : taub_new,delphi_new,toten_orb,perpinv_orb
 !
 !
   implicit none
@@ -94,8 +99,8 @@
 !
   call get_bmod_and_Phi(z(1:3),bmod,phi_elec)
 !
-  toten=z(4)**2+phi_elec
-  perpinv=z(4)**2*(1.d0-z(5)**2)/bmod
+  toten_orb=z(4)**2+phi_elec
+  perpinv_orb=z(4)**2*(1.d0-z(5)**2)/bmod
 !
   next=0
   allocate(extraset(next))
@@ -152,12 +157,9 @@
   double precision :: relmargin_loc,widthclass,xbeg,xend
   double precision :: rescond,dresconddx,psiast,dpsiastdx,taub,delphi
   double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
-  double precision :: toten_loc,perpinv_loc,fmaxw,A1ast,A2ast
+  double precision :: fmaxw,A1ast,A2ast
   double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
   double precision, dimension(neqm) :: z
-!
-  toten_loc=toten
-  perpinv_loc=perpinv
 !
   sigma=sigma_class(iclass)
   delta_R=R_class_end(iclass)-R_class_beg(iclass)
@@ -226,8 +228,9 @@
       call denstemp_of_psi(psiast,dens,temp,ddens,dtemp)
       call phielec_of_psi(psiast,phi_elec,dPhi_dpsi)
 !
-      toten=toten_loc
-      perpinv=perpinv_loc
+! toten,perpinv are never written in this loop (pertham writes toten_orb,
+! perpinv_orb instead), so they still hold the class invariants set on entry --
+! no save/restore needed.
 !
 ! Non-local thermodynamic forces Eq.(95) (former Eq.(87)):
       A2ast=dtemp/temp

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -26,12 +26,22 @@
 !
     integer          :: nmodes,nperp_max=0
     double precision :: twopim2,rm3,taub_new,delphi_new
+    !$omp threadprivate(twopim2,rm3,taub_new,delphi_new)
 ! Energy and perpendicular invariant of the resonant orbit, set by pertham and
 ! read by velo_res for the perturbed-Hamiltonian Fourier integral.  Held separate
 ! from the global class invariants toten,perpinv so the per-mode resonance loop
 ! never writes those -- they stay the shared, read-only class values, which lets
 ! the loop be parallelized without making toten,perpinv threadprivate.
     double precision :: toten_orb,perpinv_orb
+    !$omp threadprivate(toten_orb,perpinv_orb)
+! By-products of the resonance condition get_rescond ($\psi^\ast$, bounce time,
+! toroidal shift), recovered for the orbit weight.  get_rescond is an internal
+! procedure of integrate_class_resonances that is also passed as the dummy root
+! function to find_all_roots; with gfortran's trampoline for that dummy-procedure
+! call, a host-local PRIVATE variable written through it is not seen as private,
+! so these must be threadprivate module state instead of privatized host locals.
+    double precision :: psiast_res,taub_res,delphi_res
+    !$omp threadprivate(psiast_res,taub_res,delphi_res)
     integer, dimension(:), allocatable :: marr,narr
     double precision, dimension(:), allocatable :: delint_mode
 !
@@ -142,11 +152,13 @@
   use find_all_roots_mod, only : customgrid,ncustom,xcustom,nroots,roots
   use get_matrix_mod,     only : relmargin,iclass
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
-  use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp
+  use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp, &
+                                 psiast_res,taub_res,delphi_res
   use orbit_dim_mod,      only : neqm
   use global_invariants,  only : toten,perpinv,cE_ref,Phi_eff
   use sample_matrix_mod,  only : npoi,xarr
   use logging_mod,        only : tee_message
+  use interp_cache_mod,   only : interp_cache_reset
 !
   implicit none
 !
@@ -155,7 +167,7 @@
 !
   integer          :: mode,iroot,ierr
   double precision :: relmargin_loc,widthclass,xbeg,xend
-  double precision :: rescond,dresconddx,psiast,dpsiastdx,taub,delphi
+  double precision :: rescond,dresconddx,dpsiastdx
   double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
   double precision :: fmaxw,A1ast,A2ast
   double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
@@ -175,7 +187,26 @@
   allocate(xcustom(ncustom))
   xcustom=xarr
 !
-!
+! Parallel over modes: each mode is independent.  It runs its own find_all_roots
+! (nroots,roots threadprivate) and per-root starter+pertham (twopim2,rm3,taub_new,
+! delphi_new,toten_orb,perpinv_orb,next, and the interp cache threadprivate), and
+! writes only its disjoint column respoints_jp(mode,iclass) and delint_mode(mode).
+! toten,perpinv stay shared read-only (the class invariants); customgrid,ncustom,
+! xcustom and the grid arrays are shared read-only too.  The threadprivate
+! form-class bounds it reads (ifuntype,R_class_beg,R_class_end,sigma_class) are
+! copyin'd.  The get_rescond by-products psiast_res,taub_res,delphi_res are
+! threadprivate module state (resint_mod), NOT host-local privates: get_rescond
+! is passed as the dummy root function to find_all_roots, and gfortran's
+! trampoline for that call does not honor a host-local private.  reslines
+! write(31415) and tee_message go in a critical section.  Each thread resets its
+! interp cache at entry so it drops the previous class's grid before reusing it.
+  !$omp parallel default(shared) &
+  !$omp   private(mode,iroot,ierr,rescond,dresconddx,dpsiastdx) &
+  !$omp   private(one_res,Rst,xi,dxi_dx,dpsiast_dRst,absHn2,fmaxw,A1ast,A2ast) &
+  !$omp   private(dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi,z) &
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class)
+  call interp_cache_reset
+  !$omp do schedule(dynamic)
   do mode=1,nmodes
     twopim2=twopi*dble(marr(mode))
     rm3=dble(narr(mode))
@@ -184,11 +215,14 @@
     call find_all_roots(get_rescond,xbeg,xend,ierr)
 !
     if(ierr.ne.0) then
+      !$omp critical (reslines_log)
       call tee_message( &
         'integrate_class_resonances: error in find_all_roots')
-      customgrid=.false.
-      deallocate(xcustom)
-      return
+      !$omp end critical (reslines_log)
+      respoints_jp(mode,iclass)%nrespoi=0
+      respoints_jp(mode,iclass)%toten_res=toten
+      respoints_jp(mode,iclass)%perpinv_res=perpinv
+      cycle
     endif
 !
     respoints_jp(mode,iclass)%nrespoi=nroots
@@ -207,16 +241,20 @@
       Rst=R_class_beg(iclass)+delta_R*xi
 !
       call starter_doublecount(toten,perpinv,sigma,Rst,   &
-                               psiast,dpsiast_dRst,z,ierr)
+                               psiast_res,dpsiast_dRst,z,ierr)
 !
       if(ierr.ne.0) then
+        !$omp critical (reslines_log)
         call tee_message( &
           'integrate_class_resonances: error in starter_doublecount')
+        !$omp end critical (reslines_log)
         cycle
       endif
 !
       if(.true.) then
-        write(31415,*) toten,perpinv,psiast,marr(mode),narr(mode)   !<=resonant line for plotting
+        !$omp critical (reslines_log)
+        write(31415,*) toten,perpinv,psiast_res,marr(mode),narr(mode)   !<=resonant line for plotting
+        !$omp end critical (reslines_log)
       endif
 !
       respoints_jp(mode,iclass)%z_res(:,iroot)=z
@@ -224,9 +262,9 @@
       dpsiastdx=dpsiast_dRst*delta_R*dxi_dx     !$\difp{\psi^\ast}{x}$
 !
       call pertham(z,absHn2)
-      call equilmaxw(psiast,fmaxw)
-      call denstemp_of_psi(psiast,dens,temp,ddens,dtemp)
-      call phielec_of_psi(psiast,phi_elec,dPhi_dpsi)
+      call equilmaxw(psiast_res,fmaxw)
+      call denstemp_of_psi(psiast_res,dens,temp,ddens,dtemp)
+      call phielec_of_psi(psiast_res,phi_elec,dPhi_dpsi)
 !
 ! toten,perpinv are never written in this loop (pertham writes toten_orb,
 ! perpinv_orb instead), so they still hold the class invariants set on entry --
@@ -238,12 +276,12 @@
 !
 ! Expression under summation signs except the last line in Eq.(104) (former Eq.(94)):
       one_res=abs(dpsiastdx/dresconddx)*absHn2*fmaxw            &
-!ERROR, SEE in RED=>             *(Phi_eff*taub*(A1ast+A2ast*(toten-phi_elec)/temp)+delphi/temp)
-             *Phi_eff*taub*(A1ast+A2ast*(toten-phi_elec)/temp)  !<=ERROR CORRECTED
+!ERROR, SEE in RED=>             *(Phi_eff*taub_res*(A1ast+A2ast*(toten-phi_elec)/temp)+delphi_res/temp)
+             *Phi_eff*taub_res*(A1ast+A2ast*(toten-phi_elec)/temp)  !<=ERROR CORRECTED
 !
 ! emulator of box average (Heaviside function replaced with one in (104) - result is integral torque in
 ! the whole volume normalized by the reference energy $\cE_{ref}$):
-      one_res=one_res*taub
+      one_res=one_res*taub_res
 ! end emulator of box average
 !
 ! multiply expression under summation over modes with toroidal mode number, with factor $-\pi^{3/2}/4$
@@ -251,10 +289,12 @@
       one_res=one_res*rm3*pi32_over4m*cE_ref
 !
       respoints_jp(mode,iclass)%w_res(iroot)=one_res
-      respoints_jp(mode,iclass)%taub(iroot)=taub
+      respoints_jp(mode,iclass)%taub(iroot)=taub_res
       delint_mode(mode)=delint_mode(mode)+one_res
     enddo
   enddo
+  !$omp end do
+  !$omp end parallel
 !
   customgrid=.false.
   deallocate(xcustom)
@@ -279,10 +319,10 @@
 !
   call interpolate_class_doublecount(x,vec,dvec)
 !
-  psiast=vec(1)               ! $\psi^\ast$
-  taub=vec(2)                 ! $\tau_b$
-  delphi=vec(3)               ! $\Delta\varphi_b$
-  rescond=delphi+twopim2/rm3
+  psiast_res=vec(1)           ! $\psi^\ast$
+  taub_res=vec(2)             ! $\tau_b$
+  delphi_res=vec(3)           ! $\Delta\varphi_b$
+  rescond=delphi_res+twopim2/rm3
   dresconddx=dvec(3)
 !
   end subroutine get_rescond
@@ -432,6 +472,9 @@
   double precision, dimension(:), allocatable :: sbox
   double precision, dimension(:), allocatable :: taubox
   double precision, dimension(:), allocatable :: torquebox
+! Per-resonance-point box times, filled by the parallel time_in_box pass and
+! consumed by the serial accumulate/write pass below.
+  double precision, dimension(:,:), allocatable :: taubox_all
 !
   external :: get_matrix_res
 !
@@ -591,30 +634,29 @@
 ! Computation of the integral torque:
       torque_int_loc=0.d0
 !
+! Box counter (time_in_box) integrates each resonant orbit through the radial
+! boxes via dvode -- the dominant per-point cost.  Points are independent and
+! dvode_f90_m is threadprivate/thread-safe, so run them in parallel into the
+! per-point taubox_all.  z_res(1:5) is the orbit start at the Poincare cut.
+      allocate(taubox_all(nbox,nrespoints))
+      !$omp parallel do default(shared) private(i) schedule(dynamic)
       do i=1,nrespoints
-! Here box counter should be used. Below we compute an integral torque as a sum of orbit weights:
-        torque_int_loc=torque_int_loc+respoint(i)%w_res
-! Quantity torque_int_loc is a contribution of one energy level to the integral torque. Width of energy
-! interval is already included in the weight.
-! For box counter use the starting coordinates of the orbit at the Poincare cut. They are stored in
-! respoint(i)%z_res(1:5)
-! Weight of the orbit is stored in
-! respoint(i)%w_res
-! If needed, there are also total energy and perpendicular invariant available in
-! respoint(i)%toten_res
-! and
-! respoint(i)%perpinv_res
-! respectively
         call time_in_box(respoint(i)%z_res(1:5), nbox, sbox, &
-          respoint(i)%taub, taubox)
+          respoint(i)%taub, taubox_all(:,i))
+      enddo
+      !$omp end parallel do
+!
+! Serial accumulate/write pass: torque_int_loc is a running prefix sum written
+! per row to fort.1901, so it stays serial and in order; torquebox sums the
+! per-point box times.  Width of the energy interval is already in the weight.
+      do i=1,nrespoints
+        torque_int_loc=torque_int_loc+respoint(i)%w_res
         write(1901,*) respoint(i)%toten_res, &
           respoint(i)%perpinv_res, &
-          ! tormom_of_RZ(respoint(i)%toten_res, respoint(i)%perpinv_res, TODO ), &
-          torque_int_loc    !,taubox/respoint(i)%taub
-!
-        torquebox=torquebox+respoint(i)%w_res*taubox/respoint(i)%taub   !<=sum up resonances in boxes
-!
+          torque_int_loc
+        torquebox=torquebox+respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
       enddo
+      deallocate(taubox_all)
       write(1901,*) ' '
 !
       deallocate(respoint)

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -49,6 +49,13 @@
     type(respoints_fix_jperp),            dimension(:),   allocatable :: respoints_all, &
                                                                          respoints_all_tmp
     type(respoint_single),                dimension(:),   allocatable :: respoint
+! Per-energy-slice resonance bookkeeping: the energy loop (resonant_torque) runs
+! slices in parallel, and each slice fills its own J_perp grid of resonant points
+! (respoints_all/_tmp, respoints_jp, respoint) and per-mode integral (delint_mode),
+! and sizes them with its own nperp_max.  Threadprivate so slices do not collide.
+! nmodes,marr,narr are set once before the loop and read only, so they stay shared.
+    !$omp threadprivate(nperp_max,delint_mode,respoints_jp,respoints_all, &
+    !$omp               respoints_all_tmp,respoint)
   end module resint_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -453,6 +460,7 @@
                                 adaptive_jperp, npoi_init, nlagr_sampling, &
                                 eps_sampling, itermax_sampling
   use logging_mod,       only : tee_message
+  !$ use omp_lib, only : omp_set_max_active_levels
 
   implicit none
 !
@@ -480,13 +488,8 @@
 !
   allocate(sbox(nbox), taubox(nbox), torquebox(nbox))
 !
-! size of result matrix in get_matrix_res:
-  n1=nmodes
-  n2=1
-! Set adaptive sampling parameters from input:
-  nlagr=nlagr_sampling
-  eps=eps_sampling
-  itermax=itermax_sampling
+! n1,n2,nlagr,eps,itermax (sample_matrix_out_mod) are threadprivate per-slice grid
+! config; they are set inside the energy loop so each thread seeds its own.
 !
   numbasef=0 !no extra integrals sampled, pure orbit integration
   call linspace(1d0/nbox, 1d0, nbox, sbox)
@@ -543,9 +546,28 @@
     open(1902,file='subint_ofH0int_104_vsJperp_equi.dat')
   endif
 !
+! Coarse-grain parallelism: the total-energy slices are independent, so run them
+! in parallel.  All per-slice scratch (the class and J_perp grids, the resonant-
+! point bookkeeping, the orbit invariants toten,perpinv,sigma,dtau) is
+! threadprivate, so each slice keeps its own; the torque sums reduce.  Cap the
+! active level at one so the inner per-class/per-mode regions stay serial inside
+! each slice instead of oversubscribing.  File writes go to libgfortran's
+! per-unit lock; resonance lines are compared sorted, so their interleaving is
+! immaterial.
+  !$ call omp_set_max_active_levels(1)
+  !$omp parallel do default(shared) schedule(dynamic) &
+  !$omp   private(xenerg,perpinv_max,trapez_fac,nrespoints,i,k,iperp,ierr,nperp) &
+  !$omp   private(time_beg,time_end,xjperp,torque_int_loc,msg,taubox_all) &
+  !$omp   reduction(+:torque_int,torque_int_modes,torquebox)
   do ienerg=1,nenerg
     xenerg=(dble(ienerg)-0.5d0)/dble(nenerg)
     toten=toten_min+toten_range*xenerg
+! per-slice J_perp grid config (sample_matrix_out_mod is threadprivate):
+    n1=nmodes
+    n2=1
+    nlagr=nlagr_sampling
+    eps=eps_sampling
+    itermax=itermax_sampling
 !toten =   -3.1211921097605737d0
     write(msg, '(A,ES22.14)') 'toten = ', toten
     call tee_message(trim(msg))
@@ -728,6 +750,7 @@
     call tee_message(trim(msg))
 !
   enddo
+  !$omp end parallel do
 !
   if(adaptive_jperp) close(1901)
   close(1902)

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -1,23 +1,20 @@
-  module sample_matrix_mod
-    integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
-    double precision :: x,xbeg,xend,eps
-    double precision, dimension(:),     allocatable :: xarr
-    double precision, dimension(:,:),   allocatable :: amat
-    double precision, dimension(:,:,:), allocatable :: amat_arr
-  end module sample_matrix_mod
-!
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
   SUBROUTINE sample_matrix(get_matrix,ierr)
 !
   USE sample_matrix_mod
+  USE form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
+! next is threadprivate (the resonance mode loop writes it); copyin it into the
+! grid-build regions, which never write it, so each worker starts from the master
+! value.
+  USE orbit_dim_mod, only : next
 !
   IMPLICIT NONE
 !
   INTEGER, PARAMETER :: nder=0
   DOUBLE PRECISION, PARAMETER :: symm_break=0.01d0
-  INTEGER :: i,j,iter,npoi_old,iold,inew,ibeg,iend,nshift,npoilag,ierr
-  INTEGER,          DIMENSION(:),     ALLOCATABLE :: isplit
+  INTEGER :: i,j,iter,npoi_old,iold,inew,ibeg,iend,nshift,npoilag,ierr,nnew,k
+  INTEGER,          DIMENSION(:),     ALLOCATABLE :: isplit,newslots
 !
   DOUBLE PRECISION :: h,hh
   DOUBLE PRECISION, DIMENSION(:),     ALLOCATABLE :: xold
@@ -59,11 +56,22 @@
     x=xbeg+h*(i-1)+hh*(i-1)**2
     xarr(i)=x
   ENDDO
+! Initial interior fill: one independent get_matrix (starter+find_bounce) per
+! node, writing the disjoint slot amat_arr(:,:,i).  This is the find_bounce-heavy
+! cost.  x and amat are threadprivate scratch; the form-class bounds are already
+! threadprivate, so copyin seeds each worker with the master values.  toten,perpinv
+! stay SHARED and read-only here (the grid build never calls pertham, so nothing
+! writes them); next is threadprivate but unwritten here, so copyin seeds each
+! worker with the master value to keep the prior shared behavior.
+  !$omp parallel do default(shared) private(i) schedule(dynamic) &
+  !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
   DO i=2,npoi-1
+    if(.not.allocated(amat)) allocate(amat(n1,n2))
     x=xarr(i)
     CALL get_matrix
     amat_arr(:,:,i)=amat
   ENDDO
+  !$omp end parallel do
 !
   ALLOCATE(amat1(n1,n2),amat2(n1,n2),amat_maxmod(n1,n2))
 !
@@ -123,7 +131,13 @@
     ENDIF
     ALLOCATE(xarr(npoi),amat_arr(n1,n2,npoi))
 !
-! fill new arrays:
+! Serial layout pass: copy the retained old nodes into their new slots and, for
+! each split interval, reserve the new node's slot inew with its midpoint xarr.
+! Record the new-node slots in newslots so the find_bounce-heavy get_matrix calls
+! run in the parallel fill below instead of here.  Layout (slot assignment, array
+! re-allocation, the isplit decision) stays serial.
+    ALLOCATE(newslots(npoi))
+    nnew=0
     inew=0
     DO iold=1,npoi_old-1
       inew=inew+1
@@ -131,16 +145,29 @@
       amat_arr(:,:,inew)=amat_old(:,:,iold)
       IF(isplit(iold).EQ.1) THEN
         inew=inew+1
-        x=0.5d0*(xold(iold)+xold(iold+1))
-        CALL get_matrix
-        xarr(inew)=x
-        amat_arr(:,:,inew)=amat
+        xarr(inew)=0.5d0*(xold(iold)+xold(iold+1))
+        nnew=nnew+1
+        newslots(nnew)=inew
       ENDIF
     ENDDO
     inew=inew+1
     xarr(inew)=xold(npoi_old)
     amat_arr(:,:,inew)=amat_old(:,:,npoi_old)
     DEALLOCATE(isplit)
+!
+! Parallel fill pass: one independent get_matrix per new node, writing the
+! disjoint slot amat_arr(:,:,newslots(k)).  Same per-thread scratch (x,amat) and
+! copyin of the shared form-class bounds and next as the initial fill.
+    !$omp parallel do default(shared) private(k) schedule(dynamic) &
+    !$omp   copyin(ifuntype,R_class_beg,R_class_end,sigma_class,next)
+    DO k=1,nnew
+      if(.not.allocated(amat)) allocate(amat(n1,n2))
+      x=xarr(newslots(k))
+      CALL get_matrix
+      amat_arr(:,:,newslots(k))=amat
+    ENDDO
+    !$omp end parallel do
+    DEALLOCATE(newslots)
 !
 ! check which intervals should be splitted
     ALLOCATE(isplit(npoi))

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -1,0 +1,14 @@
+  module sample_matrix_mod
+    integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
+    double precision :: x,xbeg,xend,eps
+    double precision, dimension(:),     allocatable :: xarr
+    double precision, dimension(:,:),   allocatable :: amat
+    double precision, dimension(:,:,:), allocatable :: amat_arr
+! x and amat are the per-node input/output of get_matrix_doublecount: each call
+! reads x and writes amat for one grid node.  The grid-build node-fill loops in
+! sample_matrix run those calls in parallel over disjoint nodes, so x and amat
+! are genuine per-thread scratch and must be threadprivate.  The grid layout
+! (npoi,xarr,amat_arr,n1,n2,...) stays shared: the adaptive split/iter logic is
+! serial and amat_arr(:,:,i) writes are to disjoint slots.
+    !$omp threadprivate(x,amat)
+  end module sample_matrix_mod

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -4,11 +4,9 @@
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
-! x and amat are the per-node input/output of get_matrix_doublecount: each call
-! reads x and writes amat for one grid node.  The grid-build node-fill loops in
-! sample_matrix run those calls in parallel over disjoint nodes, so x and amat
-! are genuine per-thread scratch and must be threadprivate.  The grid layout
-! (npoi,xarr,amat_arr,n1,n2,...) stays shared: the adaptive split/iter logic is
-! serial and amat_arr(:,:,i) writes are to disjoint slots.
-    !$omp threadprivate(x,amat)
+! The whole class-grid scratch is per-energy-slice state: the energy loop
+! (resonant_torque) builds and interpolates one class grid per slice, and the
+! slices run in parallel, so each thread needs its own grid (xarr,amat_arr,npoi,
+! n1,n2,eps,xbeg,xend) and per-node scratch (x,amat).  nstiff,i_int are unused.
+    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
   end module sample_matrix_mod

--- a/POTATO/SRC/sample_matrix_out.f90
+++ b/POTATO/SRC/sample_matrix_out.f90
@@ -5,6 +5,12 @@
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
+! The J_perp adaptive grid scratch is per-energy-slice state: the energy loop
+! (resonant_torque) builds one J_perp grid per slice and the slices run in
+! parallel, so each thread keeps its own grid.  The config (nlagr,n1,n2,itermax,
+! eps) is set per slice at the top of the loop, so no copyin is needed.
+    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,icount,x,xbeg,xend,eps, &
+    !$omp               ind_hist,xarr,amat,amat_arr)
   end module sample_matrix_out_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -20,6 +20,13 @@
     double precision :: dtau,toten,perpinv,sigma
 ! reference energy $\cE_{ref}$, effective potential $\Phi_{eff}$:
     double precision :: cE_ref,Phi_eff
+! dtau,toten,perpinv,sigma are the per-slice/per-orbit invariants: the energy loop
+! (resonant_torque) runs each total-energy slice in parallel, and every slice
+! sets and reads its own toten (and the J_perp node its own perpinv, the class its
+! own sigma, the orbit its own dtau).  Threadprivate so concurrent slices do not
+! clobber each other.  cE_ref,Phi_eff are set once at startup (tt.f90) and read
+! only, so they stay shared.
+    !$omp threadprivate(dtau,toten,perpinv,sigma)
   end module global_invariants
 !
   module poicut_mod
@@ -62,6 +69,10 @@
     integer :: nbounds,nregions
     double precision,     dimension(:),   allocatable :: R_bo,Z_bo,psiast_bo
     type(allowed_region), dimension(:,:), allocatable :: all_regions
+! Per-slice scratch: the orbit-region/boundary formation runs once per energy
+! slice, and the slices run in parallel (resonant_torque), so each thread builds
+! its own regions.
+    !$omp threadprivate(nbounds,nregions,R_bo,Z_bo,psiast_bo,all_regions)
   end module bounds_fixpoints_mod
 !
   module form_classes_doublecount_mod

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -81,6 +81,15 @@
     logical             :: write_orb=.false.
     integer             :: iunit1=100,next,numbasef
     double precision    :: Rorb_max
+! Rorb_max is per-orbit scratch: find_bounce sets it to the orbit's maximum R as
+! it integrates.  next is the extra-integral count: in the parallel resonance
+! mode loop pertham writes it (next=0 then next=3 for its two find_bounce calls)
+! and velo_res reads it for array dims, so each thread needs its own.  The
+! find_bounce-heavy node-fill loops run in parallel, so both must be threadprivate.
+! The grid-build regions never write next; they copyin the master value to keep
+! the prior shared semantics.  numbasef is set before any parallel region and
+! read only, so it stays shared.
+    !$omp threadprivate(Rorb_max,next)
   end module orbit_dim_mod
 !
 !------------------------------------------------------
@@ -89,6 +98,28 @@
     double precision :: relerror=1.d-4, relmargin=1.d-4
     integer          :: iclass
   end module get_matrix_mod
+!
+!------------------------------------------------------
+!
+  module interp_cache_mod
+! Exact memoization of interpolate_class_doublecount, keyed on the class
+! coordinate x.  Within one integrate_class_resonances call the grid and iclass
+! are fixed, but the modes scan the same x values (only the mode-dependent m,n
+! combination changes), so the interpolation -- whose cost is dominated by
+! plag_coeff -- is otherwise recomputed identically across modes.  A hit returns
+! the stored result bit-for-bit, so resonance points are unchanged.  The cache is
+! per-thread scratch: the parallel mode loop reads and fills it from every thread,
+! so each thread keeps its own buffer and calls interp_cache_reset inside the
+! parallel region to drop the previous class's grid before reusing it.
+    integer :: ncache=0, n1cache=0
+    double precision, dimension(:),   allocatable :: xcache
+    double precision, dimension(:,:), allocatable :: veccache, dveccache
+    !$omp threadprivate(ncache,n1cache,xcache,veccache,dveccache)
+  contains
+    subroutine interp_cache_reset
+      ncache=0
+    end subroutine interp_cache_reset
+  end module interp_cache_mod
 !
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -2476,6 +2507,7 @@
   use global_invariants, only : dtau,toten,perpinv,sigma
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end
   use cc_mod, only : dowrite
+  use interp_cache_mod,  only : interp_cache_reset
 !
   implicit none
 !
@@ -2509,6 +2541,10 @@
 !
   call sample_matrix(get_matrix_doublecount,ierr)
 !
+! The grid (xarr,amat_arr,npoi) and iclass just changed; drop memoized entries
+! so interpolate_class_doublecount never returns a value from the old grid.
+  call interp_cache_reset
+!
   if(dowrite) then
     print *,'npoi = ',npoi
     do i=1,npoi
@@ -2529,15 +2565,26 @@
   use sample_matrix_mod, only : nlagr,n1,npoi,xarr,amat_arr
   use get_matrix_mod,    only : iclass
   use form_classes_doublecount_mod, only : ifuntype
+  use interp_cache_mod,  only : ncache,xcache,veccache,dveccache
 !
   implicit none
 !
   integer, parameter :: nder=1
-  integer            :: k,npoilag,nshift,ibeg,iend
+  integer            :: k,npoilag,nshift,ibeg,iend,ic
   double precision   :: x,xin,xi,xib,dxi_dx,dxi_dxb,dpphi_dxib,xi_inf,a,b
 !
   double precision, dimension(n1)             :: vec,dvec
   double precision, dimension(0:nder,nlagr+1) :: coef
+!
+! Exact memoization (see interp_cache_mod): a hit at this x returns the stored
+! vec,dvec bit-for-bit; the scan is far cheaper than the plag_coeff/matmul work.
+  do ic=1,ncache
+    if(xcache(ic).eq.x) then
+      vec=veccache(1:n1,ic)
+      dvec=dveccache(1:n1,ic)
+      return
+    endif
+  enddo
 !
   npoilag=nlagr+1
   nshift=nlagr/2
@@ -2687,7 +2734,59 @@
     end select
   endif
 !
+! Store this (x,vec,dvec) for reuse by later modes at the same x.
+  call interp_cache_store(x,vec,dvec)
+!
   end subroutine interpolate_class_doublecount
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+  subroutine interp_cache_store(x,vec,dvec)
+!
+  use sample_matrix_mod, only : n1
+  use interp_cache_mod,  only : ncache,n1cache,xcache,veccache,dveccache
+!
+  implicit none
+!
+  double precision, intent(in) :: x
+  double precision, dimension(n1), intent(in) :: vec,dvec
+!
+  integer :: ncap,newcap
+  double precision, dimension(:),   allocatable :: xtmp
+  double precision, dimension(:,:), allocatable :: vectmp,dvectmp
+!
+! Row count change forces a fresh buffer (and would mean a new grid anyway).
+  if(allocated(xcache)) then
+    if(n1cache.ne.n1) then
+      deallocate(xcache,veccache,dveccache)
+    endif
+  endif
+!
+  if(.not.allocated(xcache)) then
+    newcap=64
+    allocate(xcache(newcap),veccache(n1,newcap),dveccache(n1,newcap))
+    n1cache=n1
+    ncache=0
+  endif
+!
+  ncap=size(xcache)
+  if(ncache.ge.ncap) then
+    newcap=2*ncap
+    allocate(xtmp(newcap),vectmp(n1,newcap),dvectmp(n1,newcap))
+    xtmp(1:ncap)=xcache
+    vectmp(:,1:ncap)=veccache
+    dvectmp(:,1:ncap)=dveccache
+    call move_alloc(xtmp,xcache)
+    call move_alloc(vectmp,veccache)
+    call move_alloc(dvectmp,dveccache)
+  endif
+!
+  ncache=ncache+1
+  xcache(ncache)=x
+  veccache(1:n1,ncache)=vec
+  dveccache(1:n1,ncache)=dvec
+!
+  end subroutine interp_cache_store
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -66,13 +66,19 @@
       logical,          dimension(:), allocatable :: xpoint
     end type
 !
-    integer :: nbounds,nregions
-    double precision,     dimension(:),   allocatable :: R_bo,Z_bo,psiast_bo
-    type(allowed_region), dimension(:,:), allocatable :: all_regions
-! Per-slice scratch: the orbit-region/boundary formation runs once per energy
-! slice, and the slices run in parallel (resonant_torque), so each thread builds
-! its own regions.
-    !$omp threadprivate(nbounds,nregions,R_bo,Z_bo,psiast_bo,all_regions)
+! The region set is passed by argument from find_bounds_fixpoints to its
+! consumers, not held as module state, so the energy-slice parallel loop keeps one
+! set per thread (one caller-local per energy slice) without threadprivate on a
+! derived type with allocatable components, which gfortran does not copy per
+! thread reliably.  It is wrapped in a plain derived type so the producer/consumer
+! can take it as a scalar argument: a scalar derived-type dummy needs no explicit
+! interface, unlike an allocatable dummy, and these routines are external (the
+! caller would otherwise pass the allocatable wrongly).  nbounds,R_bo,Z_bo,
+! psiast_bo are scratch local to find_bounds_fixpoints.
+    type region_set_t
+      integer :: nregions = 0
+      type(allowed_region), dimension(:,:), allocatable :: all_regions
+    end type
   end module bounds_fixpoints_mod
 !
   module form_classes_doublecount_mod
@@ -1061,18 +1067,25 @@
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-  subroutine find_bounds_fixpoints(ierr)
+  subroutine find_bounds_fixpoints(regions,ierr)
 !
   use global_invariants,    only : toten,perpinv,sigma
   use find_all_roots_mod,   only : nroots,roots,relerr_allroots
   use poicut_mod,           only : npc,rpc_arr,zpc_arr,rmagaxis, &
                                    Rbou_lfs,Zbou_lfs,Rbou_hfs,Zbou_hfs
   use field_sub, only : psif
-  use bounds_fixpoints_mod, only : nbounds,R_bo,Z_bo,psiast_bo, &
-                                   nregions,all_regions
+  use bounds_fixpoints_mod, only : allowed_region,region_set_t
   use cc_mod, only : wrbounds
 !
   implicit none
+!
+! The region set is returned to the caller, which owns it (one set per energy
+! slice).  nregions,all_regions are built as locals and handed to regions at the
+! end; nbounds,R_bo,Z_bo,psiast_bo are scratch.
+  type(region_set_t), intent(inout) :: regions
+  integer :: nregions,nbounds
+  type(allowed_region), dimension(:,:), allocatable :: all_regions
+  double precision, dimension(:), allocatable :: R_bo,Z_bo,psiast_bo
 !
   logical, parameter :: doublecount=.true.
   integer, parameter :: niter=100
@@ -1193,6 +1206,7 @@
     else
 ! vpar2<0 in the whole domain, no regions in the domain
       nregions=0
+      regions%nregions=0
       ierr=2
       return
     endif
@@ -1794,6 +1808,10 @@
     close(5006)
   endif
 !
+! Hand the assembled region set to the caller (it owns it per slice).
+  regions%nregions=nregions
+  call move_alloc(all_regions,regions%all_regions)
+!
 !------------
 !
   contains
@@ -2175,7 +2193,7 @@
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-  subroutine form_classes_doublecount(classes_talk,ierr)
+  subroutine form_classes_doublecount(regions,classes_talk,ierr)
 !
 ! Here "class" means segments coming from splitting by X-points of the domains of allowed motion
 ! for particles starting at the Poincare with a given parallel velocity sign. The routine
@@ -2184,15 +2202,20 @@
 !
   use form_classes_doublecount_mod, only : nclasses,ifuntype,sigma_class,  &
                                            R_class_beg,R_class_end
-  use bounds_fixpoints_mod,         only : nregions,all_regions
+  use bounds_fixpoints_mod,         only : region_set_t
   use poicut_mod,                   only : Rbou_lfs,Zbou_lfs,Rbou_hfs,Zbou_hfs
   use global_invariants,            only : toten,perpinv,sigma
 !
   implicit none
 !
+! The region set is supplied by the caller (find_bounds_fixpoints filled it).
+! Alias its members so the body below reads them under their plain names.
+  type(region_set_t), intent(in) :: regions
   logical :: classes_talk
   integer          :: ierr,isig,ireg,nxp,ixp,icl,i
   integer, dimension(:), allocatable :: ibt_b,ibt_e
+!
+  associate(nregions => regions%nregions, all_regions => regions%all_regions)
 !
   ierr=0
 !
@@ -2286,6 +2309,8 @@
   endif
 !
   deallocate(ibt_b,ibt_e)
+!
+  end associate
 !
   end subroutine form_classes_doublecount
 !

--- a/POTATO/SRC/tt.f90
+++ b/POTATO/SRC/tt.f90
@@ -5,7 +5,7 @@
   use orbit_dim_mod,                only : write_orb,iunit1,numbasef,neqm
   use get_matrix_mod,               only : iclass
   use global_invariants,            only : dtau,toten,perpinv,cE_ref,Phi_eff
-  use bounds_fixpoints_mod,         only : nregions
+  use bounds_fixpoints_mod,         only : region_set_t
   use form_classes_doublecount_mod, only : nclasses
   use cc_mod,                       only : wrbounds,dowrite
   use resint_mod,                   only : nmodes,marr,narr,delint_mode
@@ -34,6 +34,7 @@
   double precision,parameter  :: p_mass=1.6726d-24
   double precision,parameter  :: ev=1.6022d-12
 !
+  type(region_set_t) :: regions
   logical :: classes_talk,plot_orbits,compute_equibrium_profiles,compute_resonant_torque,plot_poicut
   logical :: trace_single_orbit,freq_scan
 !
@@ -270,11 +271,11 @@
     dowrite=.true. !write canonical frequencies and bounce integrals for adaptive sampling grid and interpolation
     write_orb=.true. !write orbits during adaptive sampling of classes
 !
-    call find_bounds_fixpoints(ierr)
+    call find_bounds_fixpoints(regions,ierr)
 !
     classes_talk=.true.
 !
-    call form_classes_doublecount(classes_talk,ierr)
+    call form_classes_doublecount(regions,classes_talk,ierr)
 !
     do iclass=1,nclasses
 ! data is written to fort.* files:


### PR DESCRIPTION
**Draft / work in progress.** Blocked on #60.

## What

Coarse-grain OpenMP parallelism for the POTATO displacement resonance engine:
parallelize the independent total-energy slices of `resonant_torque` instead of
the per-class inner loops of #59. Energy slices are independent and roughly equal
cost, so this scales far better than the per-class fine-grain (#59 plateaus at
~1.85x from grid-build load imbalance).

Per-slice state is made `threadprivate` (`global_invariants`, the two
`sample_matrix` grid modules, the `resint_mod` bookkeeping, `find_all_roots`
search state, `odeint_mod` integrator scratch), `bmod_pert`'s lazy load is
locked, and the orbit-region set is refactored out of module state into a passed
`region_set_t` object. The energy loop runs under `!$omp parallel do` with a
`reduction` on the torque sums; the inner per-class regions stay serial via
`omp_set_max_active_levels(1)`.

## Status

- `OMP=1` is byte-identical to serial.
- At `>1` thread the reslines that are written are sorted-bit-identical to serial
  and deterministic across runs.
- It hangs at `>1` thread on a near-separatrix orbit whose step collapses
  (`velo.f90`, `hpstar -> 0`). Tracked in #60 with the suspected causes and the
  path forward.

## Verification

Small case (`nenerg=4`, `m=+-8`, `nbox=50`):

```
OMP=1  rc=0   reslines sorted-md5 == serial binary (byte-identical)
OMP>1  reslines sorted-md5 == OMP=1, stable across runs (deterministic)
OMP>1  hangs after writing the reslines (see #60)
```

History on the branch shows the two earlier dead ends (all_regions threadprivate
-> hang; bare allocatable dummy -> OMP=1 segfault) and the fixes.

## Relationship to #59

#59 (fine-grain, ~1.85x, validated) is the shippable parallelization today. This
branch supersedes it once #60 is resolved.
