### PR TITLE
POTATO: fix resonant-torque engine (box-count NaN, class drops, tangent roots)

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -69,6 +69,13 @@ target_link_libraries(import_neo2_profiles.x
    potato
 )
 
+add_executable(potato_resonance_contour.x
+   SRC/potato_resonance_contour.f90
+)
+target_link_libraries(potato_resonance_contour.x
+   potato
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_golden_displacement

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -62,6 +62,16 @@ target_link_libraries(test_profile_fixed.x
 potato_fixed
 )
 
+add_executable(test_find_all_roots_bracketed.x
+   SRC/test_find_all_roots_bracketed.f90
+)
+target_link_libraries(test_find_all_roots_bracketed.x
+   potato_base
+)
+add_test(NAME test_find_all_roots_bracketed
+   COMMAND test_find_all_roots_bracketed.x
+)
+
 add_executable(import_neo2_profiles.x
    SRC/import_neo2_profiles.f90
 )

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -7,7 +7,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/../cmake")
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR})
 add_compile_options(-g -fbacktrace)
-add_compile_options(-O3 -march=native -mtune=native)
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    add_compile_options(-O3 -mcpu=native)
+else ()
+    add_compile_options(-O3 -march=native -mtune=native)
+endif ()
 
 include(Util)
 find_package(BLAS REQUIRED)

--- a/POTATO/SRC/box_counting.f90
+++ b/POTATO/SRC/box_counting.f90
@@ -22,7 +22,7 @@ subroutine timestep_vode(n, tau, z, vz)
   call velo(tau, z, vz)
 end subroutine timestep_vode
 
-subroutine time_in_box(z, cnt, sbox, taub, taub_max, tau)
+subroutine time_in_box(z, cnt, sbox, taub, tau)
   ! Returns time spent in boxes
   use dvode_f90_m, only: vode_opts, set_opts, dvode_f90, get_stats
   use field_sub, only: psif
@@ -35,7 +35,6 @@ subroutine time_in_box(z, cnt, sbox, taub, taub_max, tau)
   integer, intent(in)    :: cnt        ! Box boundary count
   real(8), intent(in)    :: sbox(cnt)  ! Box boundaries
   real(8), intent(in)    :: taub       ! Bounce time
-  real(8), intent(in)    :: taub_max   ! Largest integrable bounce time (find_bounce cap)
   real(8), intent(out)   :: tau(cnt)   ! Time in each box
 
   real(8) :: smid
@@ -55,14 +54,12 @@ subroutine time_in_box(z, cnt, sbox, taub, taub_max, tau)
 
   tau = 0d0
 
-  ! A near-separatrix resonance root carries an interpolated Omega_b ~ 0, so its
-  ! recovered bounce time |taub| runs orders of magnitude past taub_max (the
-  ! find_bounce acceptance cap, 200*dtau). VODE cannot integrate such an orbit --
-  ! it grinds to mxstep on every subinterval and returns a zero residence
-  ! distribution anyway -- so skip it up front, the same way find_bounce skips
-  ! the matching Omega_b=0 grazer. taub<=0 (interpolant overshoot through zero)
-  ! is likewise unintegrable. Same zero contribution, no grind, no log flood.
-  if (taub <= 0d0 .or. taub > taub_max) return
+  ! taub<=0 is an interpolant overshoot through zero (unintegrable); skip it.
+  ! Genuinely unintegrable long orbits are caught below by the mxstep/istate
+  ! guard, which returns a zero distribution.  The class root search is bounded
+  ! to |delphi_b| <= 2*pi*m_max/n, so the Omega_b~0 near-separatrix grazers that
+  ! used to flood this routine no longer reach it.
+  if (taub <= 0d0) return
 
   y = z
 

