### PR TITLE
POTATO: cancel guiding-center orbits that cross the limiter wall

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -76,6 +76,16 @@ add_test(NAME test_find_all_roots_bracketed
    COMMAND test_find_all_roots_bracketed.x
 )
 
+add_executable(test_wall_loss.x
+   SRC/test_wall_loss.f90
+)
+target_link_libraries(test_wall_loss.x
+   potato_base
+)
+add_test(NAME test_wall_loss
+   COMMAND test_wall_loss.x
+)
+
 add_executable(import_neo2_profiles.x
    SRC/import_neo2_profiles.f90
 )

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(potato_base
   ${LIBNEO_SOURCE_DIR}/src/libneo_kinds.f90
   logging_mod.f90
+  wall_loss_mod.f90
   potato_input_mod.f90
   ${LIBNEO_SOURCE_DIR}/src/math_constants.f90
   alpha_lifetime_mod.f90

--- a/POTATO/SRC/odeint_allroutines.f
+++ b/POTATO/SRC/odeint_allroutines.f
@@ -89,14 +89,11 @@
       if (kmax.gt.0) xsav=x-2.*dxsav
       do 16 nstp=1,MAXSTP
         call derivs(x,y,dydx)
-! 18.07.2016
-!      if(ierrfield.ne.0) then
-!      print*,ierrfield,'=ierrfield, derivs, odeint'
-!          ialloc=0
-!          call alloc_odeint(nvar)
-!      return
-!      end if
-! 18.07.2016 end
+        if(ierrfield.ne.0) then
+          ialloc=0
+          call alloc_odeint(nvar)
+          return
+        endif
         do 12 i=1,nvar
           yscal(i)=abs(y(i))+abs(h*dydx(i))+TINY
 12      continue

--- a/POTATO/SRC/potato_input_mod.f90
+++ b/POTATO/SRC/potato_input_mod.f90
@@ -1,5 +1,6 @@
 module potato_input_mod
     use iso_fortran_env, only: output_unit
+    use wall_loss_mod, only: load_wall
     implicit none
 
     ! Calculation type: 1=orbits, 2=equilibrium profiles, 3=resonant torque
@@ -130,6 +131,8 @@ contains
         endif
 
         close(iunit)
+
+        call load_wall('convexwall.dat')
     end subroutine read_potato_input
 
     subroutine print_potato_input(iunit)

--- a/POTATO/SRC/test_wall_loss.f90
+++ b/POTATO/SRC/test_wall_loss.f90
@@ -1,0 +1,32 @@
+program test_wall_loss
+    use wall_loss_mod, only: load_wall, outside_wall, wall_loaded
+    implicit none
+
+    integer :: iunit
+    logical :: ok
+
+    open (newunit=iunit, file='test_wall_square.dat', status='replace', &
+          action='write')
+    write (iunit, *) 0.0d0, 0.0d0
+    write (iunit, *) 10.0d0, 0.0d0
+    write (iunit, *) 10.0d0, 10.0d0
+    write (iunit, *) 0.0d0, 10.0d0
+    close (iunit)
+
+    call load_wall('test_wall_square.dat')
+
+    ok = .true.
+    if (.not. wall_loaded) ok = .false.
+    if (outside_wall(5.0d0, 5.0d0)) ok = .false.
+    if (.not. outside_wall(15.0d0, 5.0d0)) ok = .false.
+    if (.not. outside_wall(5.0d0, -1.0d0)) ok = .false.
+    if (.not. outside_wall(-1.0d0, 5.0d0)) ok = .false.
+    if (.not. outside_wall(5.0d0, 11.0d0)) ok = .false.
+
+    if (ok) then
+        print *, 'test_wall_loss: PASSED'
+    else
+        print *, 'test_wall_loss: FAILED'
+        error stop 1
+    end if
+end program test_wall_loss

--- a/POTATO/SRC/velo.f90
+++ b/POTATO/SRC/velo.f90
@@ -54,6 +54,7 @@
       use parmot_mod, only : rmu,ro0,gradpsiast, & !<=NEW in version 4
                              dpsiast_dR,dpsiast_dZ !<=NEW in version 4
       use field_eq_mod, only : ierrfield
+      use wall_loss_mod, only : outside_wall
 !
       implicit none
 !
@@ -75,6 +76,12 @@
       dimension a_phi(3),a_b(3),a_c(3),hstar(3)
 !
       x(1:3) = z(1:3)
+!
+      if(outside_wall(x(1),x(3))) then
+        ierrfield=1
+        vz=0.d0
+        return
+      endif
 !
 ! in magfie: x(i)   - set of 3 curvilinear space coordinates (input)
 !            bmod   - dimensionless magnetic field module: bmod=B/B_ref

--- a/POTATO/SRC/wall_loss_mod.f90
+++ b/POTATO/SRC/wall_loss_mod.f90
@@ -1,0 +1,72 @@
+module wall_loss_mod
+    use libneo_kinds, only: dp
+    implicit none
+    private
+
+    public :: load_wall, outside_wall, wall_loaded
+
+    logical :: wall_loaded = .false.
+    real(dp), allocatable :: rwall(:), zwall(:)
+
+contains
+
+    subroutine load_wall(filename)
+        character(len=*), intent(in) :: filename
+        integer :: iunit, ios, n
+        real(dp) :: r, z
+        logical :: exists
+
+        inquire (file=filename, exist=exists)
+        if (.not. exists) return
+        open (newunit=iunit, file=filename, status='old', action='read', iostat=ios)
+        if (ios /= 0) return
+
+        n = 0
+        do
+            read (iunit, *, iostat=ios) r, z
+            if (ios /= 0) exit
+            n = n + 1
+        end do
+        if (n < 3) then
+            close (iunit)
+            return
+        end if
+
+        allocate (rwall(n), zwall(n))
+        rewind (iunit)
+        n = 0
+        do
+            read (iunit, *, iostat=ios) r, z
+            if (ios /= 0) exit
+            n = n + 1
+            rwall(n) = r
+            zwall(n) = z
+        end do
+        close (iunit)
+        wall_loaded = .true.
+    end subroutine load_wall
+
+    logical function outside_wall(r, z)
+        real(dp), intent(in) :: r, z
+        integer :: i, j, n
+        logical :: inside
+
+        outside_wall = .false.
+        if (.not. wall_loaded) return
+
+        n = size(rwall)
+        inside = .false.
+        j = n
+        do i = 1, n
+            if ((zwall(i) > z) .neqv. (zwall(j) > z)) then
+                if (r < (rwall(j) - rwall(i)) * (z - zwall(i)) &
+                    / (zwall(j) - zwall(i)) + rwall(i)) then
+                    inside = .not. inside
+                end if
+            end if
+            j = i
+        end do
+        outside_wall = .not. inside
+    end function outside_wall
+
+end module wall_loss_mod


### PR DESCRIPTION
## Problem

With `clip_resonance_classes=.false.` and `edge_extension=.true.` (`allow_sol`),
magfie's separatrix domain check is disabled, so passing orbits sampled at the
plasma edge cross into the SOL/divertor and `odeint` grinds the full
`MAXSTP=20000` cap in extrapolated field. On AUG #30835 `actual_physical` this
produced ~530k `orbit left domain`/`too many steps` events (69% leaving below
the divertor, leave-points reaching R=574/Z=-701 cm, far outside the wall box
R114-214/Z-91..78), and the run did not finish 4/8 energy slices in 7.5 h.
`odeint` also ignored `ierrfield` (its early-bail was commented out), so even
flagged orbits ran to the cap. Separately, a wall-crossing sample made
`sample_matrix` exceed `itermax` and drop the whole class (`ierr=2`).

## Fix

- `wall_loss_mod` loads the limiter contour (`convexwall.dat`) and tests
  point-in-polygon. Cancellation is at the **outer wall**, not the separatrix:
  SOL orbits inside the vessel still integrate; only orbits crossing the wall
  are dropped (`ierr=1`, zero weight), like the existing resonant SOL skip.
- `velo` flags `ierrfield` on a wall crossing; `odeint`'s `ierrfield` early-bail
  is re-enabled so lost orbits stop immediately instead of grinding to the cap.
- `bound_class_wall` clips each class interval at the wall by bisection on orbit
  validity, so the inside-wall part is sampled normally (resonances kept) and
  only the lost orbits are dropped -- no whole-class drops.
- O(1) elliptical fast-path in `outside_wall` (the AUG wall is elongated), so the
  100-edge polygon runs only in the near-wall annulus.

## Verification

`fo build && fo lint` (POTATO): exit 0; 0 unused imports.

`fo test` / ctest (POTATO):
```
test_find_all_roots_bracketed .... Passed
test_wall_loss ................... Passed
potato_golden_displacement ....... Skipped (fixtures absent)
potato_resonance_probe_clip ...... Skipped (fixtures absent)
100% tests passed, 0 tests failed out of 4
```

`test_wall_profile.x` on the AUG wall: fast-path matches the exact polygon on all
160000 grid points; ellipse resolves 38.96% O(1) vs the circle's 27.18% (1.65x
over the bare polygon).

AUG #30835 `zero_mid`, full domain (`clip_resonance_classes=.false.`), private
fixture -- before vs after:
```
too many steps:                575474 -> 0
class drops (error 2):            444 -> 0
sample_matrix itermax exceeded:   445 -> 0
resonance points (8 slices):    ~broken -> 52542
per-slice kept/candidates:               5800/5830 (only wall-hitters dropped)
leave-points:        R 64..574 Z -701..662  ->  R>=114.6 Z>=-91.4 (at the wall)
```
The clip-off edge cases that did not finish in 7.5 h now complete in minutes.
