### PR TITLE
POTATO: finish limiter-wall cancellation (class clip, fast-path) and fix torque NaN

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -86,6 +86,13 @@ add_test(NAME test_wall_loss
    COMMAND test_wall_loss.x
 )
 
+add_executable(test_wall_profile.x
+   SRC/test_wall_profile.f90
+)
+target_link_libraries(test_wall_profile.x
+   potato_base
+)
+
 add_executable(import_neo2_profiles.x
    SRC/import_neo2_profiles.f90
 )

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -171,6 +171,7 @@ subroutine integrate_class_resonances
     use interp_cache_mod,   only : interp_cache_reset
     use field_sub,          only : psif
     use field_eq_mod,       only : psi_sep
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
     !
     implicit none
     !
@@ -319,6 +320,12 @@ subroutine integrate_class_resonances
             ! multiply expression under summation over modes with toroidal mode number, with factor $-\pi^{3/2}/4$
             ! and with reference energy:
             one_res=one_res*rm3*pi32_over4m*cE_ref
+            !
+            ! A near-tangent root (dresconddx -> 0) gives an infinite
+            ! dpsiastdx/dresconddx; for a wall-crossing resonance absHn2=0, so the
+            ! product is Inf*0 = NaN.  Such a degenerate resonance carries no
+            ! physical weight -- zero it so one bad root cannot poison the torque.
+            if (.not. ieee_is_finite(one_res)) one_res=0.d0
             !
             respoints_jp(mode,iclass)%w_res(iroot)=one_res
             respoints_jp(mode,iclass)%taub(iroot)=taub_res
@@ -721,8 +728,10 @@ subroutine resonant_torque
                 write(unit1901,*) respoint(i)%toten_res, &
                     respoint(i)%perpinv_res, &
                     torque_int_loc
-                torquebox_loc=torquebox_loc &
-                    +respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
+                if(respoint(i)%w_res.ne.0.d0 .and. respoint(i)%taub.gt.0.d0) then
+                    torquebox_loc=torquebox_loc &
+                        +respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
+                endif
             enddo
             deallocate(taubox_all)
             write(unit1901,*) ' '

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -158,7 +158,6 @@
 !
   use orbit_dim_mod, only : neqm,write_orb,iunit1,Rorb_max
   use field_eq_mod, only : ierrfield
-  use logging_mod, only : log_message
 !
   implicit none
 !
@@ -188,7 +187,6 @@
   double precision :: tau0,RNorm,ZNorm,vnorm,dnorm,vel_pol,dL2_pol_min
   double precision :: dZ_dR,sign_delZ,Z_tmp
   double precision, dimension(neqm+next) :: z,z_start,vz
-  character(len=256) :: msg
 !
   external velo_ext
 !
@@ -224,11 +222,6 @@
 !
   call odeint_allroutines(z,ndim,tau0,dtau,relerr,velo_ext)
   if(ierrfield.ne.0) then
-    write(msg,'(A,2ES14.6,A,2ES14.6)') &
-      'find_bounce: orbit left domain at R,Z=', &
-      z(1),z(3),' started from R,Z=',z_start(1),z_start(3)
-    write(*,'(A)') trim(msg)
-    call log_message(trim(msg))
     ierr = 1
     return
   endif
@@ -260,11 +253,6 @@
 !
     call odeint_allroutines(z,ndim,tau0,dtau,relerr,velo_ext)
     if(ierrfield.ne.0) then
-      write(msg,'(A,2ES14.6,A,2ES14.6)') &
-        'find_bounce: orbit left domain at R,Z=', &
-        z(1),z(3),' started from R,Z=',z_start(1),z_start(3)
-      write(*,'(A)') trim(msg)
-      call log_message(trim(msg))
       ierr = 1
       return
     endif
@@ -317,11 +305,6 @@
 !
     call odeint_allroutines(z,ndim,tau0,dtau_newt,relerr,velo_ext)
     if(ierrfield.ne.0) then
-      write(msg,'(A,2ES14.6,A,2ES14.6)') &
-        'find_bounce: orbit left domain at R,Z=', &
-        z(1),z(3),' started from R,Z=',z_start(1),z_start(3)
-      write(*,'(A)') trim(msg)
-      call log_message(trim(msg))
       ierr = 1
       return
     endif

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2560,6 +2560,8 @@
 !
   if(delphi_max.gt.0.d0) call bound_class_delphi(ifuntype(iclass),xbeg,xend)
 !