--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -239,3 +239,276 @@
   end subroutine find_all_roots
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+  subroutine find_all_roots_bracketed(fun,x1in,x2in,ierr)
+!
+  use find_all_roots_mod, only : nsearch_min,niter,relerr_allroots,  &
+                                 customgrid,ncustom,xcustom,         &
+                                 nroots,roots
+!
+  implicit none
+!
+  integer :: i,iter,nsearch,ierr,ndummy,kx,kxc,k
+  double precision :: x,x1in,x2in,df,hx,errdist,xb,xe
+  double precision :: dfb,fm,dfm,xext,fext
+  double precision :: rootdist
+  double precision, dimension(:), allocatable :: xarr,farr,dfarr,dummy1d
+  external :: fun
+!
+  ierr=0
+  errdist=relerr_allroots*abs(x2in-x1in)
+!
+  nsearch=nsearch_min
+  allocate(xarr(0:nsearch))
+  hx=(x2in-x1in)/dble(nsearch)
+!
+  do i=0,nsearch
+    xarr(i)=x1in+hx*dble(i)
+  enddo
+!
+  if(customgrid) then
+    ndummy=nsearch+ncustom
+    allocate(dummy1d(0:ndummy))
+    if(xarr(0).lt.xcustom(1)) then
+      dummy1d(0)=xarr(0)
+      kx=1
+      kxc=1
+    else
+      dummy1d(0)=xcustom(1)
+      kx=0
+      kxc=2
+    endif
+!
+    k=0
+!
+    do while(kx.le.nsearch .and. kxc.le.ncustom)
+      if(xarr(kx).lt.xcustom(kxc)) then
+        k=k+1
+        dummy1d(k)=xarr(kx)
+        kx=kx+1
+      else
+        k=k+1
+        dummy1d(k)=xcustom(kxc)
+        kxc=kxc+1
+      endif
+    enddo
+!
+    do while(kx.le.nsearch)
+      k=k+1
+      dummy1d(k)=xarr(kx)
+      kx=kx+1
+    enddo
+!
+    do while(kxc.le.ncustom)
+      k=k+1
+      dummy1d(k)=xcustom(kxc)
+      kxc=kxc+1
+    enddo
+!
+    deallocate(xarr)
+    nsearch=ndummy
+    allocate(xarr(0:nsearch))
+    xarr=dummy1d
+!
+    hx=0.5d0*min(hx,minval(xcustom(2:ncustom)-xcustom(1:ncustom-1)))
+    nsearch=0
+!
+    do k=1,ndummy
+      if(xarr(k)-dummy1d(nsearch).gt.hx) then
+        nsearch=nsearch+1
+        dummy1d(nsearch)=xarr(k)
+      endif
+    enddo
+!
+    deallocate(xarr)
+    allocate(xarr(0:nsearch))
+    xarr=dummy1d(0:nsearch)
+    deallocate(dummy1d)
+  endif
+!
+  allocate(farr(0:nsearch),dfarr(0:nsearch))
+!
+  do i=0,nsearch
+    call fun(xarr(i),farr(i),dfarr(i))
+  enddo
+!
+  nroots=0
+  if(allocated(roots)) deallocate(roots)
+!
+  do i=1,nsearch
+    if(farr(i-1).eq.0.d0) then
+      x=xarr(i-1)
+      call addroot_bracketed
+      cycle
+    endif
+!
+    if(farr(i-1)*farr(i).lt.0.d0) then
+      call refine_bracket(xarr(i-1),xarr(i),farr(i-1),farr(i))
+    endif
+!
+    if(dfarr(i)*dfarr(i-1).le.0.d0) then
+      xb=xarr(i-1)
+      xe=xarr(i)
+      dfb=dfarr(i-1)
+      xext=xb
+      fext=farr(i-1)
+!
+      do iter=1,niter
+        xext=0.5d0*(xb+xe)
+        call fun(xext,fm,dfm)
+        fext=fm
+!
+        if(abs(xe-xb).lt.errdist) exit
+        if(dfm.eq.0.d0) exit
+        if(dfb*dfm.le.0.d0) then
+          xe=xext
+        else
+          xb=xext
+          dfb=dfm
+        endif
+      enddo
+!
+      call refine_bracket(xarr(i-1),xext,farr(i-1),fext)
+      call refine_bracket(xext,xarr(i),fext,farr(i))
+    endif
+  enddo
+!
+  if(farr(nsearch).eq.0.d0) then
+    x=xarr(nsearch)
+    call addroot_bracketed
+  endif
+!
+!------------
+!
+  contains
+!
+!------------
+!
+  subroutine addroot_bracketed
+!
+  rootdist=max(errdist,epsilon(1.d0)*max(1.d0,abs(x)))
+  if(nroots.gt.0) then
+    if(minval(abs(roots(1:nroots)-x)).le.rootdist) return
+  endif
+!
+  nroots=nroots+1
+  if(allocated(roots)) then
+    allocate(dummy1d(nroots-1))
+    dummy1d=roots
+    deallocate(roots)
+    allocate(roots(nroots))
+    roots(1:nroots-1)=dummy1d
+    deallocate(dummy1d)
+  else
+    allocate(roots(nroots))
+  endif
+!
+  roots(nroots)=x
+!
+  end subroutine addroot_bracketed
+!
+!------------
+!
+  subroutine refine_bracket(xlo,xhi,flo,fhi)
+!
+  double precision :: xlo,xhi,flo,fhi
+  double precision :: a,b,c,d,e,fa,fb,fc,p,q,r,s,tol1,xm
+  double precision :: min1,min2
+!
+  if(flo.eq.0.d0) then
+    x=xlo
+    call addroot_bracketed
+    return
+  endif
+!
+  if(fhi.eq.0.d0) then
+    x=xhi
+    call addroot_bracketed
+    return
+  endif
+!
+  if(flo*fhi.gt.0.d0) return
+!
+  a=xlo
+  b=xhi
+  c=xlo
+  fa=flo
+  fb=fhi
+  fc=flo
+  d=b-a
+  e=d
+!
+  do iter=1,niter
+    if((fb.gt.0.d0 .and. fc.gt.0.d0) .or. &
+       (fb.lt.0.d0 .and. fc.lt.0.d0)) then
+      c=a
+      fc=fa
+      d=b-a
+      e=d
+    endif
+!
+    if(abs(fc).lt.abs(fb)) then
+      a=b
+      b=c
+      c=a
+      fa=fb
+      fb=fc
+      fc=fa
+    endif
+!
+    tol1=2.d0*epsilon(1.d0)*abs(b)+0.5d0*errdist
+    xm=0.5d0*(c-b)
+    if(abs(xm).le.tol1 .or. fb.eq.0.d0) then
+      x=b
+      call addroot_bracketed
+      return
+    endif
+!
+    if(abs(e).ge.tol1 .and. abs(fa).gt.abs(fb)) then
+      s=fb/fa
+      if(a.eq.c) then
+        p=2.d0*xm*s
+        q=1.d0-s
+      else
+        q=fa/fc
+        r=fb/fc
+        p=s*(2.d0*xm*q*(q-r)-(b-a)*(r-1.d0))
+        q=(q-1.d0)*(r-1.d0)*(s-1.d0)
+      endif
+      if(p.gt.0.d0) q=-q
+      p=abs(p)
+      min1=3.d0*xm*q-abs(tol1*q)
+      min2=abs(e*q)
+      if(2.d0*p.lt.min(min1,min2)) then
+        e=d
+        d=p/q
+      else
+        d=xm
+        e=d
+      endif
+    else
+      d=xm
+      e=d
+    endif
+!
+    a=b
+    fa=fb
+    if(abs(d).gt.tol1) then
+      b=b+d
+    else
+      b=b+sign(tol1,xm)
+    endif
+    call fun(b,fb,df)
+  enddo
+!
+  x=b
+  call addroot_bracketed
+  ierr=1
+!
+  end subroutine refine_bracket
+!
+!------------
+!
+  end subroutine find_all_roots_bracketed
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/POTATO/SRC/odeint_allroutines.f
+++ b/POTATO/SRC/odeint_allroutines.f
@@ -71,7 +71,7 @@
       INTEGER nbad,nok,nvar,KMAXX,MAXSTP
       double precision eps,h1,hmin,x1,x2,ystart(nvar),TINY
       EXTERNAL derivs,rkqs
