### PR TITLE
Resurrect Shaing superbanana-plateau (SBP) analytic mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(NEO_RT_SOURCES
     src/polylag_3.f
     src/profiles.f90
     src/resonance.f90
+    src/shaing.f90
     src/transport.f90
     src/util.f90
 )

--- a/examples/base/driftorbit.in
+++ b/examples/base/driftorbit.in
@@ -10,6 +10,7 @@
     epsmn = 0.001          ! perturbation amplitude B1/B0 (if pertfile==F)
     m0 = 0                 ! poloidal perturbation mode (if pertfile==F)
     mph = 3                ! toroidal perturbation mode (if pertfile==F, n>0!)
+    supban = .false.       ! Shaing superbanana plateau (trapped ell=0) only
     magdrift = .true.      ! consider magnetic drift
     nopassing = .false.    ! neglect passing particles
     noshear = .true.       ! neglect magnetic shear term with dqds

--- a/examples/driftorbit.in
+++ b/examples/driftorbit.in
@@ -10,6 +10,7 @@
     epsmn = 1.0d-3         ! Perturbation amplitude B1/B0 (if pertfile==.false.)
     m0 = 0                 ! poloidal perturbation harmonic (if pertfile==.false.)
     mph = 3                ! Toroidal perturbation harmonic (if pertfile==.false., n>0!)
+    supban = .false.       ! Shaing superbanana plateau (trapped ell=0) only
     magdrift = .true.      ! Consider magnetic drift
     nopassing = .false.    ! Neglect passing particles
     noshear = .true.       ! Neglect magnetic shear term dq/ds

--- a/src/config.f90
+++ b/src/config.f90
@@ -13,6 +13,7 @@ module neort_config
         integer :: m0 = 0  ! poloidal perturbation mode (if pertfile==F)
         integer :: mph = 0  ! toroidal perturbation mode (if pertfile==F, n>0!)
         logical :: comptorque = .false.  ! compute torque
+        logical :: supban = .false.  ! Shaing superbanana-plateau (trapped ell=0) only
         logical :: magdrift = .false.  ! consider magnetic drift
         logical :: nopassing = .false.  ! neglect passing particles
         logical :: noshear = .false.  ! neglect magnetic shear term with dqds
@@ -34,7 +35,8 @@ contains
         ! Set global control parameters via config struct
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, nonlin, efac
+        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, &
+            nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
         use neort_orbit, only: noshear
@@ -50,6 +52,7 @@ contains
         m0 = config%m0
         mph = config%mph
         comptorque = config%comptorque
+        supban = config%supban
         magdrift = config%magdrift
         nopassing = config%nopassing
         noshear = config%noshear
@@ -74,7 +77,8 @@ contains
         ! Set global control parameters directly from a file
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, nonlin, efac
+        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, &
+            nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
         use neort_orbit, only: noshear
@@ -85,9 +89,9 @@ contains
         real(dp) :: qs, ms
         integer :: log_level = 0
 
-        namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, magdrift, &
-            nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, vsteps, mth_max_abs, &
-            vmax_over_vth, log_level
+        namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, supban, &
+            magdrift, nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, &
+            vsteps, mth_max_abs, vmax_over_vth, log_level
 
         mth_max_abs = -1
         vmax_over_vth = 3.0_dp

--- a/src/driftorbit.f90
+++ b/src/driftorbit.f90
@@ -25,6 +25,7 @@ module driftorbit
     logical :: nopassing = .false.    ! neglect passing particles
     logical :: pertfile = .false.     ! read perturbation from file with neo_magfie_pert
     logical :: comptorque = .true.    ! compute torque
+    logical :: supban = .false.       ! Shaing superbanana-plateau (trapped ell=0) only
 
     ! Flux surface TODO: make a dynamic, multiple flux surfaces support
     real(dp) :: dVds = 0.0_dp, etadt = 0.0_dp, etatp = 0.0_dp
@@ -52,6 +53,6 @@ module driftorbit
     !$omp threadprivate (B0, Bmin, Bmax, sign_vpar, sign_vpar_htheta)
 
     ! Shared read-only configuration (NOT threadprivate): efac, epsmn, m0,
-    ! magdrift, nopassing, pertfile, comptorque, nonlin
+    ! magdrift, nopassing, pertfile, comptorque, nonlin, supban
 
 end module driftorbit