+  call bound_class_wall(xbeg,xend)
+!
   eps=relerror
 !
   call sample_matrix(get_matrix_doublecount,ierr)
@@ -2653,6 +2655,74 @@
   end function eval_delphi
 !
   end subroutine bound_class_delphi
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+  subroutine bound_class_wall(xb,xe)
+!
+! Trim the class interval to where the orbit closes inside the limiter wall.
+! A wall-crossing orbit fails in get_matrix_doublecount (amat(3,1) left at the
+! huge sentinel); without this trim a single lost sample makes sample_matrix
+! exceed itermax and the whole class is dropped (ierr=2) instead of only the
+! lost orbits.  Trims both endpoints by bisection on orbit validity, so the
+! inside-wall part of the class is still sampled and its resonances kept.
+!
+  use sample_matrix_mod, only : n1,n2,x,amat
+  use wall_loss_mod,     only : wall_loaded
+!
+  implicit none
+!
+  double precision :: xb,xe,xmid
+  logical :: amat_was_alloc
+!
+  external :: get_matrix_doublecount
+!
+  if(.not.wall_loaded) return
+!
+  amat_was_alloc=allocated(amat)
+  if(.not.amat_was_alloc) allocate(amat(n1,n2))
+!
+  xmid=0.5d0*(xb+xe)
+  if(.not.orbit_lost(xmid)) then
+    call trim_lost(xmid,xe)
+    call trim_lost(xmid,xb)
+  endif
+!
+  if(.not.amat_was_alloc) deallocate(amat)
+!
+  contains
+!
+  subroutine trim_lost(xsafe,xdiv)
+  double precision :: xsafe,xdiv,xlo,xhi,xm
+  integer :: it
+!
+  if(.not.orbit_lost(xdiv)) return
+!
+  xlo=xsafe
+  xhi=xdiv
+  do it=1,40
+    xm=0.5d0*(xlo+xhi)
+    if(orbit_lost(xm)) then
+      xhi=xm
+    else
+      xlo=xm
+    endif
+    if(abs(xhi-xlo).lt.1.d-3*max(1.d0,abs(xdiv))) exit
+  enddo
+  xdiv=xlo
+  end subroutine trim_lost
+!
+  logical function orbit_lost(xval)
+  double precision :: xval
+! huge sentinel: get_matrix_doublecount leaves amat untouched when the orbit
+! fails (e.g. crosses the wall), so an untouched entry reads as a lost orbit.
+  amat(3,1)=huge(1.d0)
+  x=xval
+  call get_matrix_doublecount
+  orbit_lost = (amat(3,1).eq.huge(1.d0))
+  end function orbit_lost
+!
+  end subroutine bound_class_wall
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/POTATO/SRC/test_wall_loss.f90
+++ b/POTATO/SRC/test_wall_loss.f90
@@ -18,6 +18,7 @@ program test_wall_loss
     ok = .true.
     if (.not. wall_loaded) ok = .false.
     if (outside_wall(5.0d0, 5.0d0)) ok = .false.
+    if (outside_wall(9.0d0, 9.0d0)) ok = .false.
     if (.not. outside_wall(15.0d0, 5.0d0)) ok = .false.
     if (.not. outside_wall(5.0d0, -1.0d0)) ok = .false.
     if (.not. outside_wall(-1.0d0, 5.0d0)) ok = .false.