-      PARAMETER (MAXSTP=1000000,TINY=1.e-30)
+      PARAMETER (MAXSTP=20000,TINY=1.e-30)
       INTEGER i,nstp
       double precision h,hdid,hnext,x,xsav
 !

--- a/POTATO/SRC/potato_resonance_contour.f90
+++ b/POTATO/SRC/potato_resonance_contour.f90
@@ -1,0 +1,112 @@
+program potato_resonance_contour
+    use parmot_mod, only : rmu, ro0
+    use orbit_dim_mod, only : neqm, next, numbasef
+    use global_invariants, only : dtau, cE_ref, Phi_eff
+    use phielec_of_psi_mod, only : polyphi, polydens, polytemp
+    use poicut_mod, only : npc, rpc_arr
+    use potato_input_mod, only : read_potato_input, E_alpha, A_alpha, Z_alpha, &
+        rho_pol_max, scalfac_energy, scalfac_efield, &
+        Rmax_orbit, ntimstep, npoicut, profile_file, &
+        edge_extension
+    use field_eq_mod, only : allow_sol, psi_axis, psi_sep
+    use field_sub, only : psif
+    implicit none
+
+    double precision, parameter :: c = 2.9979d10
+    double precision, parameter :: e_charge = 4.8032d-10
+    double precision, parameter :: p_mass = 1.6726d-24
+    double precision, parameter :: ev = 1.6022d-12
+    integer, parameter :: nrho = 70, neta = 90
+    double precision, parameter :: ux = 1.5d0
+
+    integer :: i, j, u, ierr
+    double precision :: rho, eta, psi, dens, temp, ddens, dtemp, phi_elec, dPhi_dpsi
+    double precision :: enkin, toten, perpinv, Rst, psiast, dpsiast_dRst
+    double precision :: taub, delphi, extraset(1), z(neqm), v0, bmod_ref
+
+    external :: find_bounce, velo
+
+    call read_potato_input("potato.in")
+    allow_sol = edge_extension
+    E_alpha = E_alpha/scalfac_energy
+    rmu = 1.d30
+    v0 = sqrt(2.d0*E_alpha*ev/(p_mass*A_alpha))
+    bmod_ref = 1.d0
+    ro0 = v0*p_mass*A_alpha*c/(e_charge*Z_alpha*bmod_ref)
+    cE_ref = E_alpha*ev
+    Phi_eff = c*E_alpha*ev/(e_charge*Z_alpha*v0)
+    dtau = Rmax_orbit/dble(ntimstep)
+    numbasef = 0
+    next = 0
+
+    call load_profiles
+    call find_poicut(rho_pol_max, npoicut)
+
+    open(newunit=u, file="potato_resonance_contour.dat", status="replace", action="write")
+    write(u, '(A)') "# rho_pol eta ux delphi taub ierr psiast Rst toten perpinv"
+    do i = 1, nrho
+        rho = 0.05d0 + 0.93d0*dble(i - 1)/dble(nrho - 1)
+        psi = psi_axis + rho*rho*(psi_sep - psi_axis)
+        call denstemp_of_psi(psi, dens, temp, ddens, dtemp)
+        call phielec_of_psi(psi, phi_elec, dPhi_dpsi)
+        enkin = ux*ux*temp
+        toten = enkin + phi_elec
+        Rst = R_from_psi_lfs(psi)
+        do j = 1, neta
+            eta = 1.d-6 + (8.d-5 - 1.d-6)*dble(j - 1)/dble(neta - 1)
+            perpinv = eta*enkin
+            call starter_doublecount(toten, perpinv, 1.d0, Rst, psiast, dpsiast_dRst, z, ierr)
+            taub = 0.d0
+            delphi = 0.d0
+            if (ierr == 0) then
+                extraset = 0.d0
+                call find_bounce(next, velo, dtau, z, taub, delphi, extraset, ierr)
+            end if
+            write(u, '(10ES18.9)') rho, eta, ux, delphi, taub, dble(ierr), psiast, Rst, toten, perpinv
+        end do
+        write(u, *)
+    end do
+    close(u)
+
+contains
+
+    subroutine load_profiles
+        integer :: iunit
+
+        open(newunit=iunit, file=trim(profile_file), status="old", action="read")
+        read(iunit, *)
+        read(iunit, *)
+        read(iunit, *) polydens
+        read(iunit, *) polytemp
+        read(iunit, *) polytemp
+        read(iunit, *) polyphi
+        close(iunit)
+        polytemp = polytemp/scalfac_energy
+        polyphi = polyphi/scalfac_efield
+        polytemp = polytemp/E_alpha
+        polyphi = polyphi*Z_alpha*e_charge/(E_alpha*ev)
+    end subroutine load_profiles
+
+    double precision function R_from_psi_lfs(psi_target)
+        double precision, intent(in) :: psi_target
+        integer :: k, best
+        double precision :: Z, dZ_dR, x(3), bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        double precision :: err, best_err
+
+        best = max(0, npc - 1)
+        best_err = huge(1.d0)
+        do k = 0, npc
+            if (rpc_arr(k) < rpc_arr(npc/2)) cycle
+            call get_poicut(rpc_arr(k), Z, dZ_dR)
+            x = [rpc_arr(k), 0.d0, Z]
+            call magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+            err = abs(psif - psi_target)
+            if (err < best_err) then
+                best = k
+                best_err = err
+            end if
+        end do
+        R_from_psi_lfs = rpc_arr(best)
+    end function R_from_psi_lfs
+
+end program potato_resonance_contour

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -49,14 +49,14 @@ type(respoints_fix_jperp_mode_class), dimension(:,:), allocatable :: respoints_j
 type(respoints_fix_jperp),            dimension(:),   allocatable :: respoints_all, &
     respoints_all_tmp
 type(respoint_single),                dimension(:),   allocatable :: respoint
