### PR TITLE
Link granular libneo sub-targets (decompose-neo-core)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,11 +171,11 @@ target_link_libraries(neo_rt PUBLIC
 )
 
 if(USE_STANDALONE)
-    target_link_libraries(neo_rt PUBLIC neo)
-    get_target_property(_neo_incdirs neo INTERFACE_INCLUDE_DIRECTORIES)
-    if(_neo_incdirs)
-        target_include_directories(neo_rt PUBLIC ${_neo_incdirs})
-    endif()
+    target_link_libraries(neo_rt PUBLIC
+        LIBNEO::magfie
+        LIBNEO::boozer
+        LIBNEO::field
+    )
     target_include_directories(neo_rt PUBLIC
         "${CMAKE_BINARY_DIR}/libneo"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,6 @@ if(USE_STANDALONE)
         LIBNEO::boozer
         LIBNEO::field
     )
-    target_include_directories(neo_rt PUBLIC
-        "${CMAKE_BINARY_DIR}/libneo"
-    )
 endif()
 
 target_link_libraries(${PROJECT_EXE_NAME} neo_rt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,9 +172,7 @@ target_link_libraries(neo_rt PUBLIC
 
 if(USE_STANDALONE)
     target_link_libraries(neo_rt PUBLIC
-        LIBNEO::magfie
         LIBNEO::boozer
-        LIBNEO::field
     )
 endif()
 


### PR DESCRIPTION
Standalone build now links the granular libneo sub-targets LIBNEO::magfie, LIBNEO::boozer, and LIBNEO::field instead of the monolithic neo umbrella. The boozer_chartmap_types and boozer_chartmap_io modules used by do_magfie_standalone are provided by LIBNEO::boozer; magfie and field cover the remaining magnetic-field interfaces. Module include directories propagate transitively from the sub-target INTERFACE_INCLUDE_DIRECTORIES, so the manual neo include extraction is removed.

Matches libneo branch dep-audit/decompose-neo-core.

## Verification

Built with LIBNEO_REF=dep-audit/decompose-neo-core; neo_rt.x and neo_rt_diag.x link cleanly. ctest unit suite: 4/4 passed (test_timestep, test_parallel, test_neort_lib, test_chartmap_input).