--- a/POTATO/SRC/test_wall_profile.f90
+++ b/POTATO/SRC/test_wall_profile.f90
@@ -1,0 +1,79 @@
+program test_wall_profile
+    use libneo_kinds, only: dp
+    use wall_loss_mod, only: load_wall, wall_loaded, outside_wall, &
+        outside_wall_exact, fastpath_resolves_circle, fastpath_resolves_ellipse
+    implicit none
+
+    integer, parameter :: ng = 400, nrep = 200
+    real(dp), parameter :: rlo = 80.0_dp, rhi = 240.0_dp
+    real(dp), parameter :: zlo = -130.0_dp, zhi = 110.0_dp
+    character(len=512) :: wallfile
+    integer :: i, k, rep, npts, ncirc, nell, mism
+    integer(8) :: acc_fast, acc_exact
+    real(dp) :: r, z, t0, t1, t_fast, t_exact
+
+    if (command_argument_count() < 1) then
+        print *, 'usage: test_wall_profile.x <convexwall.dat>'
+        error stop 1
+    end if
+    call get_command_argument(1, wallfile)
+    call load_wall(trim(wallfile))
+    if (.not. wall_loaded) then
+        print *, 'could not load wall: ', trim(wallfile)
+        error stop 1
+    end if
+
+    npts = 0; ncirc = 0; nell = 0; mism = 0
+    do i = 1, ng
+        r = rlo + (rhi - rlo) * (i - 0.5_dp) / ng
+        do k = 1, ng
+            z = zlo + (zhi - zlo) * (k - 0.5_dp) / ng
+            npts = npts + 1
+            if (fastpath_resolves_circle(r, z)) ncirc = ncirc + 1
+            if (fastpath_resolves_ellipse(r, z)) nell = nell + 1
+            if (outside_wall(r, z) .neqv. outside_wall_exact(r, z)) mism = mism + 1
+        end do
+    end do
+
+    acc_fast = 0
+    call cpu_time(t0)
+    do rep = 1, nrep
+        do i = 1, ng
+            r = rlo + (rhi - rlo) * (i - 0.5_dp) / ng
+            do k = 1, ng
+                z = zlo + (zhi - zlo) * (k - 0.5_dp) / ng
+                if (outside_wall(r, z)) acc_fast = acc_fast + 1
+            end do
+        end do
+    end do
+    call cpu_time(t1)
+    t_fast = t1 - t0
+
+    acc_exact = 0
+    call cpu_time(t0)
+    do rep = 1, nrep
+        do i = 1, ng
+            r = rlo + (rhi - rlo) * (i - 0.5_dp) / ng
+            do k = 1, ng
+                z = zlo + (zhi - zlo) * (k - 0.5_dp) / ng
+                if (outside_wall_exact(r, z)) acc_exact = acc_exact + 1
+            end do
+        end do
+    end do
+    call cpu_time(t1)
+    t_exact = t1 - t0
+    if (acc_fast /= acc_exact) error stop 'profile accumulators differ'
+
+    print '(A,I0)', 'grid points:            ', npts
+    print '(A,F6.2,A)', 'circle fast-path:       ', 100.0_dp*ncirc/npts, '% O(1)'
+    print '(A,F6.2,A)', 'ellipse fast-path:      ', 100.0_dp*nell/npts, '% O(1)'
+    print '(A,F6.2,A)', 'polygon tests, circle:  ', 100.0_dp*(npts-ncirc)/npts, '% of calls'
+    print '(A,F6.2,A)', 'polygon tests, ellipse: ', 100.0_dp*(npts-nell)/npts, '% of calls'
+    print '(A,ES10.3,A,ES10.3,A,F5.2,A)', 'time fast=', t_fast, 's exact=', t_exact, &
+        's  speedup=', t_exact/t_fast, 'x'
+    if (mism /= 0) then
+        print '(A,I0)', 'FAIL fast-path disagrees with polygon: ', mism
+        error stop 1
+    end if
+    print *, 'fast-path matches exact on all points'
+end program test_wall_profile

--- a/POTATO/SRC/wall_loss_mod.f90
+++ b/POTATO/SRC/wall_loss_mod.f90
@@ -3,11 +3,13 @@ module wall_loss_mod
     implicit none
     private
 
-    public :: load_wall, outside_wall, wall_loaded
+    public :: load_wall, outside_wall, outside_wall_exact, wall_loaded
+    public :: fastpath_resolves_circle, fastpath_resolves_ellipse
 
     logical :: wall_loaded = .false.
     real(dp), allocatable :: rwall(:), zwall(:)
-    real(dp) :: rc, zc, r_in2, r_out2
+    real(dp) :: rc, zc, sz
+    real(dp) :: r_in2_c, r_out2_c, r_in2_e, r_out2_e
 
 contains
 
@@ -45,49 +47,77 @@ contains
         end do
         close (iunit)
 
-        call set_bounding_circles()
+        call set_bounding_shapes()
         wall_loaded = .true.
     end subroutine load_wall
 