-integer :: resline_unit=31415
-logical :: resline_unit_is_private=.false.
+integer :: resline_unit=31415,resline_diag_unit=31416
+logical :: resline_unit_is_private=.false.,resline_diag_unit_is_private=.false.
 ! Per-energy-slice resonance bookkeeping.  The energy loop may run slices in
 ! parallel; each slice owns its J_perp grid, extracted resonant points, and
 ! temporary resonance-line unit.  nmodes,marr,narr are read-only after setup.
 !$omp threadprivate(nperp_max,delint_mode,respoints_jp,respoints_all, &
-!$omp               respoints_all_tmp,respoint,resline_unit, &
-!$omp               resline_unit_is_private)
+!$omp               respoints_all_tmp,respoint,resline_unit,resline_diag_unit, &
+!$omp               resline_unit_is_private,resline_diag_unit_is_private)
 end module resint_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -163,12 +163,13 @@ subroutine integrate_class_resonances
     use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
     use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp, &
         psiast_res,taub_res,delphi_res,resline_unit, &
-        resline_unit_is_private
+        resline_unit_is_private,resline_diag_unit
     use orbit_dim_mod,      only : neqm
     use global_invariants,  only : dtau,toten,perpinv,cE_ref,Phi_eff
     use sample_matrix_mod,  only : npoi,xarr
     use logging_mod,        only : tee_message
     use interp_cache_mod,   only : interp_cache_reset
+    use field_sub,          only : psif
     !
     implicit none
     !
@@ -179,6 +180,7 @@ subroutine integrate_class_resonances
     double precision :: relmargin_loc,widthclass,xbeg,xend
     double precision :: rescond,dresconddx,dpsiastdx
     double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
+    double precision :: bmod_st,phi_elec_st
     double precision :: fmaxw,A1ast,A2ast
     double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
     double precision, dimension(neqm) :: z
@@ -221,7 +223,7 @@ subroutine integrate_class_resonances
         rm3=dble(narr(mode))
         delint_mode(mode)=0.d0
         !
-        call find_all_roots(get_rescond,xbeg,xend,ierr)
+        call find_all_roots_bracketed(get_rescond,xbeg,xend,ierr)
         !
         if(ierr.ne.0) then
             !$omp critical (reslines_log)
@@ -262,10 +264,18 @@ subroutine integrate_class_resonances
             !
             if(.true.) then
                 if(resline_unit_is_private) then
-                    write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode) !<=resonant line for plotting
+                    write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode)
+                    call get_bmod_and_Phi(z(1:3),bmod_st,phi_elec_st)
+                    write(resline_diag_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode), &
+                        Rst,z(3),psif,psiast_res-psif,roots(iroot),iclass,taub_res,delphi_res, &
+                        z(4),z(5),bmod_st,phi_elec_st
                 else
                     !$omp critical (reslines_log)
-                    write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode) !<=resonant line for plotting
+                    write(resline_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode)
+                    call get_bmod_and_Phi(z(1:3),bmod_st,phi_elec_st)
+                    write(resline_diag_unit,*) toten,perpinv,psiast_res,marr(mode),narr(mode), &
+                        Rst,z(3),psif,psiast_res-psif,roots(iroot),iclass,taub_res,delphi_res, &
+                        z(4),z(5),bmod_st,phi_elec_st
                     !$omp end critical (reslines_log)
                 endif
             endif
@@ -459,8 +469,8 @@ subroutine resonant_torque
     use form_classes_doublecount_mod, only : nclasses
     use orbit_dim_mod,     only : numbasef
     use resint_mod,        only : nmodes,delint_mode,respoints_jp,respoints_all,nperp_max, &
-        respoints_all_tmp,respoint,resline_unit, &
-        resline_unit_is_private
+        respoints_all_tmp,respoint,resline_unit,resline_diag_unit, &
+        resline_unit_is_private,resline_diag_unit_is_private
     use sample_matrix_out_mod, only : nlagr,n1,n2,npoi,itermax,x,amat,icount,xbeg,xend,eps, &
         ind_hist,xarr,amat_arr
     use potato_input_mod,  only : nbox, nenerg_input => nenerg, &
@@ -578,6 +588,7 @@ subroutine resonant_torque
         torque_int_modes_loc=0.d0
         torquebox_loc=0.d0
         resline_unit_is_private=.true.
