### PR TITLE
Make velocity-space upper cutoff configurable

### DIFF
--- a/doc/library.md
+++ b/doc/library.md
@@ -137,6 +137,7 @@ type :: config_t
     real(8) :: epsmn, mph
     real(8) :: bfac, efac
     real(8) :: M_t, vth
+    real(8) :: vmax_over_vth
     integer :: m0, inp_swi, vsteps, mth_max_abs, log_level
     logical :: comptorque, magdrift, nopassing, noshear, pertfile, nonlin
 end type
@@ -144,6 +145,10 @@ end type
 
 `mth_max_abs=-1` preserves the historical q-dependent harmonic range. A
 nonnegative value selects the exact symmetric range `-mth_max_abs:mth_max_abs`.
+
+`vmax_over_vth=3.0` sets the upper velocity-space cutoff in units of the
+thermal velocity. The default preserves the historical hard-coded bound; a
+larger value captures more of a far-tail resonance. It must be positive.
 
 ### transport_data_t
 

--- a/doc/running.md
+++ b/doc/running.md
@@ -63,6 +63,7 @@ The parameter file is a Fortran namelist `&params` with the fields listed below.
 | `inp_swi` | Boozer input switch. | Passed to `do_magfie`. |
 | `vsteps` | Number of velocity grid points. | Set to `0` for adaptive quadrature. |
 | `mth_max_abs` | Maximum absolute orbit-resonance harmonic. | Default `-1` keeps the historical `±ceil(2\|mph q\|)` range; `0` selects only `mth=0`. |
+| `vmax_over_vth` | Upper velocity-space cutoff in units of `vth`. | Default `3.0` keeps the historical hard-coded bound; must be positive. |
 | `log_level` | Verbosity level for the logger. | Defined in `src/logging.f90`. |
 
 ### Magnetic field data

--- a/src/config.f90
+++ b/src/config.f90
@@ -23,6 +23,7 @@ module neort_config
         integer :: inp_swi = 0  ! input switch for Boozer file
         integer :: vsteps = 0  ! integration steps in velocity space
         integer :: mth_max_abs = -1 ! negative: historical q-dependent range
+        real(dp) :: vmax_over_vth = 3.0_dp  ! upper velocity cutoff / vth
         integer :: log_level = 0  ! how much to log
         !*! will be overwritten if using splines from plasma.in and profile.in files
     end type config_t
@@ -35,7 +36,7 @@ contains
         use do_magfie_pert_mod, only: mph, set_mph
         use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, nonlin, efac
         use logger, only: set_log_level
-        use neort, only: vsteps, mth_max_abs
+        use neort, only: vsteps, mth_max_abs, vmax_over_vth
         use neort_orbit, only: noshear
         use neort_profiles, only: M_t, vth
         use util, only: qe, mu, qi, mi
@@ -60,6 +61,8 @@ contains
         vsteps = config%vsteps
         if (config%mth_max_abs < -1) error stop "mth_max_abs must be -1 or nonnegative"
         mth_max_abs = config%mth_max_abs
+        if (config%vmax_over_vth <= 0.0_dp) error stop "vmax_over_vth must be positive"
+        vmax_over_vth = config%vmax_over_vth
 
         qi = config%qs * qe
         mi = config%ms * mu
@@ -73,7 +76,7 @@ contains
         use do_magfie_pert_mod, only: mph, set_mph
         use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, nonlin, efac
         use logger, only: set_log_level
-        use neort, only: vsteps, mth_max_abs
+        use neort, only: vsteps, mth_max_abs, vmax_over_vth
         use neort_orbit, only: noshear
         use neort_profiles, only: M_t, vth
         use util, only: qe, mu, qi, mi
@@ -84,14 +87,16 @@ contains
 
         namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, magdrift, &
             nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, vsteps, mth_max_abs, &
-            log_level
+            vmax_over_vth, log_level
 
         mth_max_abs = -1
+        vmax_over_vth = 3.0_dp
         open (unit=9, file=config_file, status="old", form="formatted")
         read (9, nml=params)
         close (unit=9)
 
         if (mth_max_abs < -1) error stop "mth_max_abs must be -1 or nonnegative"
+        if (vmax_over_vth <= 0.0_dp) error stop "vmax_over_vth must be positive"
 
         M_t = M_t * efac / bfac
         qi = qs * qe

--- a/src/neort.f90
+++ b/src/neort.f90
@@ -18,6 +18,10 @@ module neort
     ! preserves the historical q-dependent automatic range.
     integer :: mth_max_abs = -1
 