-    subroutine set_bounding_circles()
-        integer :: i, j, n
-        real(dp) :: dx, dy, seg2, dist2
+    subroutine set_bounding_shapes()
+        integer :: n
+        real(dp) :: span_r, span_z
 
         n = size(rwall)
         rc = sum(rwall) / n
         zc = sum(zwall) / n
+
+        span_r = maxval(rwall) - minval(rwall)
+        span_z = maxval(zwall) - minval(zwall)
+        if (span_z > 0.0_dp) then
+            sz = span_r / span_z
+        else
+            sz = 1.0_dp
+        end if
+
+        call bounding_circles(1.0_dp, r_in2_c, r_out2_c)
+        call bounding_circles(sz, r_in2_e, r_out2_e)
+    end subroutine set_bounding_shapes
+
+    subroutine bounding_circles(scale_z, r_in2, r_out2)
+        real(dp), intent(in) :: scale_z
+        real(dp), intent(out) :: r_in2, r_out2
+        integer :: i, j, n
+        real(dp) :: dx, dy, seg2, dist2
+
+        n = size(rwall)
         r_in2 = huge(1.0_dp)
         r_out2 = 0.0_dp
         j = n
         do i = 1, n
-            dist2 = (rwall(i) - rc)**2 + (zwall(i) - zc)**2
+            dist2 = (rwall(i) - rc)**2 + (scale_z*(zwall(i) - zc))**2
             if (dist2 > r_out2) r_out2 = dist2
             dx = rwall(i) - rwall(j)
-            dy = zwall(i) - zwall(j)
+            dy = scale_z*(zwall(i) - zwall(j))
             seg2 = dx*dx + dy*dy
             if (seg2 > 0.0_dp) then
-                dist2 = (dx*(zc - zwall(j)) - dy*(rc - rwall(j)))**2 / seg2
+                dist2 = (dx*scale_z*(zc - zwall(j)) - dy*(rc - rwall(j)))**2 / seg2
                 if (dist2 < r_in2) r_in2 = dist2
             end if
             j = i
         end do
-    end subroutine set_bounding_circles
+    end subroutine bounding_circles
 
     logical function outside_wall(r, z)
         real(dp), intent(in) :: r, z
-        integer :: i, j, n
         real(dp) :: d2
-        logical :: inside
 
         outside_wall = .false.
         if (.not. wall_loaded) return
 
-        d2 = (r - rc)**2 + (z - zc)**2
-        if (d2 <= r_in2) return
-        if (d2 >= r_out2) then
+        d2 = (r - rc)**2 + (sz*(z - zc))**2
+        if (d2 <= r_in2_e) return
+        if (d2 >= r_out2_e) then
             outside_wall = .true.
             return
         end if
+        outside_wall = outside_wall_exact(r, z)
+    end function outside_wall
+
+    logical function outside_wall_exact(r, z)
+        real(dp), intent(in) :: r, z
+        integer :: i, j, n
+        logical :: inside
+
+        outside_wall_exact = .false.
+        if (.not. wall_loaded) return
 
         n = size(rwall)
         inside = .false.
@@ -101,7 +131,23 @@ contains
             end if
             j = i
         end do
-        outside_wall = .not. inside
-    end function outside_wall
+        outside_wall_exact = .not. inside
+    end function outside_wall_exact
+
+    logical function fastpath_resolves_circle(r, z)
+        real(dp), intent(in) :: r, z
+        real(dp) :: d2
+
+        d2 = (r - rc)**2 + (z - zc)**2
+        fastpath_resolves_circle = d2 <= r_in2_c .or. d2 >= r_out2_c
+    end function fastpath_resolves_circle
+
+    logical function fastpath_resolves_ellipse(r, z)
+        real(dp), intent(in) :: r, z
+        real(dp) :: d2
+
+        d2 = (r - rc)**2 + (sz*(z - zc))**2
+        fastpath_resolves_ellipse = d2 <= r_in2_e .or. d2 >= r_out2_e
+    end function fastpath_resolves_ellipse
 
 end module wall_loss_mod

--- a/POTATO/SRC/wall_loss_mod.f90
+++ b/POTATO/SRC/wall_loss_mod.f90
@@ -7,6 +7,7 @@ module wall_loss_mod
 
     logical :: wall_loaded = .false.
     real(dp), allocatable :: rwall(:), zwall(:)
+    real(dp) :: rc, zc, r_in2, r_out2
 
 contains
 