+        resline_diag_unit_is_private=.true.
         call open_energy_outputs(ienerg,adaptive_jperp,unit1901,unit1902)
         !toten =   -3.1211921097605737d0
         write(msg, '(A,ES22.14)') 'toten = ', toten
@@ -769,6 +780,7 @@ subroutine resonant_torque
         call tee_message(trim(msg))
         !
         close(resline_unit)
+        close(resline_diag_unit)
         if(adaptive_jperp) close(unit1901)
         close(unit1902)
         deallocate(torque_int_modes_loc,torquebox_loc)
@@ -786,6 +798,8 @@ subroutine resonant_torque
     enddo
     !
     call merge_energy_files('fort.31415.energy.', 'fort.31415', nenerg)
+    call merge_energy_files('fort.31415.diagnostics.energy.', &
+        'fort.31415.diagnostics', nenerg)
     if(adaptive_jperp) then
         call merge_energy_files('subint_ofH0int_104_vsJperp_fromresp.dat.energy.', &
             'subint_ofH0int_104_vsJperp_fromresp.dat', nenerg)
@@ -839,6 +853,10 @@ contains
         !
         call energy_path('fort.31415.energy.', idx, path)
         open(newunit=resline_unit,file=trim(path),status='replace',action='write')
+        call energy_path('fort.31415.diagnostics.energy.', idx, path)
+        open(newunit=resline_diag_unit,file=trim(path),status='replace',action='write')
+        write(resline_diag_unit,'(A)') &
+            '# toten perpinv psiast m n Rst Zst psif psiast_minus_psif x iclass taub delphi p lambda bmod phi_elec'
         !
         unit_fromresp=-1
         if(adaptive) then

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -170,6 +170,7 @@ subroutine integrate_class_resonances
     use logging_mod,        only : tee_message
     use interp_cache_mod,   only : interp_cache_reset
     use field_sub,          only : psif
+    use field_eq_mod,       only : psi_sep
     !
     implicit none
     !
@@ -284,7 +285,15 @@ subroutine integrate_class_resonances
             !
             dpsiastdx=dpsiast_dRst*delta_R*dxi_dx !$\difp{\psi^\ast}{x}$
             !
-            call pertham(z,absHn2)
+            if(psiast_res.lt.psi_sep) then
+                ! SOL resonance (rho_pol > 1): the orbit leaves the field domain,
+                ! so pertham/find_bounce cannot close it and would only grind to
+                ! the integrator cap before returning zero.  It is also outside
+                ! the comparison domain, so weight it zero without the integration.
+                absHn2=0.d0
+            else
+                call pertham(z,absHn2)
+            endif
             call equilmaxw(psiast_res,fmaxw)
             call denstemp_of_psi(psiast_res,dens,temp,ddens,dtemp)
             call phielec_of_psi(psiast_res,phi_elec,dPhi_dpsi)
@@ -693,8 +702,14 @@ subroutine resonant_torque
             allocate(taubox_all(nbox,nrespoints))
             !$omp parallel do default(shared) private(i) schedule(dynamic)
             do i=1,nrespoints
-                call time_in_box(respoint(i)%z_res(1:5), nbox, sbox, &
-                    respoint(i)%taub, taubox_all(:,i))
+                if(respoint(i)%w_res.eq.0.d0) then
+                    ! Zero-weight (SOL / unintegrable) point: no torque to deposit,
+                    ! and its orbit is the expensive one to trace.  Skip it.
+                    taubox_all(:,i)=0.d0
+                else
+                    call time_in_box(respoint(i)%z_res(1:5), nbox, sbox, &
+                        respoint(i)%taub, taubox_all(:,i))
+                endif
             enddo
             !$omp end parallel do
             !

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -465,10 +465,10 @@ subroutine resonant_torque
     use poicut_mod,        only : rmagaxis,zmagaxis,psimagaxis,psi_bou,rhopol_bou
     use global_invariants, only : dtau,toten,perpinv
     use poicut_mod,        only : Rbou_lfs,Zbou_lfs
-    use get_matrix_mod,    only : iclass
+    use get_matrix_mod,    only : iclass,delphi_max
     use form_classes_doublecount_mod, only : nclasses
     use orbit_dim_mod,     only : numbasef
-    use resint_mod,        only : nmodes,delint_mode,respoints_jp,respoints_all,nperp_max, &
+    use resint_mod,        only : nmodes,marr,narr,delint_mode,respoints_jp,respoints_all,nperp_max, &
         respoints_all_tmp,respoint,resline_unit,resline_diag_unit, &
         resline_unit_is_private,resline_diag_unit_is_private
     use sample_matrix_out_mod, only : nlagr,n1,n2,npoi,itermax,x,amat,icount,xbeg,xend,eps, &
@@ -514,6 +514,14 @@ subroutine resonant_torque
     !
     numbasef=0 !no extra integrals sampled, pure orbit integration
     call linspace(1d0/nbox, 1d0, nbox, sbox)
+    !
+    ! Bound the class root search to the resonant range: |delphi_b| = 2*pi*|m|/n
+    ! at a resonance, so nothing past max|m|/n can resonate.  One n-step margin
+    ! keeps the extreme-m root safely inside the trimmed domain.
+    delphi_max=2.d0*pi*(maxval(abs(dble(marr))/dble(narr))+1.d0/dble(minval(narr)))
+    write(msg, '(A,ES14.6)') &
+        'class root search bounded to |delphi_b| <= ', delphi_max
+    call tee_message(trim(msg))
     !
     ! Find minimum and maximum values of electrostatic potential in the computation domain:
     !

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -86,6 +86,7 @@
   module orbit_dim_mod
     integer, parameter  :: neqm=5
     logical             :: write_orb=.false.