+    ! Upper velocity-space cutoff in units of the thermal velocity. Default 3.0
+    ! preserves the historical hard-coded bound and bit-reproducibility.
+    real(dp) :: vmax_over_vth = 3.0_dp
+
 contains
 
     pure subroutine harmonic_bounds(mph_value, q_value, max_abs, mth_min, mth_max)
@@ -245,7 +249,7 @@ contains
         Trest = 0.0_dp
 
         vminp = 1.0e-6_dp * vth
-        vmaxp = 3.0_dp * vth
+        vmaxp = vmax_over_vth * vth
         vmint = vminp
         vmaxt = vmaxp
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,11 @@ add_test(NAME test_harmonic_bounds
     COMMAND test_harmonic_bounds.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_test(NAME test_vmax_over_vth
+    COMMAND test_vmax_over_vth.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 set_tests_properties(test_chartmap_input PROPERTIES
     ENVIRONMENT
         "CHARTMAP_FILE=${CMAKE_CURRENT_SOURCE_DIR}/fixtures/circ_chartmap.nc;BC_FILE=${CMAKE_SOURCE_DIR}/examples/circ.bc"

--- a/test/test_vmax_over_vth.f90
+++ b/test/test_vmax_over_vth.f90
@@ -1,0 +1,51 @@
+program test_vmax_over_vth
+    use iso_fortran_env, only: dp => real64
+    use neort, only: configured => vmax_over_vth
+    use neort_config, only: config_t, set_config, read_and_set_config
+
+    implicit none
+
+    type(config_t) :: config
+    integer :: unit
+
+    ! config_t default preserves the historical hard-coded cutoff
+    if (config%vmax_over_vth /= 3.0_dp) error stop "config_t default changed"
+
+    ! set_config transfers an explicit value to the module variable
+    config%vmax_over_vth = 4.5_dp
+    call set_config(config)
+    if (configured /= 4.5_dp) error stop "config_t did not set vmax_over_vth"
+
+    config = config_t()
+    call set_config(config)
+    if (configured /= 3.0_dp) error stop "config_t default not restored"
+
+    ! namelist parsing picks up an explicit value
+    call write_namelist("vmax.in", "    vmax_over_vth = 5.0")
+    call read_and_set_config("vmax.in")
+    if (configured /= 5.0_dp) error stop "namelist value not read"
+
+    ! namelist parsing falls back to the default when the field is absent
+    call write_namelist("vmax.in", "")
+    call read_and_set_config("vmax.in")
+    if (configured /= 3.0_dp) error stop "namelist default changed"
+
+    open (newunit=unit, file="vmax.in", status="old")
+    close (unit, status="delete")
+
+contains
+
+    subroutine write_namelist(path, extra_line)
+        character(len=*), intent(in) :: path, extra_line
+        integer :: u
+
+        open (newunit=u, file=path, status="replace", form="formatted")
+        write (u, '(A)') "&params"
+        write (u, '(A)') "    qs = 1.0"
+        write (u, '(A)') "    ms = 2.0"
+        if (len_trim(extra_line) > 0) write (u, '(A)') trim(extra_line)
+        write (u, '(A)') "/"
+        close (u)
+    end subroutine write_namelist
+
+end program test_vmax_over_vth


### PR DESCRIPTION
## Motivation

The upper velocity-space bound was hard-coded at `3 vth` in
`compute_transport_harmonic`. This silently truncates the far-tail
(`E/T >= 7.5`) portion of near-deeply-trapped resonances. For the ITER TC24
`ell=0` resonance at `s_tor=0.04`, roughly 38% of the resonant weight lives
above `u = 3` and is discarded, and the reported radial extent of the feature
is set by where the resonance threshold `u_c(s)` crosses the arbitrary `3.0`
cutoff rather than by physics. A non-configurable cutoff also prevents
cross-code comparisons from stating their energy-grid domain.

## Change

Add a `vmax_over_vth` control (default `3.0`) following the existing
`mth_max_abs` pattern:

- `config_t` field with default `3.0`;
- transfer to the `neort` module variable in both `set_config` and
  `read_and_set_config`;
- `&params` namelist entry;
- positivity validation (`error stop` if `<= 0`);
- used for both `vmaxp` and `vmaxt`.

Default `3.0` preserves the historical bound and bit-reproducibility of
archived runs; the in-tree `ripple_plateau` benchmark is unchanged.

## Tests

New `test_vmax_over_vth` covers the `config_t` default, `set_config` value
transfer, and namelist parsing of both an explicit value and the omitted
default. Full `fo check` green (9/9 ctest); `ripple_plateau` passes.

Docs updated in `doc/library.md` and `doc/running.md`.