@@ -43,16 +44,50 @@ contains
             zwall(n) = z
         end do
         close (iunit)
+
+        call set_bounding_circles()
         wall_loaded = .true.
     end subroutine load_wall
+
+    subroutine set_bounding_circles()
+        integer :: i, j, n
+        real(dp) :: dx, dy, seg2, dist2
+
+        n = size(rwall)
+        rc = sum(rwall) / n
+        zc = sum(zwall) / n
+        r_in2 = huge(1.0_dp)
+        r_out2 = 0.0_dp
+        j = n
+        do i = 1, n
+            dist2 = (rwall(i) - rc)**2 + (zwall(i) - zc)**2
+            if (dist2 > r_out2) r_out2 = dist2
+            dx = rwall(i) - rwall(j)
+            dy = zwall(i) - zwall(j)
+            seg2 = dx*dx + dy*dy
+            if (seg2 > 0.0_dp) then
+                dist2 = (dx*(zc - zwall(j)) - dy*(rc - rwall(j)))**2 / seg2
+                if (dist2 < r_in2) r_in2 = dist2
+            end if
+            j = i
+        end do
+    end subroutine set_bounding_circles
 
     logical function outside_wall(r, z)
         real(dp), intent(in) :: r, z
         integer :: i, j, n
+        real(dp) :: d2
         logical :: inside
 
         outside_wall = .false.
         if (.not. wall_loaded) return
+
+        d2 = (r - rc)**2 + (z - zc)**2
+        if (d2 <= r_in2) return
+        if (d2 >= r_out2) then
+            outside_wall = .true.
+            return
+        end if
 
         n = size(rwall)
         inside = .false.


### PR DESCRIPTION
Completes the limiter-wall work that PR #69 started: #69 squash-merged only the
first commit (the bare wall cancellation), so `main` was missing the rest. This
branch carries the remainder and fixes a torque NaN found afterwards.

## What was missing from main

- **Drop only the lost orbits, not whole classes.** A class straddling the wall
  has sample orbits that fail; without bounding, `sample_matrix` exceeded
  `itermax` and dropped the whole class (`ierr=2`), collapsing energy slices
  (AUG #30835 `zero_mid`: 444 class drops). `bound_class_wall` clips each class
  interval at the wall by bisection on orbit validity, so the inside-wall part
  is sampled normally and only the wall-hitting orbits are dropped
  (`data ~= candidates` per slice; class drops 444 -> 0).
- **No per-orbit log spam.** The cancellation fired millions of times; the
  `orbit left domain` write flooded stdout (3.5M lines/run). Removed.
- **O(1) elliptical wall fast-path + profiler.** The AUG limiter is elongated;
  an anisotropically-scaled inscribed/circumscribed test resolves 39% of queries
  without the 100-edge polygon vs 27% for a circle (1.65x), exact on 160k pts.

## Torque NaN fix

The fuller clip-off sampling reaches degenerate edge resonances. A near-tangent
root (`dresconddx -> 0`) makes `dpsiastdx/dresconddx` infinite; for a
wall-crossing resonance `absHn2=0`, so `one_res = Inf*0 = NaN`. The box
accumulation also divides `taubox/taub`, which is `0/0` for a `taub<=0` root.
One NaN weight poisons the whole box-counted torque. Fix: zero any non-finite
`one_res`, and skip the box deposit when `w_res=0` or `taub<=0`.

## Verification

`fo build && fo lint` (POTATO): exit 0; 0 unused imports.

`fo test` / ctest: `test_wall_loss`, `test_find_all_roots_bracketed` Passed;
golden + probe Skipped (fixtures absent); 100% passed.

AUG #30835 `zero_thin`, full domain (`clip_resonance_classes=.false.`):
```
boxcounted NaN/rows:   200/200  ->  0/200
integral_torque:           NaN  ->  -3581.808   (pre-change: -3581.8)
boxcounted values match the pre-change run to all printed digits
```
AUG #30835 `zero_mid`, full domain: class drops 444 -> 0, itermax-exceeded
445 -> 0, resonance points recover to 52542.

Clip-true golden case (`potato_zero_mid`, default `potato.in`): integral matches
the golden within OpenMP reduction-order noise (~5e-9, pre-existing
nondeterminism), 0 NaN; the new guards are no-ops on this path.
