### PR TITLE
Harden driftorbit_root failure paths and resonance loop control

### DIFF
--- a/src/diag/diag_bounce_debug.f90
+++ b/src/diag/diag_bounce_debug.f90
@@ -108,6 +108,7 @@ contains
       if (nroots > 0) then
         do kr = 1, nroots
           eta_res = driftorbit_root(v, 1.0e-8_dp*abs(Om_tE), roots(kr,1), roots(kr,2))
+          if (eta_res(1) < 0.0_dp) cycle  ! bracket-failure sentinel
           eta = eta_res(1)
           call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
           taub = 2.0_dp*acos(-1.0_dp)/abs(Omth)

--- a/src/diag/diag_bounce_nonlin.f90
+++ b/src/diag/diag_bounce_nonlin.f90
@@ -98,7 +98,8 @@ contains
 
         ! Print simple stats
         do j = 1, size(ux_list)
-            write(*,'(A,F5.2,A,1x,ES12.4,1x,ES12.4)') 'ux=', ux_list(j), ' min/max:', minval(att_nonlin(:,j)), maxval(att_nonlin(:,j))
+            write(*,'(A,F5.2,A,1x,ES12.4,1x,ES12.4)') 'ux=', ux_list(j), &
+                ' min/max:', minval(att_nonlin(:,j)), maxval(att_nonlin(:,j))
         end do
 
     end subroutine run_bounce_nonlin_diag

--- a/src/diag/diag_contrib_map.f90
+++ b/src/diag/diag_contrib_map.f90
@@ -156,6 +156,7 @@ contains
       if (nroots == 0) return
       do kr = 1, nroots
         eta_res = driftorbit_root(v, 1.0e-8_dp*abs(Om_tE), roots(kr, 1), roots(kr, 2))
+        if (eta_res(1) < 0.0_dp) cycle  ! bracket-failure sentinel
         eta = eta_res(1)
 
         v_eff = max(v, 1.0e-8_dp*vth)

--- a/src/resonance.f90
+++ b/src/resonance.f90
@@ -56,7 +56,7 @@ contains
 
         real(dp) :: driftorbit_root(2)
         real(dp), intent(in) :: v, tol, eta_min, eta_max
-        real(dp) :: res, res_old, eta0, eta_old
+        real(dp) :: res, res_old, eta_old
         real(dp) :: Omph, dOmphdv, dOmphdeta
         real(dp) :: Omth, dOmthdv, dOmthdeta
         integer :: maxit, k, state
@@ -71,7 +71,6 @@ contains
 
         maxit = 100
         state = -2
-        eta0 = eta
         eta_old = 0.0_dp
         res = 0.0_dp
 
@@ -99,6 +98,12 @@ contains
                   "driftorbit_root couldn't bracket 0 for v/vth = ", v / vth, LF // &
                   TAB // "etamin = ", etamin2, ", etamax = ", etamax2
             call warning(msg)
+            ! Defined sentinel: eta is a non-negative pitch parameter, so a
+            ! negative root position flags "no resonance in this bracket".
+            ! eta_res(2) is set to a defined non-NaN value; callers must
+            ! detect the sentinel (eta_res(1) < 0) and skip this bracket.
+            driftorbit_root(1) = -1.0_dp
+            driftorbit_root(2) = 0.0_dp
             return
         end if
 
@@ -136,6 +141,5 @@ contains
                   TAB // "tol = ", tol
             call warning(msg)
         end if
-        eta = eta0
     end function driftorbit_root
 end module neort_resonance

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -93,9 +93,12 @@ contains
         do ku = 1, vsteps
             v = ux * vth
             call driftorbit_coarse(v, etamin, etamax, roots, nroots)
-            if (nroots == 0) continue
+            ! No explicit nroots==0 guard: the do-loop below is empty when
+            ! nroots==0, and a bare `cycle` here would skip the trailing
+            ! `ux = ux + du` velocity-grid increment and stall the sweep.
             do kr = 1, nroots
                 eta_res = driftorbit_root(v, 1.0e-8_dp * abs(Om_tE), roots(kr, 1), roots(kr, 2))
