### PR TITLE
Default vmax_over_vth to 4.0

### DIFF
--- a/doc/library.md
+++ b/doc/library.md
@@ -146,9 +146,11 @@ end type
 `mth_max_abs=-1` preserves the historical q-dependent harmonic range. A
 nonnegative value selects the exact symmetric range `-mth_max_abs:mth_max_abs`.
 
-`vmax_over_vth=3.0` sets the upper velocity-space cutoff in units of the
-thermal velocity. The default preserves the historical hard-coded bound; a
-larger value captures more of a far-tail resonance. It must be positive.
+`vmax_over_vth=4.0` sets the upper velocity-space cutoff in units of the
+thermal velocity. The default of `4.0` captures the far-tail resonance that the
+old hard-coded `3.0` bound truncated; `v_max = 5` is converged against `4`. Set
+`vmax_over_vth=3.0` to reproduce pre-2026-07-20 archived results. It must be
+positive.
 
 ### transport_data_t
 

--- a/doc/running.md
+++ b/doc/running.md
@@ -63,7 +63,7 @@ The parameter file is a Fortran namelist `&params` with the fields listed below.
 | `inp_swi` | Boozer input switch. | Passed to `do_magfie`. |
 | `vsteps` | Number of velocity grid points. | Set to `0` for adaptive quadrature. |
 | `mth_max_abs` | Maximum absolute orbit-resonance harmonic. | Default `-1` keeps the historical `±ceil(2\|mph q\|)` range; `0` selects only `mth=0`. |
-| `vmax_over_vth` | Upper velocity-space cutoff in units of `vth`. | Default `3.0` keeps the historical hard-coded bound; must be positive. |
+| `vmax_over_vth` | Upper velocity-space cutoff in units of `vth`. | Default `4.0` captures the far-tail resonance (the old `3.0` bound truncated it); set `3.0` to reproduce pre-2026-07-20 results; must be positive. |
 | `log_level` | Verbosity level for the logger. | Defined in `src/logging.f90`. |
 
 ### Magnetic field data

--- a/src/config.f90
+++ b/src/config.f90
@@ -24,7 +24,7 @@ module neort_config
         integer :: inp_swi = 0  ! input switch for Boozer file
         integer :: vsteps = 0  ! integration steps in velocity space
         integer :: mth_max_abs = -1 ! negative: historical q-dependent range
-        real(dp) :: vmax_over_vth = 3.0_dp  ! upper velocity cutoff / vth
+        real(dp) :: vmax_over_vth = 4.0_dp  ! upper velocity cutoff / vth
         integer :: log_level = 0  ! how much to log
         !*! will be overwritten if using splines from plasma.in and profile.in files
     end type config_t
@@ -94,7 +94,7 @@ contains
             vsteps, mth_max_abs, vmax_over_vth, log_level
 
         mth_max_abs = -1
-        vmax_over_vth = 3.0_dp
+        vmax_over_vth = 4.0_dp
         open (unit=9, file=config_file, status="old", form="formatted")
         read (9, nml=params)
         close (unit=9)

--- a/src/neort.f90
+++ b/src/neort.f90
@@ -18,9 +18,10 @@ module neort
     ! preserves the historical q-dependent automatic range.
     integer :: mth_max_abs = -1
 
-    ! Upper velocity-space cutoff in units of the thermal velocity. Default 3.0
-    ! preserves the historical hard-coded bound and bit-reproducibility.
-    real(dp) :: vmax_over_vth = 3.0_dp
+    ! Upper velocity-space cutoff in units of the thermal velocity. Default 4.0
+    ! captures the far-tail resonance; the historical hard-coded 3.0 bound
+    ! truncated it. Set vmax_over_vth = 3.0 to reproduce pre-2026-07-20 results.
+    real(dp) :: vmax_over_vth = 4.0_dp
 
 contains
 

--- a/test/golden_record/input/template.in
+++ b/test/golden_record/input/template.in
@@ -15,5 +15,6 @@
     efac = 1.0
     inp_swi = 9
     vsteps = 512
+    vmax_over_vth = 3.0
     log_level = -1
 /

--- a/test/test_vmax_over_vth.f90
+++ b/test/test_vmax_over_vth.f90
@@ -8,8 +8,8 @@ program test_vmax_over_vth
     type(config_t) :: config
     integer :: unit
 
-    ! config_t default preserves the historical hard-coded cutoff
-    if (config%vmax_over_vth /= 3.0_dp) error stop "config_t default changed"
+    ! config_t default is the converged 4*vth cutoff
+    if (config%vmax_over_vth /= 4.0_dp) error stop "config_t default changed"
 
     ! set_config transfers an explicit value to the module variable
     config%vmax_over_vth = 4.5_dp
@@ -18,7 +18,7 @@ program test_vmax_over_vth
 
     config = config_t()
     call set_config(config)
-    if (configured /= 3.0_dp) error stop "config_t default not restored"
+    if (configured /= 4.0_dp) error stop "config_t default not restored"
 
     ! namelist parsing picks up an explicit value
     call write_namelist("vmax.in", "    vmax_over_vth = 5.0")
@@ -28,7 +28,7 @@ program test_vmax_over_vth
     ! namelist parsing falls back to the default when the field is absent
     call write_namelist("vmax.in", "")
     call read_and_set_config("vmax.in")
-    if (configured /= 3.0_dp) error stop "namelist default changed"
+    if (configured /= 4.0_dp) error stop "namelist default changed"
 
     open (newunit=unit, file="vmax.in", status="old")
     close (unit, status="delete")


### PR DESCRIPTION
## What

Change the default velocity-space cutoff `vmax_over_vth` from `3.0` to `4.0`.

## Why

The hard `3*vth` cutoff truncated ~38% of the ITER `ell=0` tail resonance and
created a radial-edge artifact. `v_max = 5` is converged against `4`, so `4*vth`
is the correct physics default.

Reproducing pre-2026-07-20 archived results now requires setting
`vmax_over_vth = 3.0` explicitly. This is documented in `doc/library.md`,
`doc/running.md`, and the source comments.

## Changes

- `src/config.f90`: `config_t` default and the `read_and_set_config` namelist
  reset now default to `4.0_dp`.
- `src/neort.f90`: module default (added in #75) now `4.0_dp`, comment updated.
- `doc/library.md`, `doc/running.md`: documented new default and the 3.0
  reproduction escape hatch.
- `test/test_vmax_over_vth.f90`: default expectations updated to `4.0`.

## Test stability

Checked the in-repo benchmarks for `v_max = 3`-dependent reference values:

- **golden_record** compares actual `output/torque/integral` against the
  committed `golden.h5` (generated at the historical `3.0` default) at 0.5%
  scale-relative tolerance. It would fail at the new default, so
  `test/golden_record/input/template.in` now pins `vmax_over_vth = 3.0` to keep
  the golden stable.
- **ripple_plateau** and **superbanana_plateau** compare against *analytic*
  references (D12/D11 = 3.0 theoretical; an analytic SBP model that itself
  integrates to `5*vth`), not `v_max = 3`-pinned numbers. They pass unchanged at
  the new `4.0` default and are left unpinned so they exercise it.

`fo check` (build + Fortran tests) and the golden/ripple/superbanana pytest
suites all pass (11 passed).