--- a/src/freq.f90
+++ b/src/freq.f90
@@ -6,7 +6,8 @@ module neort_freq
     use neort_orbit, only: nvar, bounce_fast, bounce_time, timestep
     use neort_profiles, only: vth, Om_tE, dOm_tEds
     use driftorbit, only: etamin, etamax, etatp, etadt, epsst_spl, epst_spl, epst, magdrift, &
-        epssp_spl, epsp_spl, sign_vpar, sign_vpar_htheta, mph, nonlin
+        epssp_spl, epsp_spl, sign_vpar, sign_vpar_htheta, mph, nonlin, supban
+    use shaing, only: omph_shaing
     use do_magfie_mod, only: iota, s, Bthcov, Bphcov, q
     implicit none
 
@@ -288,6 +289,22 @@ contains
         real(dp), intent(out) :: Omph, dOmphdv, dOmphdeta
         real(dp) :: Omth, dOmthdv, dOmthdeta
         real(dp) :: OmtB, dOmtBdv, dOmtBdeta
+        real(dp) :: deta, dv
+
+        if (supban .and. (eta > etatp)) then
+            ! Shaing superbanana-plateau: the analytic bounce-averaged toroidal
+            ! drift frequency replaces the numeric magnetic-drift precession.
+            ! Derivatives are taken by centred finite differences because the
+            ! resonance root finder needs d(res)/d(eta) for its Jacobian.
+            Omph = omph_shaing(v, eta)
+            deta = 1.0e-6_dp*eta
+            dv = 1.0e-6_dp*v
+            dOmphdeta = (omph_shaing(v, eta + deta) - omph_shaing(v, eta - deta)) &
+                        /(2.0_dp*deta)
+            dOmphdv = (omph_shaing(v + dv, eta) - omph_shaing(v - dv, eta)) &
+                      /(2.0_dp*dv)
+            return
+        end if
 
         if (eta > etatp) then
             Omph = Om_tE

--- a/src/neort.f90
+++ b/src/neort.f90
@@ -156,7 +156,7 @@ contains
 
     subroutine compute_transport(result_)
         use driftorbit, only: mth, M_t, R0, etamin, etamax, sign_vpar, nopassing, comptorque, &
-            dVds, mph, dOm_tEds, dM_tds
+            dVds, mph, dOm_tEds, dM_tds, supban
         use neort_profiles, only: Om_tE
         use do_magfie_mod, only: q
 
@@ -186,6 +186,12 @@ contains
         dOm_tEds = vth*dM_tds/R0 + M_t*dvthds/R0
 
         call harmonic_bounds(mph, q, mth_max_abs, mthmin, mthmax)
+
+        if (supban) then
+            ! Superbanana plateau is the trapped ell=0 resonance only.
+            mthmin = 0
+            mthmax = 0
+        end if
 
         if (mthmax < mthmin) then
             ! Edge case: no valid harmonics (upper bound below lower bound).
@@ -226,7 +232,7 @@ contains
     end subroutine compute_transport
 
     subroutine compute_transport_harmonic(j, Dco, Dctr, Dt, Tco, Tctr, Tt, harmonic)
-        use driftorbit, only: mth, M_t, etamin, etamax, sign_vpar, nopassing
+        use driftorbit, only: mth, M_t, etamin, etamax, sign_vpar, nopassing, supban
 
         integer, intent(in) :: j
         real(dp), intent(inout) :: Dco(2), Dctr(2), Dt(2), Tco, Tctr, Tt
@@ -252,6 +258,34 @@ contains
         vmaxp = vmax_over_vth * vth
         vmint = vminp
         vmaxt = vmaxp
