### PR TITLE
Expose POTATO invariant handoff

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -96,6 +96,16 @@ add_test(NAME test_wall_loss
    COMMAND test_wall_loss.x
 )
 
+add_executable(test_potato_invariants.x
+   SRC/test_potato_invariants.f90
+)
+target_link_libraries(test_potato_invariants.x
+   potato_base
+)
+add_test(NAME test_potato_invariants
+   COMMAND test_potato_invariants.x
+)
+
 add_executable(test_wall_profile.x
    SRC/test_wall_profile.f90
 )
@@ -126,6 +136,13 @@ target_link_libraries(potato_resonance_probe.x
 
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
+    add_test(NAME potato_invariant_handoff
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/invariant_handoff/test_invariant_handoff.py
+            $<TARGET_FILE:potato.x>
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
+    )
+    set_tests_properties(potato_invariant_handoff PROPERTIES TIMEOUT 150)
     add_test(NAME potato_golden_displacement
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_displacement/test_potato_golden.py

--- a/POTATO/README.md
+++ b/POTATO/README.md
@@ -43,3 +43,33 @@ on an idle machine and 400-600 s under any concurrent load, because they
 oversubscribe the 16 cores.
 
 The reslines output is identical for every thread count.
+
+## SIMPLE-compatible invariant handoff
+
+Single-orbit (`itest_type=4`) and radial-frequency-scan (`itest_type=5`) runs
+write `potato_invariants.dat` without changing the existing `fort.100` or
+`freq_scan.dat` schemas.  The versioned file contains the local state and the
+three axisymmetric invariants needed by SIMPLE:
+
+```text
+H0       = p^2 + phi_elec
+J_perp   = p^2 (1 - xi^2)/B
+psi_star = psi + rho0 p xi h_phi = (c/q) P_phi
+```
+
+Here `p=v/v0`, `xi=v_parallel/v`, `v0=sqrt(2 E_ref/m)` in cm/s, `B` is in
+POTATO's native gauss convention, `phi_elec=q Phi/E_ref`, and `psi_star`,
+`psi_axis`, and `psi_edge` use the same native g-eqdsk flux gauge and units
+(G cm^2).  Time remains POTATO's `tau=v0*t`; SIMPLE's private symplectic
+sqrt(2) scaling is not part of this file.
+
+SIMPLE currently supports only the magnetic Hamiltonian.  Therefore status is
+zero only when `phi_elec` is zero to numerical tolerance; a nonzero-potential
+row still records POTATO's correct total `H0`, but has status 2 and must not be
+converted.  Status 1 means invalid normalization input and status 3 means the
+field evaluation failed.
+
+For a scan, rows retain the requested increasing-`R` order (HFS to LFS when
+the input bounds are ordered that way), matching POTATO's `R_c` convention.
+No `rho_pol`/`rho_tor` identification or outer/inner orbit selection is
+implied by the handoff.

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(potato_base
   logging_mod.f90
   wall_loss_mod.f90
   potato_input_mod.f90
-  ${LIBNEO_SOURCE_DIR}/src/math_constants.f90
+  potato_invariants_mod.f90
+  ${LIBNEO_SOURCE_DIR}/src/util/math_constants.f90
   alpha_lifetime_mod.f90
   ${LIBNEO_SOURCE_DIR}/src/MC/chamb_divB0.f90
   ${LIBNEO_SOURCE_DIR}/src/magfie/magfie_cyl.f90

--- a/POTATO/SRC/potato_invariants_mod.f90
+++ b/POTATO/SRC/potato_invariants_mod.f90
@@ -1,0 +1,127 @@
+module potato_invariants_mod
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+
+    private
+
+    integer, parameter, public :: POTATO_INVARIANT_SUCCESS = 0
+    integer, parameter, public :: POTATO_INVARIANT_INVALID_INPUT = 1
+    integer, parameter, public :: POTATO_INVARIANT_NONZERO_POTENTIAL = 2
+    integer, parameter, public :: POTATO_INVARIANT_FIELD_ERROR = 3
+    real(dp), parameter :: POTENTIAL_TOLERANCE = 1.0e-12_dp
+
+    type, public :: potato_invariant_t
+        real(dp) :: p = 0.0_dp
+        real(dp) :: xi = 0.0_dp
+        real(dp) :: h0 = 0.0_dp
+        real(dp) :: j_perp = 0.0_dp
+        real(dp) :: psi_star = 0.0_dp
+        real(dp) :: psi_axis = 0.0_dp
+        real(dp) :: psi_edge = 0.0_dp
+        real(dp) :: phi_elec = 0.0_dp
+        real(dp) :: v0 = 0.0_dp
+        integer :: sigma = 0
+        integer :: status = POTATO_INVARIANT_INVALID_INPUT
+    end type potato_invariant_t
+
+    public :: open_potato_invariant_handoff, potato_invariant_from_local_state
+    public :: write_potato_invariant_from_local_state
+
+contains
+
+    subroutine open_potato_invariant_handoff(iunit)
+        integer, intent(out) :: iunit
+
+        open(newunit=iunit, file='potato_invariants.dat', status='replace', &
+            action='write')
+        write(iunit, '(A)') '# potato-simple-invariants-v1'
+        write(iunit, '(A)') '# id R_cm Z_cm p xi sigma H0 J_perp psi_star '// &
+            'psi_axis psi_edge phi_elec v0_cm_s status'
+    end subroutine open_potato_invariant_handoff
+
+    subroutine write_potato_invariant_from_local_state(iunit, identifier, &
+            radius, height, p, xi, bmod, h_phi, psi, phi_elec, rho0, &
+            psi_axis, psi_edge, v0, field_status)
+        integer, intent(in) :: iunit, identifier, field_status
+        real(dp), intent(in) :: radius, height, p, xi, bmod, h_phi, psi
+        real(dp), intent(in) :: phi_elec, rho0, psi_axis, psi_edge, v0
+        type(potato_invariant_t) :: invariant
+
+        call potato_invariant_from_local_state(p, xi, bmod, h_phi, psi, &
+            phi_elec, rho0, psi_axis, psi_edge, v0, invariant)
+        if (field_status /= 0) invariant%status = POTATO_INVARIANT_FIELD_ERROR
+        call write_potato_invariant(iunit, identifier, radius, height, invariant)
+    end subroutine write_potato_invariant_from_local_state
+
+    subroutine write_potato_invariant(iunit, identifier, radius, height, invariant)
+        integer, intent(in) :: iunit, identifier
+        real(dp), intent(in) :: radius, height
+        type(potato_invariant_t), intent(in) :: invariant
+
+        write(iunit, '(I0,1X,4(ES24.16,1X),I0,1X,7(ES24.16,1X),I0)') &
+            identifier, radius, height, invariant%p, invariant%xi, &
+            invariant%sigma, invariant%h0, invariant%j_perp, &
+            invariant%psi_star, invariant%psi_axis, invariant%psi_edge, &
+            invariant%phi_elec, invariant%v0, invariant%status
+    end subroutine write_potato_invariant
+
+    pure subroutine potato_invariant_from_local_state(p, xi, bmod, h_phi, &
+            psi, phi_elec, rho0, psi_axis, psi_edge, v0, invariant)
+        real(dp), intent(in) :: p, xi, bmod, h_phi, psi, phi_elec, rho0
+        real(dp), intent(in) :: psi_axis, psi_edge, v0
+        type(potato_invariant_t), intent(out) :: invariant
+
+        invariant = potato_invariant_t()
+        call copy_input_metadata(p, xi, phi_elec, psi_axis, psi_edge, v0, &
+            invariant)
+        if (.not. local_state_is_valid(p, xi, bmod, h_phi, psi, rho0, &
+                psi_axis, psi_edge, v0)) return
+        invariant%h0 = p**2 + phi_elec
+        invariant%j_perp = p**2*(1.0_dp - xi**2)/bmod
+        invariant%psi_star = psi + rho0*p*xi*h_phi
+        if (abs(phi_elec) > POTENTIAL_TOLERANCE) then
+            invariant%status = POTATO_INVARIANT_NONZERO_POTENTIAL
+            return
+        end if
+        invariant%status = POTATO_INVARIANT_SUCCESS
+    end subroutine potato_invariant_from_local_state
+
+    pure subroutine copy_input_metadata(p, xi, phi_elec, psi_axis, psi_edge, &
+            v0, invariant)
+        real(dp), intent(in) :: p, xi, phi_elec, psi_axis, psi_edge, v0
+        type(potato_invariant_t), intent(inout) :: invariant
+
+        invariant%p = p
+        invariant%xi = xi
+        invariant%phi_elec = phi_elec
+        invariant%psi_axis = psi_axis
+        invariant%psi_edge = psi_edge
+        invariant%v0 = v0
+        if (xi > 0.0_dp) invariant%sigma = 1
+        if (xi < 0.0_dp) invariant%sigma = -1
+    end subroutine copy_input_metadata
+
+    pure logical function local_state_is_valid(p, xi, bmod, h_phi, psi, &
+            rho0, psi_axis, psi_edge, v0)
+        real(dp), intent(in) :: p, xi, bmod, h_phi, psi, rho0
+        real(dp), intent(in) :: psi_axis, psi_edge, v0
+
+        local_state_is_valid = .false.
+        if (.not. ieee_is_finite(p)) return
+        if (.not. ieee_is_finite(xi)) return
+        if (.not. ieee_is_finite(bmod)) return
+        if (.not. ieee_is_finite(h_phi)) return
+        if (.not. ieee_is_finite(psi)) return
+        if (.not. ieee_is_finite(rho0)) return
+        if (.not. ieee_is_finite(psi_axis)) return
+        if (.not. ieee_is_finite(psi_edge)) return
+        if (.not. ieee_is_finite(v0)) return
+        if (p <= 0.0_dp) return
+        if (abs(xi) > 1.0_dp) return
+        if (bmod <= 0.0_dp) return
+        if (v0 <= 0.0_dp) return
+        if (psi_edge == psi_axis) return
+        local_state_is_valid = .true.
+    end function local_state_is_valid
+end module potato_invariants_mod

--- a/POTATO/SRC/test_potato_invariants.f90
+++ b/POTATO/SRC/test_potato_invariants.f90
@@ -1,0 +1,53 @@
+program test_potato_invariants
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use potato_invariants_mod, only: POTATO_INVARIANT_INVALID_INPUT, &
+        POTATO_INVARIANT_NONZERO_POTENTIAL, POTATO_INVARIANT_SUCCESS, &
+        potato_invariant_t, potato_invariant_from_local_state
+    implicit none
+
+    type(potato_invariant_t) :: invariant
+
+    call potato_invariant_from_local_state(2.0_dp, -0.5_dp, 4.0_dp, 3.0_dp, &
+        7.0_dp, 0.0_dp, 0.25_dp, 1.0_dp, 9.0_dp, 2.5e7_dp, invariant)
+    call require(invariant%status == POTATO_INVARIANT_SUCCESS, 'valid status')
+    call require_close(invariant%h0, 4.0_dp, 1.0e-14_dp, 'H0 normalization')
+    call require_close(invariant%j_perp, 0.75_dp, 1.0e-14_dp, &
+        'J_perp normalization')
+    call require_close(invariant%psi_star, 6.25_dp, 1.0e-14_dp, &
+        'psi_star normalization')
+    call require(invariant%sigma == -1, 'parallel sign')
+    call require_close(invariant%psi_axis, 1.0_dp, 1.0e-14_dp, 'axis flux')
+    call require_close(invariant%psi_edge, 9.0_dp, 1.0e-14_dp, 'edge flux')
+    call require_close(invariant%v0, 2.5e7_dp, 1.0e-7_dp, 'reference velocity')
+
+    call potato_invariant_from_local_state(1.0_dp, 0.3_dp, 2.0_dp, 1.0_dp, &
+        0.5_dp, 1.0e-3_dp, 0.1_dp, 0.0_dp, 1.0_dp, 1.0_dp, invariant)
+    call require(invariant%status == POTATO_INVARIANT_NONZERO_POTENTIAL, &
+        'electrostatic potential rejection')
+    call require_close(invariant%h0, 1.001_dp, 1.0e-14_dp, &
+        'POTATO total energy includes potential')
+
+    call potato_invariant_from_local_state(1.0_dp, 1.1_dp, 2.0_dp, 1.0_dp, &
+        0.5_dp, 0.0_dp, 0.1_dp, 0.0_dp, 1.0_dp, 1.0_dp, invariant)
+    call require(invariant%status == POTATO_INVARIANT_INVALID_INPUT, &
+        'invalid pitch rejection')
+
+contains
+
+    subroutine require(condition, message)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: message
+
+        if (.not. condition) then
+            write (*, '(A)') 'FAILED: '//message
+            error stop 1
+        end if
+    end subroutine require
+
+    subroutine require_close(actual, expected, tolerance, message)
+        real(dp), intent(in) :: actual, expected, tolerance
+        character(len=*), intent(in) :: message
+
+        call require(abs(actual - expected) <= tolerance, message)
+    end subroutine require_close
+end program test_potato_invariants

--- a/POTATO/SRC/tt.f90
+++ b/POTATO/SRC/tt.f90
@@ -24,7 +24,9 @@
                                           input_clip_resonance_classes => clip_resonance_classes, &
                                           orbit_Rstart, orbit_Zstart, orbit_lambda, &
                                           freq_Rmin, freq_Rmax, freq_n
-  use field_eq_mod,                 only : allow_sol, psi_axis, psi_sep
+  use potato_invariants_mod,        only : open_potato_invariant_handoff, &
+                                          write_potato_invariant_from_local_state
+  use field_eq_mod,                 only : allow_sol, ierrfield, psi_axis, psi_sep
   use field_sub,                    only : psif
 !
   implicit none
@@ -39,17 +41,18 @@
   logical :: classes_talk,plot_orbits,compute_equibrium_profiles,compute_resonant_torque,plot_poicut
   logical :: trace_single_orbit,freq_scan
 !
-  integer          :: ifdir_type,ierr,m,iunit,i,log_u
+  integer          :: ifdir_type,ierr,m,iunit,i,log_u,invariant_unit
   double precision :: v0,bmod_ref
   double precision, dimension(:,:), allocatable :: resint
   double precision, dimension(neqm) :: z_single
   double precision :: taub_single,delphi_single,extraset_single(1)
   type(region_set_t) :: regions
-  external :: find_bounce, velo, magfie
+  external :: elefie, find_bounce, velo, magfie
 ! frequency radial scan (itest_type=5):
   integer          :: ifreq
   double precision :: Rstep,omega_b,omega_phi,s_norm,rhopol
   double precision :: bmod_d,sqrtg_d,bder_d(3),hcovar_d(3),hctrvr_d(3),hcurl_d(3),x_d(3)
+  double precision :: phi_elec_d,derphi_d(3)
 
 !
 !
@@ -196,6 +199,14 @@
     z_single(3)=orbit_Zstart   ! Z [cm]
     z_single(4)=1.d0           ! p, monoenergetic at E_alpha
     z_single(5)=orbit_lambda   ! pitch cosine v_par/v
+    x_d=z_single(1:3)
+    call magfie(x_d,bmod_d,sqrtg_d,bder_d,hcovar_d,hctrvr_d,hcurl_d)
+    call elefie(x_d,phi_elec_d,derphi_d)
+    call open_potato_invariant_handoff(invariant_unit)
+    call write_potato_invariant_from_local_state(invariant_unit,1, &
+         z_single(1),z_single(3),z_single(4),z_single(5),bmod_d, &
+         hcovar_d(2),psif,phi_elec_d,ro0,psi_axis,psi_sep,v0,ierrfield)
+    close(invariant_unit)
     write_orb=.true.
     iunit1=100
     extraset_single=0.d0
@@ -217,6 +228,7 @@
     call tee_message('Frequency radial scan')
     write_orb=.false.
     open(iunit,file='freq_scan.dat',status='replace',action='write')
+    call open_potato_invariant_handoff(invariant_unit)
     write(iunit,'(A)') '# R_start[cm] rho_pol omega_b[1/s] omega_phi[1/s] '// &
                        'taub delphi ierr'
     Rstep=(freq_Rmax-freq_Rmin)/dble(max(freq_n-1,1))
@@ -229,6 +241,10 @@
 ! flux label of the start point: evaluate the field there, then normalize psi.
       x_d=z_single(1:3)
       call magfie(x_d,bmod_d,sqrtg_d,bder_d,hcovar_d,hctrvr_d,hcurl_d)
+      call elefie(x_d,phi_elec_d,derphi_d)
+      call write_potato_invariant_from_local_state(invariant_unit,ifreq, &
+           z_single(1),z_single(3),z_single(4),z_single(5),bmod_d, &
+           hcovar_d(2),psif,phi_elec_d,ro0,psi_axis,psi_sep,v0,ierrfield)
       s_norm=(psif-psi_axis)/(psi_sep-psi_axis)
       rhopol=sqrt(max(s_norm,0.d0))
       extraset_single=0.d0
@@ -245,6 +261,7 @@
       endif
     enddo
     close(iunit)
+    close(invariant_unit)
     call tee_message('Frequency radial scan done -> freq_scan.dat')
   endif
 !

--- a/POTATO/test/invariant_handoff/test_invariant_handoff.py
+++ b/POTATO/test/invariant_handoff/test_invariant_handoff.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import math
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+INPUT_NAMES = (
+    "circ.eqdsk",
+    "convexwall.dat",
+    "field_divB0.inp",
+    "profile_poly.in",
+)
+EXPECTED_COLUMNS = (
+    "id",
+    "R_cm",
+    "Z_cm",
+    "p",
+    "xi",
+    "sigma",
+    "H0",
+    "J_perp",
+    "psi_star",
+    "psi_axis",
+    "psi_edge",
+    "phi_elec",
+    "v0_cm_s",
+    "status",
+)
+
+
+def write_input(path: Path, itest_type: int = 4, scan: bool = False) -> None:
+    scan_input = """
+  freq_Rmin = 145d0
+  freq_Rmax = 175d0
+  freq_n = 3
+""" if scan else ""
+    path.write_text(
+        f"""&potato_nml
+  itest_type = {itest_type}
+  E_alpha = 5d3
+  A_alpha = 2d0
+  Z_alpha = 1d0
+  rho_pol_max = 0.65d0
+  Rmax_orbit = 250d0
+  ntimstep = 2000
+  npoicut = 1000
+  orbit_Rstart = 180d0
+  orbit_Zstart = 0d0
+  orbit_lambda = 0.3d0
+  profile_file = 'profile_poly.in'
+{scan_input}
+/
+"""
+    )
+
+
+def zero_electric_potential(path: Path) -> None:
+    lines = path.read_text().splitlines()
+    lines[-1] = " ".join(["0.0"] * 10)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def read_handoff(path: Path) -> tuple[list[str], list[list[float]]]:
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if lines[0] != "# potato-simple-invariants-v1":
+        raise AssertionError(f"unexpected handoff version: {lines[0]}")
+    columns = lines[1].removeprefix("# ").split()
+    rows = [[float(value) for value in line.split()] for line in lines[2:]]
+    return columns, rows
+
+
+def require_valid_rows(columns: list[str], rows: list[list[float]]) -> None:
+    if tuple(columns) != EXPECTED_COLUMNS:
+        raise AssertionError(f"unexpected columns: {columns}")
+    for values in rows:
+        if len(values) != len(EXPECTED_COLUMNS):
+            raise AssertionError(f"unexpected row width: {len(values)}")
+        row = dict(zip(columns, values))
+        if not all(math.isfinite(value) for value in values):
+            raise AssertionError("handoff contains non-finite values")
+        if row["status"] != 0 or row["sigma"] != 1:
+            raise AssertionError(f"unexpected status/sign: {row}")
+        if not math.isclose(row["H0"], 1.0, rel_tol=0.0, abs_tol=1e-14):
+            raise AssertionError(f"unexpected H0: {row['H0']}")
+        if row["J_perp"] <= 0.0 or row["psi_edge"] == row["psi_axis"]:
+            raise AssertionError(f"invalid invariants: {row}")
+        if abs(row["phi_elec"]) > 1e-12 or row["v0_cm_s"] <= 0.0:
+            raise AssertionError(f"invalid normalization metadata: {row}")
+
+
+def require_frequency_output(path: Path, expected_rows: int) -> None:
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    expected_header = "# R_start[cm] rho_pol omega_b[1/s] omega_phi[1/s] taub delphi ierr"
+    if lines[0] != expected_header:
+        raise AssertionError(f"unexpected frequency header: {lines[0]}")
+    if len(lines) != expected_rows + 1:
+        raise AssertionError(f"unexpected frequency row count: {len(lines) - 1}")
+    if any(len(line.split()) != 7 for line in lines[1:]):
+        raise AssertionError("frequency output schema changed")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: test_invariant_handoff.py <potato.x> <fixture-dir>")
+        return 2
+
+    executable = Path(sys.argv[1]).resolve()
+    fixture = Path(sys.argv[2]).resolve()
+    with tempfile.TemporaryDirectory(prefix="potato-invariants-") as tmp:
+        work = Path(tmp)
+        for name in INPUT_NAMES:
+            shutil.copy(fixture / name, work / name)
+        zero_electric_potential(work / "profile_poly.in")
+        write_input(work / "potato.in")
+        subprocess.run([executable], cwd=work, check=True, timeout=120)
+        columns, rows = read_handoff(work / "potato_invariants.dat")
+        require_valid_rows(columns, rows)
+        if len(rows) != 1:
+            raise AssertionError(f"unexpected single-orbit row count: {len(rows)}")
+
+        write_input(work / "potato.in", itest_type=5, scan=True)
+        subprocess.run([executable], cwd=work, check=True, timeout=120)
+        columns, rows = read_handoff(work / "potato_invariants.dat")
+        require_valid_rows(columns, rows)
+        if [row[0] for row in rows] != [1.0, 2.0, 3.0]:
+            raise AssertionError("frequency handoff identifiers changed")
+        require_frequency_output(work / "freq_scan.dat", 3)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a side-effect-free POTATO invariant producer for `H0`, `J_perp`, and raw `psi_star`
- write a versioned `potato_invariants.dat` from single-orbit and frequency-scan modes without changing existing output schemas
- document cgs flux, reference-velocity, electrostatic-potential, time, and topology conventions
- add unit and single/scan integration coverage

Closes #73.

## Validation
- Release POTATO build succeeds
- all 6 configured POTATO tests pass (2 fixture-dependent tests skip as designed)
- `fo fmt --check` and `fo lint` pass
- repository-level `fo check` remains blocked by the pre-existing `neort_setup_at_s`/`neort_lib` mismatch outside POTATO
- benchmark sibling end-to-end test reconstructs the reactor-size orbit in SIMPLE and matches both frequencies within 2%