+                if (eta_res(1) < 0.0_dp) cycle  ! bracket-failure sentinel
                 eta = eta_res(1)
 
                 call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,11 @@ add_test(NAME test_vmax_over_vth
     COMMAND test_vmax_over_vth.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_test(NAME test_resonance_bracket
+    COMMAND ${CMAKE_BINARY_DIR}/test_resonance_bracket.x
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/base
+)
 set_tests_properties(test_chartmap_input PROPERTIES
     ENVIRONMENT
         "CHARTMAP_FILE=${CMAKE_CURRENT_SOURCE_DIR}/fixtures/circ_chartmap.nc;BC_FILE=${CMAKE_SOURCE_DIR}/examples/circ.bc"

--- a/test/test_resonance_bracket.f90
+++ b/test/test_resonance_bracket.f90
@@ -1,0 +1,43 @@
+program test_resonance_bracket
+    ! Regression test for the driftorbit_root bracket-failure sentinel.
+    !
+    ! When driftorbit_root is handed an eta bracket that contains no
+    ! resonance (driftorbit_nroot == 0), it must return a *defined* result
+    ! rather than leaving driftorbit_root(1:2) unassigned. The contract is a
+    ! negative sentinel in eta_res(1) (eta is a non-negative pitch parameter)
+    ! and a defined eta_res(2). The production caller only ever passes
+    ! sign-change brackets, so this path is inactive for production inputs;
+    ! this test pins the defined failure behaviour directly.
+    use iso_fortran_env, only: dp => real64
+    use logger, only: set_log_level
+    use neort_lib, only: neort_init, neort_prepare_splines, neort_setup_at_s
+    use driftorbit, only: mth, vth, etatp, etadt
+    use neort_resonance, only: driftorbit_root
+
+    implicit none
+
+    real(dp) :: eta_res(2), eta_mid, v
+
+    call set_log_level(-1)  ! silence the expected bracket-failure warning
+
+    call neort_init("driftorbit.in", "in_file")
+    call neort_prepare_splines("plasma.in", "profile.in")
+    call neort_setup_at_s(0.5_dp)
+
+    mth = 1
+    v = vth
+
+    ! Degenerate (zero-width) bracket inside the trapped domain: no sign
+    ! change, so driftorbit_nroot returns 0 and the failure path is taken.
+    eta_mid = 0.5_dp*(etatp + etadt)
+    eta_res = driftorbit_root(v, 1.0e-8_dp, eta_mid, eta_mid)
+
+    if (.not. (eta_res(1) < 0.0_dp)) then
+        error stop "bracket failure must return a negative eta sentinel"
+    end if
+    if (eta_res(2) /= 0.0_dp) then
+        error stop "bracket failure must return a defined eta_res(2)"
+    end if
+
+    print *, "test_resonance_bracket PASSED"
+end program test_resonance_bracket


### PR DESCRIPTION
## Summary

Fixes latent robustness defects in the resonance root finder and the transport
velocity sweep, found during a hostile audit of the resonance path. **None of
these change production numerics** — see verification below.

## Changes

- **`src/resonance.f90` — undefined bracket-failure result.** When the eta
  bracket handed to `driftorbit_root` contains no sign change
  (`driftorbit_nroot == 0`), the function warned and returned with its result
  array `driftorbit_root(1:2)` never assigned. Callers then divided by
  `abs(eta_res(2))` on undefined memory. It now returns a defined sentinel
  (`eta_res(1) = -1`, a value no physical pitch parameter can take;
  `eta_res(2) = 0`). All three callers (`transport`, `diag_bounce_debug`,
  `diag_contrib_map`) detect the sentinel and skip the bracket.
- **`src/resonance.f90` — uninitialized `eta0`.** Removed the dead `eta0` local:
  `eta0 = eta` read `eta` before it was assigned, and the paired `eta = eta0`
  restore wrote to a local that is never read again.
- **`src/transport.f90` — no-op `continue`.** `if (nroots == 0) continue` is not
  loop control (a bare `continue` is a no-op). A literal `cycle` would be a
  regression here: it skips the trailing `ux = ux + du` velocity-grid increment
  and stalls the sweep. The following `do kr = 1, nroots` loop is already empty
  when `nroots == 0`, so the correct, numerically-inert fix is to remove the
  misleading line.
- **Test.** `test_resonance_bracket` pins the bracket-failure sentinel by handing
  `driftorbit_root` a zero-width (no-root) bracket and asserting the defined
  return contract.

## Verification

- `fo` build/lint clean; 9 registered tests pass; `ripple_plateau` benchmark
  passes.
- **Production numerics unchanged (bit-identical).** `neo_rt.x` output on the
  `ripple_plateau` case is byte-identical (matching SHA256) between this branch
  and a pristine-`main` build.

## Incidental CI fix

The `NEO-RT` Debug/Fast workflow was already red on `main` (a14d086, 3889245):
`src/diag/diag_bounce_nonlin.f90:101` was 134 chars and the Debug build compiles
with `-Werror=line-truncation`, truncating the line mid-expression. This PR wraps
that `write` across two lines (no behavior change) so the pipeline is green.