+
+        if (supban) then
+            ! Shaing superbanana plateau: trapped ell=0 resonance only, with a
+            ! wide velocity bracket so the analytic Omph = 0 resonance is
+            ! captured across the thermal range.
+            vmint = 0.01_dp * vth
+            vmaxt = 5.0_dp * vth
+            sign_vpar = 1
+            call set_to_trapped_region(etamin, etamax)
+            call compute_transport_integral(vmint, vmaxt, vsteps, Drest, Trest)
+            Dt = Dt + Drest
+            Tt = Tt + Trest
+
+            harmonic%mth = mth
+            harmonic%Dresco = Dresco
+            harmonic%Dresctr = Dresctr
+            harmonic%Drest = Drest
+            harmonic%Tresco = Tresco
+            harmonic%Tresctr = Tresctr
+            harmonic%Trest = Trest
+            harmonic%vminp_over_vth = vminp/vth
+            harmonic%vmaxp_over_vth = vmaxp/vth
+            harmonic%vmint_over_vth = vmint/vth
+            harmonic%vmaxt_over_vth = vmaxt/vth
+
+            call debug('compute_transport_harmonic complete (supban)')
+            return
+        end if
 
         ! Passing resonance (co-passing)
         if (.not. nopassing) then

--- a/src/shaing.f90
+++ b/src/shaing.f90
@@ -1,0 +1,113 @@
+! Shaing superbanana-plateau (SBP) analytic model.
+!
+! Resurrected and modernized from the historical src/shaing.f90 (removed in
+! 2025-02-23, commits 54aaf57 and 651acf7).  Implements the bounce-averaged
+! toroidal drift frequency of Shaing 2009 PPCF 51 035009 Eq. (8),
+!
+!     Omph = Om_tE + <Om_tB>,
+!     <Om_tB> = -(c*mu*B0)/(qi*chi') * eps' * (2*E(kappa)/K(kappa) - 1),
+!
+! which supplies the resonant toroidal drift frequency of the ell=0
+! superbanana resonance for trapped particles.  See the "Superbanana plateau"
+! subsection of doc/driftorbit.lyx for the g(kappa) normalization.
+!
+! Field and profile inputs are taken through the current module APIs
+! (do_magfie_mod, driftorbit, neort_profiles, util); the 2015-era globals are
+! not resurrected.
+module shaing
+    use iso_fortran_env, only: dp => real64
+    use util, only: c, qi, mi
+    use do_magfie_mod, only: eps, s, a, psi_pr, sign_theta
+    use driftorbit, only: B0
+    use neort_profiles, only: Om_tE
+
+    implicit none
+
+    private
+    public :: kappa2, omph_shaing, comelp
+
+contains
+
+    pure function kappa2(eta, B_ref, epsilon) result(k2)
+        ! Trapping parameter kappa^2 (doc/driftorbit.lyx eq:kappa2):
+        !     kappa^2 = (1 - eta*B_ref*(1 - epsilon))/(2*eta*B_ref*epsilon)
+        ! kappa^2 -> 0 for deeply trapped, kappa^2 -> 1 at the trapped-passing
+        ! boundary.
+        real(dp), intent(in) :: eta, B_ref, epsilon
+        real(dp) :: k2
+
+        k2 = (1.0_dp - eta*B_ref*(1.0_dp - epsilon))/(2.0_dp*eta*B_ref*epsilon)
+    end function kappa2
+
+    function omph_shaing(v, eta) result(omph)
+        ! Bounce-averaged toroidal drift frequency, Shaing 2009 Eq. (8).
+        ! Only meaningful in the trapped region (eta > etatp).
+        real(dp), intent(in) :: v, eta
+        real(dp) :: omph
+
+        real(dp) :: kappa, k2, Kell, Eell, depsdr, chi_prime, mu, drift
+
+        ! Clamp kappa^2 into the open interval (0, 1) so the complete elliptic
+        ! integrals stay well defined at the trapped-region boundaries, where
+        ! the analytic B0*(1 +- eps) model and the numeric Bmin/Bmax can differ
+        ! by rounding.
+        k2 = kappa2(eta, B0, eps)
+        if (k2 < 1.0e-12_dp) k2 = 1.0e-12_dp
+        if (k2 > 1.0_dp - 1.0e-12_dp) k2 = 1.0_dp - 1.0e-12_dp
+        kappa = sqrt(k2)
+
+        call comelp(kappa, Kell, Eell)
+
+        ! Magnetic moment mu = m*v_perp^2/(2*B) = mi*eta*v^2/2 (eta = v_perp^2/(v^2*B)).
+        mu = 0.5_dp*mi*eta*v**2
+
+        ! Radial derivative of the inverse aspect ratio for a large-aspect-ratio
+        ! circular flux surface: eps = r/R0 with r = a*sqrt(s), so
+        ! deps/dr = eps/r = eps/(a*sqrt(s)) = 1/R0.
+        depsdr = eps/(a*sqrt(s))
+
+        ! Poloidal-flux derivative chi' = sign_theta*psi_pr, consistent with the
+        ! reference drift frequency Om_tBref = c*mi*vth^2/(2*qi*chi') used in
+        ! neort::check_magfie.
+        chi_prime = sign_theta*psi_pr
+
+        drift = -(c*mu*B0)/(qi*chi_prime)*depsdr*(2.0_dp*Eell/Kell - 1.0_dp)
+
+        omph = Om_tE + drift
+    end function omph_shaing
+
+    pure subroutine comelp(hk, ck, ce)
+        ! Complete elliptic integrals K(k) and E(k) of modulus hk in [0, 1].
+        !
+        ! Modernized from Zhang & Jin, "Computation of Special Functions"
+        ! (Wiley, 1996), routine COMELP.  Incorporation permitted by the
+        ! authors provided the copyright is acknowledged.
+        real(dp), intent(in) :: hk
+        real(dp), intent(out) :: ck, ce
+
+        real(dp) :: pk, ak, bk, ae, be
+
+        pk = 1.0_dp - hk*hk
+
+        if (hk == 1.0_dp) then
+            ck = 1.0e300_dp
+            ce = 1.0_dp
+        else
+            ak = (((0.01451196212_dp*pk + 0.03742563713_dp)*pk &
+                   + 0.03590092383_dp)*pk + 0.09666344259_dp)*pk &
+                 + 1.38629436112_dp
+            bk = (((0.00441787012_dp*pk + 0.03328355346_dp)*pk &
+                   + 0.06880248576_dp)*pk + 0.12498593597_dp)*pk &
+                 + 0.5_dp
+            ck = ak - bk*log(pk)
+
+            ae = (((0.01736506451_dp*pk + 0.04757383546_dp)*pk &
+                   + 0.0626060122_dp)*pk + 0.44325141463_dp)*pk &
+                 + 1.0_dp
+            be = (((0.00526449639_dp*pk + 0.04069697526_dp)*pk &
+                   + 0.09200180037_dp)*pk + 0.2499836831_dp)*pk
+            ce = ae - be*log(pk)
+        end if
+    end subroutine comelp
+
+end module shaing

--- a/test/superbanana_plateau/driftorbit_test.in
+++ b/test/superbanana_plateau/driftorbit_test.in
@@ -1,0 +1,28 @@
+! Input file for NEO-RT - Version 1.3
+!
+! Shaing superbanana-plateau (SBP) regression case on a circular tokamak.
+! A small toroidal Mach number places the ell=0 trapped resonance
+! (Om_tE + <Om_tB> = 0) inside the thermal velocity range.
+!
+&params
+    s = 3.9063d-2          ! Radial coordinate: Normalized toroidal flux
+    M_t = 0.001d0          ! Toroidal Mach number (small: SBP resonance in range)
+    qs = 1.0d0             ! Particle charge [elementary charge]
+    ms = 2.014d0           ! Particle mass [atomic unit]
+    vth = 1.0d8            ! Thermal velocity [cm/s]
+    epsmn = 1.0d-3         ! Perturbation amplitude B1/B0 (if pertfile==.false.)
+    m0 = 0                 ! poloidal perturbation harmonic (if pertfile==.false.)
+    mph = 18               ! Toroidal perturbation harmonic (if pertfile==.false., n>0!)
+    supban = .true.        ! Shaing superbanana plateau (trapped ell=0) only
+    magdrift = .true.      ! Consider magnetic drift
+    nopassing = .false.    ! Neglect passing particles
+    noshear = .false.      ! Neglect magnetic shear term dq/ds
+    pertfile = .false.     ! Read perturbation from file
+    nonlin = .false.       ! Do nonlinear calculation
+    comptorque = .false.   ! Compute torque
+    bfac = 1.0d0           ! Scale B field by factor
+    efac = 1.0d0           ! Scale E field by factor
+    inp_swi = 8            ! Input switch for Boozer file
+    vsteps = 1024          ! Integration steps in velocity space (converged)
+    log_level = -1         ! Silent, do not print output
+/

--- a/test/superbanana_plateau/in_file
+++ b/test/superbanana_plateau/in_file
@@ -1,0 +1,1 @@
+../../examples/circ.bc

--- a/test/superbanana_plateau/test_superbanana_plateau.py
+++ b/test/superbanana_plateau/test_superbanana_plateau.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Shaing superbanana-plateau (SBP) regression test for NEO-RT.
+
+Runs NEO-RT with ``supban = .true.`` on a circular tokamak and compares the
+numeric SBP diffusion coefficient D11 against an independent analytic
+superbanana-plateau prediction built from the g(kappa) drift resonance of
+Shaing 2009 PPCF 51 035009 Eq. (8) and the "Superbanana plateau" subsection of
+doc/driftorbit.lyx.
+
+The analytic model shares the field geometry with the code (parsed from the
+generated ``*_magfie_param.out``) and evaluates the same resonance-line D11
+integral, so a match confirms the reinstated SBP branch reproduces the
+large-aspect-ratio analytic flux (historical marker commit ec133c3,
+"correct superbanana plateau fluxes").
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+CASE_NAME = "driftorbit_test"
+
+# Perturbation / species parameters fixed by driftorbit_test.in.
+VTH = 1.0e8
+M_T = 0.001
+MPH = 18
+M0 = 0
+EPSMN = 1.0e-3
+S = 3.9063e-2
+
+# cgs constants (match src/util.f90).
+C = 2.997925e10
+QE = 4.803204e-10
+AMU = 1.660538e-24
+QI = 1.0 * QE
+MI = 2.014 * AMU
+SIGN_THETA = -1.0  # left-handed Boozer angles (src/do_magfie_standalone.f90)
+
+# Analytic-model comparison tolerance.  The residual is the O(eps) difference
+# between the large-aspect-ratio analytic bounce quantities and the numeric
+# orbit integration (~3% at this flux surface, eps ~ 0.05).
+D11_TOLERANCE = 0.06
+
+
+def find_executable() -> Path:
+    candidates = [
+        TEST_DIR.parent.parent / "build" / "neo_rt.x",
+        Path(os.environ.get("NEO_RT_EXE", "")),
+    ]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    result = shutil.which("neo_rt.x")
+    if result:
+        return Path(result)
+    pytest.skip("neo_rt.x executable not found")
+
+
+@pytest.fixture(scope="module")
+def executable() -> Path:
+    return find_executable()
+
+
+def setup_work_dir(work_dir: Path) -> None:
+    input_file = TEST_DIR / f"{CASE_NAME}.in"
+    if not input_file.exists():
+        pytest.fail(f"Required input file missing: {input_file}")
+    (work_dir / f"{CASE_NAME}.in").symlink_to(input_file)
+
+    in_file_src = TEST_DIR / "in_file"
+    if not in_file_src.exists():
+        pytest.fail(f"Required input file missing: {in_file_src}")
+    (work_dir / "in_file").symlink_to(in_file_src.resolve())
+
+
+def run_neort(executable: Path, work_dir: Path) -> None:
+    result = subprocess.run(
+        [str(executable), CASE_NAME],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"neo_rt.x failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+def parse_field_params(work_dir: Path) -> dict:
+    """Read flux-surface geometry from the generated magfie_param output."""
+    param_file = work_dir / f"{CASE_NAME}_magfie_param.out"
+    wanted = ("eps", "R0", "a", "psi_pr", "B0", "q", "iota", "dVds")
+    params: dict = {}
+    with open(param_file, "r") as f:
+        for line in f:
+            fields = line.split()
+            # Lines read: "check_magfie: <name> = <value>"
+            if len(fields) >= 4 and fields[0] == "check_magfie:" and fields[2] == "=":
+                name = fields[1]
+                if name in wanted:
+                    params[name] = float(fields[3])
+    missing = [k for k in wanted if k not in params]
+    if missing:
+        pytest.fail(f"Missing field params {missing} in {param_file}")
+    return params
+
+
+# --- analytic superbanana-plateau model ------------------------------------
+
+
+def comelp(k2: float):
+    """Complete elliptic integrals K(k), E(k) with k^2 = k2 (matches Fortran)."""
+    pk = 1.0 - k2
+    ak = (((0.01451196212 * pk + 0.03742563713) * pk + 0.03590092383) * pk
+          + 0.09666344259) * pk + 1.38629436112
+    bk = (((0.00441787012 * pk + 0.03328355346) * pk + 0.06880248576) * pk
+          + 0.12498593597) * pk + 0.5
+    K = ak - bk * np.log(pk)
+    ae = (((0.01736506451 * pk + 0.04757383546) * pk + 0.0626060122) * pk
+          + 0.44325141463) * pk + 1.0
+    be = (((0.00526449639 * pk + 0.04069697526) * pk + 0.09200180037) * pk
+          + 0.2499836831) * pk
+    E = ae - be * np.log(pk)
+    return K, E
+
+
+def d11_analytic(p: dict, neta: int = 3000, npsi: int = 6001) -> float:
+    """Analytic SBP D11 (normalized by the ripple-plateau Dp), same field."""
+    eps, R0, a = p["eps"], p["R0"], p["a"]
+    B0, psi_pr, q = p["B0"], p["psi_pr"], p["q"]
+    iota, dVds = p["iota"], p["dVds"]
+
+    om_te = VTH * M_T / R0
+    chi = SIGN_THETA * psi_pr
+    depsdr = eps / (a * np.sqrt(S))     # = 1/R0 for a circular flux surface
+    hth = iota / R0                     # contravariant poloidal, leading order
+    meff = M0 + q * MPH
+
+    Dp = np.pi * VTH**3 / (16.0 * R0 * iota * (QI * B0 / (MI * C))**2)
+    dsdreff = 2.0 / a * np.sqrt(S)
+    vmin, vmax = 0.01 * VTH, 5.0 * VTH
+
+    etatp = 1.0 / (B0 * (1.0 + eps))
+    etadt = 1.0 / (B0 * (1.0 - eps))
+    etas = np.linspace(etatp * (1.0 + 1e-8), etadt * (1.0 - 1e-8), neta)
+
+    psi = np.linspace(-np.pi / 2, np.pi / 2, npsi)
+    spsi = np.sin(psi)
+
+    integrand = np.zeros(neta)
+    for i, eta in enumerate(etas):
+        k2 = (1.0 - eta * B0 * (1.0 - eps)) / (2.0 * eta * B0 * eps)
+        if k2 <= 1e-12 or k2 >= 1.0 - 1e-12:
+            continue
+        K, E = comelp(k2)
+        drift_shape = 2.0 * E / K - 1.0
+        if drift_shape <= 0.0:  # no ell=0 resonance for these pitch values
+            continue
+
+        # Resonance Om_tE + <Om_tB> = 0 with <Om_tB> = -C0*drift_shape*v^2
+        # gives v^2 explicitly (removes the velocity-space singularity).
+        c0 = (C * 0.5 * MI * eta * B0 / (QI * chi)) * depsdr
+        v2 = om_te / (c0 * drift_shape)
+        if v2 <= 0.0:
+            continue
+        v = np.sqrt(v2)
+        if v < vmin or v > vmax:
+            continue
+        ux = v / VTH
+
+        # Bounce time and bounce-averaged perturbation for B = B0(1 - eps cos th),
+        # h^theta = iota/R0 (large-aspect-ratio circular model field).
+        kap = np.sqrt(k2)
+        th = 2.0 * np.arcsin(kap * spsi)
+        weight = 1.0 / np.sqrt(1.0 - k2 * spsi**2)
+        Bth = B0 * (1.0 - eps * np.cos(th))
+        Hb = EPSMN * np.trapezoid((2.0 - eta * Bth) * np.cos(meff * th) * weight,
+                                  psi) / (2.0 * K)
+        taub = 8.0 * K / (v * np.sqrt(2.0 * eta * B0 * eps) * hth)
+
+        Hmn2 = Hb**2 * (MI * v2 / 2.0)**2
+        d11int = (np.pi**1.5 * MPH**2 * C**2 * q * VTH
+                  / (QI**2 * dVds * abs(psi_pr))
+                  * ux**3 * np.exp(-ux**2) * taub * Hmn2)
+        # Resonance-line Jacobian: |d Omph / d ux| = 2 Om_tE / ux at resonance.
+        integrand[i] = d11int * ux / (2.0 * MPH * om_te)
+
+    acc = np.trapezoid(integrand, etas)
+    return dsdreff**(-2) * acc / Dp
+
+
+def load_d11(work_dir: Path) -> float:
+    data = np.loadtxt(work_dir / f"{CASE_NAME}.out")
+    return float(data[4])  # column: total D11
+
+
+def test_superbanana_plateau(executable: Path, tmp_path: Path) -> None:
+    """Numeric SBP D11 matches the analytic superbanana-plateau prediction."""
+    work_dir = tmp_path / "superbanana_plateau"
+    work_dir.mkdir()
+    setup_work_dir(work_dir)
+
+    run_neort(executable, work_dir)
+
+    d11_code = load_d11(work_dir)
+    assert d11_code > 0.0, "SBP D11 is zero: ell=0 resonance not found"
+
+    params = parse_field_params(work_dir)
+    d11_pred = d11_analytic(params)
+
+    rel_err = abs(d11_code - d11_pred) / d11_pred
+    assert rel_err < D11_TOLERANCE, (
+        f"SBP D11 = {d11_code:.4e} deviates from analytic prediction "
+        f"{d11_pred:.4e} by {rel_err * 100:.1f}% "
+        f"(tolerance: {D11_TOLERANCE * 100:.0f}%)"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Reinstates the historical Shaing superbanana-plateau (SBP) analytic transport
mode, removed in `54aaf57` ("Remove supban field") and `651acf7`
("Clean: Unused files"). The model implements the bounce-averaged toroidal
drift frequency of Shaing 2009 PPCF 51 035009 Eq. (8),

```
Omph = Om_tE + <Om_tB>,
<Om_tB> = -(c*mu*B0)/(qi*chi') * eps' * (2*E(kappa)/K(kappa) - 1)
```

which supplies the resonant toroidal drift frequency of the trapped `ell=0`
superbanana resonance. Scope is SBP only (the connected `nu`-`sqrt(nu)`
formula is intentionally not added).

## Changes

- **`src/shaing.f90`** (new `module shaing`): modern `kappa2()` and
  `omph_shaing()` using `real(dp)`, `use ..., only:`, intent-ed args, fprettify
  88/4. libneo/fortnum export no complete elliptic integrals, so a modernized
  `comelp` (Zhang & Jin) is vendored into the module. Field/profile inputs are
  wired through the current module APIs (`do_magfie_mod` for `B0`/`eps`/`psi_pr`,
  `neort_profiles` for `Om_tE`); the 2015 globals are not resurrected. `eps'`
  uses the large-aspect-ratio circular form `eps/(a*sqrt(s)) = 1/R0`.
- **`src/config.f90`**: new namelist logical `supban = .false.` (config type
  field + namelist entry + transfer), mirroring the existing flags.
- **`src/freq.f90`**: `Om_ph` returns `omph_shaing` (with finite-difference
  eta/v derivatives for the resonance Jacobian) in the trapped region when
  `supban` is set.
- **`src/neort.f90`**: trapped-only SBP branch gated on `supban`
  (`vmint=0.01*vth`, `vmaxt=5*vth`, `sigv=1`, `set_to_trapped_region`, single
  `compute_transport_integral`), restricted to the `ell=0` (`mth=0`) harmonic.
  The default path is byte-identical when `supban=.false.` (golden-record tests
  confirm).
- **`test/superbanana_plateau/`**: regression test mirroring `ripple_plateau`.
  Runs a circular-tokamak SBP case and compares the numeric `D11` against an
  independent analytic superbanana-plateau prediction built from the
  `doc/driftorbit.lyx` `g(kappa)` resonance-line integral, sharing the field
  geometry parsed from the run output. Agreement ~2.7% (tolerance 6%). The
  normalization reproduced is that of marker commit `ec133c3`
  ("correct superbanana plateau fluxes").

## Testing

- `fo` build/check green; existing `ctest` (10) and `pytest` golden-record (9)
  suites unchanged; new SBP test passes.
- Rebased onto latest `main` (keeps both this feature and the sibling
  `vmax_over_vth` cutoff, which governs the standard path while the SBP branch
  keeps its own `5*vth` bracket per the analytic model).

## Usage

Produce an SBP torque/transport profile by adding to the `&params` namelist:

```
supban = .true.    ! Shaing superbanana plateau (trapped ell=0) only
M_t = 0.001d0      ! small Mach number so the Om_tE + <Om_tB> = 0 resonance sits in range
magdrift = .true.
```