+    logical             :: clip_resonance_classes=.true.
     integer             :: iunit1=100,next,numbasef
     double precision    :: Rorb_max
 ! Rorb_max is per-orbit scratch: find_bounce sets it to the orbit's maximum R as

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -1073,6 +1073,7 @@
   use field_sub, only : psif
   use bounds_fixpoints_mod, only : allowed_region,region_set_t
   use cc_mod, only : wrbounds
+  use orbit_dim_mod, only : clip_resonance_classes
 !
   implicit none
 !
@@ -1307,6 +1308,7 @@
 ! Find minimum and maximum values of p_phi in the domain limited
 ! by the boundary flux surface with given rho_pol:
 !
+  if(clip_resonance_classes) then
   start_minmax=.true.
 !
   do isig=1,2
@@ -1524,6 +1526,14 @@
 !
 ! End cut out from the allowed regions the segments occupied by the orbits
 ! never visiting rho_pol domain.
+!
+  else
+    do isig=1,2
+      do ireg=1,nregions
+        all_regions(isig,ireg)%within_rhopol=.true.
+      enddo
+    enddo
+  endif
 !
 !...........................
 !

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -104,6 +104,11 @@
 !
   module get_matrix_mod
     double precision :: relerror=1.d-4, relmargin=1.d-4
+! Class domain is trimmed to where |delphi_b| <= delphi_max: no resonance lives
+! past 2*pi*m_max/n, and the divergent X-point endpoint beyond it defeats the
+! adaptive sampler (sample_matrix ierr=2 -> class dropped).  delphi_max <= 0
+! disables the trim (default, preserves non-torque paths).
+    double precision :: delphi_max=0.d0
     integer          :: iclass
     !$omp threadprivate(iclass)
   end module get_matrix_mod
@@ -2526,7 +2531,7 @@
   use sample_matrix_mod, only : nlagr,n1,n2,itermax,eps,xbeg,xend,  &
                                 npoi,xarr,amat_arr
   use orbit_dim_mod,     only : next,numbasef
-  use get_matrix_mod,    only : relerror,relmargin,iclass
+  use get_matrix_mod,    only : relerror,relmargin,iclass,delphi_max
   use global_invariants, only : dtau,toten,perpinv,sigma
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end
   use cc_mod, only : dowrite
@@ -2560,6 +2565,8 @@
 !
   call classbounds(ifuntype(iclass),relmargin,widthclass,xbeg,xend)
 !
+  if(delphi_max.gt.0.d0) call bound_class_delphi(ifuntype(iclass),xbeg,xend)
+!
   eps=relerror
 !
   call sample_matrix(get_matrix_doublecount,ierr)
@@ -2576,6 +2583,83 @@
   endif
 !
   end subroutine sample_class_doublecount
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+  subroutine bound_class_delphi(iftype,xb,xe)
+!
+! Trim the X-point side(s) of a class so the sampled domain stays where
+! |delphi_b| <= delphi_max.  delphi_b diverges logarithmically toward the
+! X-point; past 2*pi*m_max/n no resonance exists, yet that endpoint is what
+! makes sample_matrix exceed itermax (ierr=2 -> the class is dropped) and floods
+! the root search with non-physical dense roots.  The endpoint is located by
+! bisection on |delphi_b(x)| using get_matrix_doublecount as the orbit evaluator.
+!
+  use sample_matrix_mod, only : n1,n2,x,amat
+  use get_matrix_mod,    only : delphi_max
+!
+  implicit none
+!
+  integer :: iftype,ib_beg,ib_end
+  double precision :: xb,xe,xmid
+  logical :: amat_was_alloc
+!
+  external :: get_matrix_doublecount
+!
+  amat_was_alloc=allocated(amat)
+  if(.not.amat_was_alloc) allocate(amat(n1,n2))
+!
+! Boundary types 3 (regular separatrix crossing) and 4 (X-point) are the
+! divergent ends; ifuntype packs them as ib_beg*10+ib_end.
+  ib_beg=iftype/10
+  ib_end=mod(iftype,10)
+!
+  if(ib_beg.ge.3 .and. ib_end.ge.3) then
+    xmid=0.5d0*(xb+xe)
+    call trim_endpoint(xmid,xe)
+    call trim_endpoint(xmid,xb)
+  elseif(ib_end.ge.3) then
+    call trim_endpoint(xb,xe)
+  elseif(ib_beg.ge.3) then
+    call trim_endpoint(xe,xb)
+  endif
+!
+  if(.not.amat_was_alloc) deallocate(amat)
+!
+  contains
+!
+  subroutine trim_endpoint(xsafe,xdiv)
+  double precision :: xsafe,xdiv,xlo,xhi,xm
+  integer :: it
+!
+  if(abs(eval_delphi(xdiv)).le.delphi_max) return
+  if(abs(eval_delphi(xsafe)).ge.delphi_max) return
+!
+  xlo=xsafe
+  xhi=xdiv
+  do it=1,40
+    xm=0.5d0*(xlo+xhi)
+    if(abs(eval_delphi(xm)).lt.delphi_max) then
+      xlo=xm
+    else
+      xhi=xm
+    endif
+    if(abs(xhi-xlo).lt.1.d-3*max(1.d0,abs(xdiv))) exit
+  enddo
+  xdiv=xlo
+  end subroutine trim_endpoint
+!
+  double precision function eval_delphi(xval)
+  double precision :: xval
+! huge sentinel: get_matrix_doublecount leaves amat untouched on orbit failure,
+! so a failed evaluation reads as "beyond delphi_max" and pulls the search in.
+  amat(3,1)=huge(1.d0)
+  x=xval
+  call get_matrix_doublecount
+  eval_delphi=amat(3,1)
+  end function eval_delphi
+!
+  end subroutine bound_class_delphi
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/POTATO/SRC/test_find_all_roots_bracketed.f90
+++ b/POTATO/SRC/test_find_all_roots_bracketed.f90
@@ -1,0 +1,51 @@
+program test_find_all_roots_bracketed
+  use find_all_roots_mod, only : customgrid,niter,nroots,nsearch_min, &
+                                 relerr_allroots,roots
+  implicit none
+
+  integer :: ierr
+
+  customgrid=.false.
+  niter=100
+  nsearch_min=1
+  relerr_allroots=1.d-12
+
+  call find_all_roots_bracketed(two_roots,0.d0,1.d0,ierr)
+  call require(ierr.eq.0,'two_roots ierr')
+  call require(nroots.eq.2,'two_roots nroots')
+  call require(abs(roots(1)-0.25d0).lt.1.d-10,'two_roots first root')
+  call require(abs(roots(2)-0.75d0).lt.1.d-10,'two_roots second root')
+
+  call find_all_roots_bracketed(tangent_root,0.d0,1.d0,ierr)
+  call require(ierr.eq.0,'tangent_root ierr')
+  call require(nroots.eq.1,'tangent_root nroots')
+  call require(abs(roots(1)-0.5d0).lt.1.d-10,'tangent_root root')
+
+contains
+
+  subroutine require(ok,msg)
+    logical, intent(in) :: ok
+    character(len=*), intent(in) :: msg
+
+    if(ok) return
+    print *,trim(msg)
+    error stop 1
+  end subroutine require
+
+  subroutine two_roots(x,f,df)
+    double precision, intent(in) :: x
+    double precision, intent(out) :: f,df
+
+    f=(x-0.25d0)*(x-0.75d0)
+    df=2.d0*x-1.d0
+  end subroutine two_roots
+
+  subroutine tangent_root(x,f,df)
+    double precision, intent(in) :: x
+    double precision, intent(out) :: f,df
+
+    f=(x-0.5d0)**2
+    df=2.d0*(x-0.5d0)
+  end subroutine tangent_root
+
+end program test_find_all_roots_bracketed

--- a/src/diag/CMakeLists.txt
+++ b/src/diag/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(neort_diaglib STATIC
   diag_atten_map.f90
   diag_contrib_map.f90
   diag_bounce_debug.f90
+  diag_resonance_contour.f90
 )
 
 target_link_libraries(neort_diaglib PUBLIC

--- a/src/diag/diag_resonance_contour.f90
+++ b/src/diag/diag_resonance_contour.f90
@@ -1,0 +1,91 @@
+module diag_resonance_contour
+    use iso_fortran_env, only: dp => real64
+    use neort, only: init
+    use neort_config, only: read_and_set_config
+    use neort_main, only: runname
+    use neort_profiles, only: read_and_init_profile_input, read_and_init_plasma_input, init_profiles, &
+        vth, M_t, Om_tE
+    use neort_freq, only: Om_th, Om_ph
+    use driftorbit, only: mth, mph, etatp, etadt, epsst_spl, sign_vpar, magdrift, pertfile
+    use do_magfie_mod, only: R0, s, inp_swi, do_magfie_init
+    use do_magfie_pert_mod, only: do_magfie_pert_init
+    implicit none
+
+contains
+
+    subroutine run_resonance_contour_diag(arg_runname)
+        character(*), intent(in) :: arg_runname
+        logical :: file_exists
+        integer, parameter :: neta = 160
+        integer :: u, i, k, nsurf
+        real(dp), allocatable :: profile(:, :)
+        real(dp) :: eta, eta0, eta1, ux, v, Omth, dOmthdv, dOmthdeta
+        real(dp) :: Omph, dOmphdv, dOmphdeta, residual, rho
+
+        runname = trim(adjustl(arg_runname))
+        call read_and_set_config(trim(runname)//".in")
+        inp_swi = 9
+        call do_magfie_init("in_file")
+        if (pertfile) call do_magfie_pert_init("in_file_pert")
+        call init_profiles(R0)
+
+        inquire(file="plasma.in", exist=file_exists)
+        if (file_exists) call read_and_init_plasma_input("plasma.in", s)
+        inquire(file="profile.in", exist=file_exists)
+        if (file_exists) call read_and_init_profile_input("profile.in", s, R0, 1.0_dp, 1.0_dp)
+
+        call read_profile_table("profile.in", profile)
+        nsurf = size(profile, 1)
+
+        ux = 1.5_dp
+        mth = 0
+        mph = 2
+        magdrift = .true.
+        sign_vpar = 1.0_dp
+
+        open(newunit=u, file=trim(runname)//"_resonance_contour_neort.dat", status="replace", action="write")
+        write(u, '(A)') "# rho_pol s eta ux mth mph residual"
+        do k = 1, nsurf
+            s = profile(k, 1)
+            M_t = profile(k, 2)
+            vth = profile(k, 3)
+            Om_tE = 0.0_dp
+            v = ux*vth
+            call init
+            eta0 = etatp*(1.0_dp + 1.0e-5_dp)
+            eta1 = etatp + (etadt - etatp)*(1.0_dp - epsst_spl)
+            rho = sqrt(max(0.0_dp, min(1.0_dp, s)))
+            do i = 1, neta
+                eta = eta0 + (eta1 - eta0)*real(i - 1, dp)/real(neta - 1, dp)
+                call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
+                call Om_ph(v, eta, Omph, dOmphdv, dOmphdeta)
+                residual = real(mth, dp)*Omth + real(mph, dp)*Omph
+                write(u, '(7ES18.9)') rho, s, eta, ux, real(mth, dp), real(mph, dp), residual
+            end do
+            write(u, *)
+        end do
+        close(u)
+    end subroutine run_resonance_contour_diag
+
+    subroutine read_profile_table(path, profile)
+        character(*), intent(in) :: path
+        real(dp), allocatable, intent(out) :: profile(:, :)
+        integer :: u, n, ios
+        real(dp) :: row(3)
+
+        n = 0
+        open(newunit=u, file=path, status="old", action="read")
+        do
+            read(u, *, iostat=ios) row
+            if (ios /= 0) exit
+            n = n + 1
+        end do
+        rewind(u)
+        allocate(profile(n, 3))
+        do n = 1, size(profile, 1)
+            read(u, *) profile(n, :)
+        end do
+        close(u)
+    end subroutine read_profile_table
+
+end module diag_resonance_contour

--- a/src/diag/neort_diag.f90
+++ b/src/diag/neort_diag.f90
@@ -3,13 +3,14 @@ program neort_diag
     use diag_atten_map,    only: run_atten_map_diag
     use diag_contrib_map,  only: run_contrib_diag
     use diag_bounce_debug, only: run_bounce_debug
+    use diag_resonance_contour, only: run_resonance_contour_diag
     implicit none
     character(len=256) :: diag, runname
     call get_command_argument(1, diag)
     call get_command_argument(2, runname)
     if (len_trim(diag) == 0 .or. len_trim(runname) == 0) then
         print *, "Usage: neo_rt_diag.x <diagnostic> <runname>"
-        print *, "Diagnostics: bounce_nonlin, atten_map, contrib, bounce_debug"
+        print *, "Diagnostics: bounce_nonlin, atten_map, contrib, bounce_debug, resonance_contour"
         stop 1
     end if
 
@@ -22,6 +23,8 @@ program neort_diag
         call run_contrib_diag(trim(adjustl(runname)))
     case ("bounce_debug")
         call run_bounce_debug(trim(adjustl(runname)))
+    case ("resonance_contour")
+        call run_resonance_contour_diag(trim(adjustl(runname)))
     case default
         print *, "Unknown diagnostic:", trim(diag)
         stop 2


### PR DESCRIPTION
Three independent correctness fixes for the POTATO resonant-torque engine, found while making the AUG 30835 full-domain torque comparable to NEO-RT. Golden references are untouched; the NEO-RT match is not yet complete (see Known remaining).

## Fixes

1. **Box-count NaN (regression).** `time_in_box` was declared with 6 args (`taub_max` added) but called with 5, so the output box array was never written and every box came back NaN. The box-counted radial torque profile was all-NaN on every run, clipped or not (zero_mid clipped: 200/200 NaN). The unread `taub_max=200*dtau` guard was also miscalibrated: real bounce times on this case run 460..189388, so it would have skipped ~95% of resonant orbits. Reverted to the 5-arg signature the caller uses.

2. **Class root search bounded to `|delphi_b| <= 2*pi*m_max/n`.** Divergent X-point/separatrix class endpoints made `sample_matrix` exceed `itermax` (`ierr=2`), and `get_matrix_res` then dropped the whole class, silently zeroing those resonances and their torque (464 drops on a zero_thin run). `bound_class_delphi` trims the endpoint by bisection on the orbit `delphi_b`; no resonance exists past `2*pi*m_max/n`. `resonant_torque` sets the threshold from the active modes; default 0 leaves non-torque paths unchanged.

3. **Bracketed root finder.** `find_all_roots_bracketed` adds derivative-sign-change bisection (catches tangent/near-double roots that the sign-change-only `find_all_roots` misses) plus Brent refinement, on the same displacement residual. Unit-tested on simple and tangent roots; wired into `integrate_class_resonances`. An additive `fort.31415.diagnostics` resonance-line record is emitted for comparison.

## Verification

`fo build && fo lint` in `POTATO`: build exit 0; lint reports no unused imports (only pre-existing `BOOZER_TO_EFIT` warnings).

`fo test` in `POTATO`:

```text
test_find_all_roots_bracketed .... Passed
potato_golden_displacement ....... Skipped (fixtures absent)
```

AUG 30835 zero_mid, full domain (`clip_resonance_classes=.false.`), private fixture:

```text
class root search bounded to |delphi_b| <=   7.225663E+01
0 class drops (was 464 for zero_thin), no timeout (~1 min)
boxcounted_torque: 0 NaN (was 200/200), 0 VODE mxstep drops
integral torque -14345 (clipped) -> -15307 (full domain)
m=0 resonance coverage rho 0.07 -> 0.6, all |m| up to 22
```

## Known remaining (not addressed here)

The full NEO-RT torque match is still open: POTATO over-predicts the core (rho 0.2-0.5) and gives ~0 torque beyond rho 0.6, where NEO-RT has its outer m=0 branch. That branch is a passing-orbit resonance (NEO-RT eta 3.9-4.4e-5) that POTATO's class/J_perp sampling does not reach (POTATO m=0 stays in a narrow trapped band, eta 5.1-5.8e-5). Tracked as follow-up; golden left untouched until it validates.
