### PR TITLE
Fail closed on incomplete POTATO torque accounting

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -122,6 +122,16 @@ add_test(NAME test_potato_invariants
    COMMAND test_potato_invariants.x
 )
 
+add_executable(test_matrix_callback_status.x
+   SRC/test_matrix_callback_status.f90
+)
+target_link_libraries(test_matrix_callback_status.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+add_test(NAME test_matrix_callback_status
+   COMMAND test_matrix_callback_status.x
+)
+
 add_executable(test_wall_profile.x
    SRC/test_wall_profile.f90
 )

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -188,6 +188,13 @@ target_link_libraries(potato_hamiltonian_probe.x
    "$<LINK_GROUP:RESCAN,potato,potato_base>"
 )
 
+add_executable(potato_poicut_probe.x
+   SRC/potato_poicut_probe.f90
+)
+target_link_libraries(potato_poicut_probe.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter
@@ -226,4 +233,11 @@ if(Python3_Interpreter_FOUND)
         SKIP_RETURN_CODE 77
         TIMEOUT 240
     )
+    add_test(NAME potato_poicut_translation
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/poicut_translation/test_poicut_translation.py
+            $<TARGET_FILE:potato_poicut_probe.x>
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
+    )
+    set_tests_properties(potato_poicut_translation PROPERTIES TIMEOUT 150)
 endif()

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -132,6 +132,16 @@ add_test(NAME test_matrix_callback_status
    COMMAND test_matrix_callback_status.x
 )
 
+add_executable(test_potato_input_validation.x
+   SRC/test_potato_input_validation.f90
+)
+target_link_libraries(test_potato_input_validation.x
+   potato_base
+)
+add_test(NAME test_potato_input_validation
+   COMMAND test_potato_input_validation.x
+)
+
 add_executable(test_wall_profile.x
    SRC/test_wall_profile.f90
 )

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -98,6 +98,16 @@ add_test(NAME test_signed_toroidal_bound
    COMMAND test_signed_toroidal_bound.x
 )
 
+add_executable(test_box_counting_status.x
+   SRC/test_box_counting_status.f90
+)
+target_link_libraries(test_box_counting_status.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+add_test(NAME test_box_counting_status
+   COMMAND test_box_counting_status.x
+)
+
 add_executable(test_wall_loss.x
    SRC/test_wall_loss.f90
 )
@@ -234,6 +244,11 @@ if(Python3_Interpreter_FOUND)
             ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
     )
     set_tests_properties(potato_invariant_handoff PROPERTIES TIMEOUT 150)
+    add_test(NAME potato_resonance_golden
+        COMMAND ${Python3_EXECUTABLE} -m pytest -q
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance/test_resonance_golden.py
+    )
+    set_tests_properties(potato_resonance_golden PROPERTIES TIMEOUT 150)
     add_test(NAME potato_golden_displacement
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_displacement/test_potato_golden.py

--- a/POTATO/README.md
+++ b/POTATO/README.md
@@ -49,6 +49,11 @@ The displayed `n=+3` is the current TC24 MARS-to-CCW result:
 `phi_CCW=-phi_MARS` and `n_CCW=-RNTOR=+3`. It is not a universal MARS
 default; another field must supply its own signed laboratory-coordinate map.
 
+POTATO keeps the signed `n_tor` in the resonance condition and perturbation
+phase. The final toroidal torque factor is `abs(n_tor)`, as in
+`equilmaxw.tex`; changing the signed representation of the same real field
+must not reverse the torque.
+
 The matching profile converter also keeps the coordinate and electric-field
 conventions explicit:
 
@@ -98,6 +103,42 @@ on an idle machine and 400-600 s under any concurrent load, because they
 oversubscribe the 16 cores.
 
 The reslines output is identical for every thread count.
+
+## Resonant-torque outputs
+
+`integral_torque.dat` is the volume-integrated native toroidal torque in erg
+(`1 erg = 1e-7 N m`). `boxcounted_torque.dat` contains one incremental torque
+per `s_pol` interval, followed by the lower and upper interval edges; its first
+column is not a density. A density with respect to another abscissa requires
+division by that abscissa's mapped bin width. In particular, a published
+`rho_tor` plot must map every `s_pol` edge through `eqmagprofs.dat` and divide
+the bin torque by `Delta rho_tor`.
+
+Orbit residence at `s_pol>1` is not part of the last closed-flux bin.
+`boxcounted_torque_outside.dat` serializes that signed contribution separately
+as `torque_erg, s_pol_lower_bound`. The sum of the closed-flux bins and this
+outside contribution reconstructs `integral_torque.dat`.
+
+`potato_completeness.dat` is mandatory acceptance evidence. Every computed
+energy must have status zero and zero failed J-perp, class, orbit, resonance,
+root, and box-disposition counts. A zero process exit or a printed scalar
+alone is not evidence of a complete torque.
+
+`potato_resonance_weights.dat` is the accepted root-level quadrature ledger:
+
+```text
+energy_index jperp_index class_index root_index m2 n3
+root_disposition box_disposition H0_over_Eref Jperp psiast taub
+final_weight_erg outside_s_pol_fraction
+```
+
+`m2` is a canonical bounce harmonic, not a spatial Boozer poloidal harmonic.
+`n3` is the signed laboratory toroidal mode. Root disposition `0` means a
+computed root and `1` an explicit outside-LCFS zero; box disposition `0` means
+a complete residence trace and `-1` a zero-weight trace skipped by definition.
+The outside fraction uses `-1` only for that skipped case. The sum of
+`final_weight_erg` reconstructs `integral_torque.dat`; grouping the same
+column by `m2,n3` reconstructs the canonical-mode torque ledger.
 
 ## SIMPLE-compatible invariant handoff
 

--- a/POTATO/SRC/box_counting.f90
+++ b/POTATO/SRC/box_counting.f90
@@ -1,123 +1,213 @@
-subroutine linspace(a, b, cnt, out)
-  implicit none
+module box_counting_status_mod
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    implicit none
 
-  real(8), intent(in) :: a, b
-  integer :: i, cnt
-  real(8), intent(inout) :: out(cnt)
-  real(8) :: delta
-
-  delta = (b-a)/(cnt-1)
-  do i=1,cnt
-    out(i) = a + delta*(i-1)
-  end do
-end subroutine linspace
-
-subroutine timestep_vode(n, tau, z, vz)
-  implicit none
-  ! See velo for details
-  integer(4), intent(in) :: n     ! number of equations
-  real(8), intent(in)    :: tau   ! Time
-  real(8), intent(in)    :: z(n)  ! Phase-position
-  real(8), intent(out)   :: vz(n) ! Phase-velocity
-  call velo(tau, z, vz)
-end subroutine timestep_vode
-
-subroutine time_in_box(z, cnt, sbox, taub, tau)
-  ! Returns time spent in boxes
-  use dvode_f90_m, only: vode_opts, set_opts, dvode_f90, get_stats
-  use field_sub, only: psif
-  use field_eq_mod, only: psi_axis, psi_sep
-  use orbit_dim_mod, only: neqm
-
-  implicit none
-
-  real(8), intent(in)    :: z(neqm)    ! Starting position
-  integer, intent(in)    :: cnt        ! Box boundary count
-  real(8), intent(in)    :: sbox(cnt)  ! Box boundaries
-  real(8), intent(in)    :: taub       ! Bounce time
-  real(8), intent(out)   :: tau(cnt)   ! Time in each box
-
-  real(8) :: smid
-  real(8) :: y(neqm)
-
-  integer(4) :: k, nsample
-  real(8) :: ti
-
-  real(8) :: atol(neqm), rtol, tout
-  integer(4) :: itask, istate, method_flag
-  type (vode_opts) :: options
-  real(8) :: bmod, phi_elec, s
-  real(8) :: sold, told
-  integer(4) :: sind ! s index
-
-  external timestep_vode
-
-  tau = 0d0
-
-  ! taub<=0 is an interpolant overshoot through zero (unintegrable); skip it.
-  ! Genuinely unintegrable long orbits are caught below by the mxstep/istate
-  ! guard, which returns a zero distribution.  The class root search is bounded
-  ! to |delphi_b| <= 2*pi*m_max/n, so the Omega_b~0 near-separatrix grazers that
-  ! used to flood this routine no longer reach it.
-  if (taub <= 0d0) return
-
-  y = z
-
-  rtol = 1d-12
-  atol = 1d-13
-  itask = 1
-  istate = 1
-  method_flag = 10
-  options = set_opts(method_flag=method_flag, abserr_vector=atol, &
-    relerr=rtol, mxstep=2000)
-
-  nsample = min(256, max(64, size(sbox)))
-  ti = 0d0
-
-  call get_bmod_and_Phi(z(1:3), bmod, phi_elec)
-
-  s = abs((psif-psi_axis)/(psi_sep-psi_axis))
-  sold = s
-  told = 0d0
-  do k = 1,nsample
-    tout = taub*dble(k)/dble(nsample)
-    call dvode_f90( &
-        timestep_vode, neqm, y, ti, tout, itask, istate, options)
-    if (istate == -1) then
-      print *, 'time_in_box: VODE exceeded mxstep at k =', k, &
-        ' ti =', ti, ' taub =', taub
-      tau = 0d0
-      return
-    endif
-    if (istate /= 2) then
-      print *, 'time_in_box: VODE failed with istate =', istate, &
-        ' k =', k, ' ti =', ti, ' taub =', taub
-      tau = 0d0
-      return
-    end if
-
-    call get_bmod_and_Phi(y(1:3), bmod, phi_elec)
-
-    s = abs((psif-psi_axis)/(psi_sep-psi_axis))
-    smid = 0.5d0*(sold+s)
-    sind = radial_box_index(smid)
-    tau(sind) = tau(sind) + ti-told
-    sold = s
-    told = ti
-  end do
+    integer, parameter :: box_count_skipped_zero_weight = -1
+    integer, parameter :: box_count_ok = 0
+    integer, parameter :: box_count_nonpositive_bounce = 1
+    integer, parameter :: box_count_vode_mxstep = 2
+    integer, parameter :: box_count_vode_failed = 3
+    integer, parameter :: box_count_nonfinite = 4
+    integer, parameter :: box_count_negative_residence = 5
+    integer, parameter :: box_count_residence_mismatch = 6
 
 contains
 
-  integer function radial_box_index(sval)
-    real(8), intent(in) :: sval
-    integer :: ibox
+    pure integer function box_count_vode_status(istate)
+        integer, intent(in) :: istate
 
-    radial_box_index = size(sbox)
-    do ibox = 1,size(sbox)
-      if (sval <= sbox(ibox)) then
-        radial_box_index = ibox
-        exit
-      endif
-    enddo
-  end function radial_box_index
-end subroutine time_in_box
+        if (istate == 2) then
+            box_count_vode_status = box_count_ok
+        elseif (istate == -1) then
+            box_count_vode_status = box_count_vode_mxstep
+        else
+            box_count_vode_status = box_count_vode_failed
+        endif
+    end function box_count_vode_status
+
+    pure integer function box_count_residence_status(taub, tau, tau_outside)
+        real(8), intent(in) :: taub
+        real(8), intent(in) :: tau(:)
+        real(8), intent(in) :: tau_outside
+
+        real(8) :: residence_sum, tolerance
+
+        if (.not. ieee_is_finite(taub) .or. &
+            .not. all(ieee_is_finite(tau)) .or. &
+            .not. ieee_is_finite(tau_outside)) then
+            box_count_residence_status = box_count_nonfinite
+            return
+        endif
+        if (taub <= 0d0) then
+            box_count_residence_status = box_count_nonpositive_bounce
+            return
+        endif
+
+        tolerance = max(1d-10*abs(taub), &
+            1024d0*epsilon(taub)*max(abs(taub), 1d0))
+        if (any(tau < -tolerance) .or. tau_outside < -tolerance) then
+            box_count_residence_status = box_count_negative_residence
+            return
+        endif
+
+        residence_sum = sum(tau) + tau_outside
+        if (abs(residence_sum-taub) > tolerance) then
+            box_count_residence_status = box_count_residence_mismatch
+            return
+        endif
+
+        box_count_residence_status = box_count_ok
+    end function box_count_residence_status
+
+end module box_counting_status_mod
+
+subroutine linspace(a, b, cnt, out)
+    implicit none
+
+    real(8), intent(in) :: a, b
+    integer :: i, cnt
+    real(8), intent(inout) :: out(cnt)
+    real(8) :: delta
+
+    delta = (b-a)/(cnt-1)
+    do i=1,cnt
+        out(i) = a + delta*(i-1)
+    end do
+end subroutine linspace
+
+subroutine timestep_vode(n, tau, z, vz)
+    implicit none
+    ! See velo for details
+    integer(4), intent(in) :: n ! number of equations
+    real(8), intent(in)    :: tau ! Time
+    real(8), intent(in)    :: z(n) ! Phase-position
+    real(8), intent(out)   :: vz(n) ! Phase-velocity
+    call velo(tau, z, vz)
+end subroutine timestep_vode
+
+subroutine time_in_box(z, cnt, sbox, taub, tau, tau_outside, status)
+    ! Returns time spent in boxes
+    use dvode_f90_m, only: vode_opts, set_opts, dvode_f90, get_stats
+    use field_sub, only: psif
+    use field_eq_mod, only: psi_axis, psi_sep
+    use orbit_dim_mod, only: neqm
+    use box_counting_status_mod, only: box_count_ok, &
+        box_count_nonpositive_bounce, box_count_nonfinite, &
+        box_count_residence_status, box_count_vode_status
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+
+    real(8), intent(in)    :: z(neqm) ! Starting position
+    integer, intent(in)    :: cnt ! Box boundary count
+    real(8), intent(in)    :: sbox(cnt) ! Box boundaries
+    real(8), intent(in)    :: taub ! Bounce time
+    real(8), intent(out)   :: tau(cnt) ! Time in each box
+    real(8), intent(out)   :: tau_outside ! Time at s_pol > final box edge
+    integer, intent(out)   :: status ! box_counting_status_mod code
+
+    real(8) :: smid
+    real(8) :: y(neqm)
+
+    integer(4) :: k, nsample
+    real(8) :: ti
+
+    real(8) :: atol(neqm), rtol, tout
+    integer(4) :: itask, istate, method_flag
+    type (vode_opts) :: options
+        real(8) :: bmod, phi_elec, s
+        real(8) :: sold, told
+        integer(4) :: sind ! s index
+
+        external timestep_vode
+
+        tau = 0d0
+        tau_outside = 0d0
+        if (.not. ieee_is_finite(taub)) then
+            status = box_count_nonfinite
+            return
+        elseif (taub <= 0d0) then
+            ! An interpolant overshoot through zero is a failed disposition, not a
+            ! zero torque deposition.
+            status = box_count_nonpositive_bounce
+            return
+        else
+            status = box_count_ok
+        endif
+
+        y = z
+
+        rtol = 1d-12
+        atol = 1d-13
+        itask = 1
+        istate = 1
+        method_flag = 10
+        options = set_opts(method_flag=method_flag, abserr_vector=atol, &
+            relerr=rtol, mxstep=2000)
+
+        nsample = min(256, max(64, size(sbox)))
+        ti = 0d0
+
+        call get_bmod_and_Phi(z(1:3), bmod, phi_elec)
+
+        s = abs((psif-psi_axis)/(psi_sep-psi_axis))
+        sold = s
+        told = 0d0
+        do k = 1,nsample
+            tout = taub*dble(k)/dble(nsample)
+            call dvode_f90( &
+                timestep_vode, neqm, y, ti, tout, itask, istate, options)
+            status = box_count_vode_status(istate)
+            if (status /= box_count_ok) then
+                if (istate == -1) then
+                    print *, 'time_in_box: VODE exceeded mxstep at k =', k, &
+                        ' ti =', ti, ' taub =', taub
+                else
+                    print *, 'time_in_box: VODE failed with istate =', istate, &
+                        ' k =', k, ' ti =', ti, ' taub =', taub
+                endif
+                tau = 0d0
+                tau_outside = 0d0
+                return
+            end if
+
+            call get_bmod_and_Phi(y(1:3), bmod, phi_elec)
+
+            s = abs((psif-psi_axis)/(psi_sep-psi_axis))
+            smid = 0.5d0*(sold+s)
+            if (.not. ieee_is_finite(smid)) then
+                status = box_count_nonfinite
+                tau = 0d0
+                tau_outside = 0d0
+                return
+            elseif (smid > sbox(size(sbox))) then
+                tau_outside = tau_outside + ti-told
+            else
+                sind = radial_box_index(smid)
+                tau(sind) = tau(sind) + ti-told
+            endif
+            sold = s
+            told = ti
+        end do
+
+        status = box_count_residence_status(taub, tau, tau_outside)
+        if (status /= box_count_ok) then
+            tau = 0d0
+            tau_outside = 0d0
+        endif
+
+    contains
+
+        integer function radial_box_index(sval)
+            real(8), intent(in) :: sval
+            integer :: ibox
+
+            radial_box_index = size(sbox)
+            do ibox = 1,size(sbox)
+                if (sval <= sbox(ibox)) then
+                    radial_box_index = ibox
+                    exit
+                endif
+            enddo
+        end function radial_box_index
+    end subroutine time_in_box

--- a/POTATO/SRC/potato_input_mod.f90
+++ b/POTATO/SRC/potato_input_mod.f90
@@ -9,12 +9,12 @@ module potato_input_mod
     integer :: itest_type = 3
 
     ! Species parameters
-    double precision :: E_alpha = 5d3       ! Reference energy [eV]
-    double precision :: A_alpha = 2d0       ! Mass number
-    double precision :: Z_alpha = 1d0       ! Charge number
+    double precision :: E_alpha = 5d3 ! Reference energy [eV]
+    double precision :: A_alpha = 2d0 ! Mass number
+    double precision :: Z_alpha = 1d0 ! Charge number
 
     ! Flux surface
-    double precision :: rho_pol = 0.6d0     ! Poloidal radius
+    double precision :: rho_pol = 0.6d0 ! Poloidal radius
     double precision :: rho_pol_max = 0.9d0 ! Max rho_pol for Poincare cut
 
     ! Scaling factors
@@ -22,8 +22,8 @@ module potato_input_mod
     double precision :: scalfac_efield = 1d0
 
     ! Orbit integration
-    double precision :: Rmax_orbit = 200d0  ! Max R for orbit integration
-    integer :: ntimstep = 30                ! Number of time steps
+    double precision :: Rmax_orbit = 200d0 ! Max R for orbit integration
+    integer :: ntimstep = 30 ! Number of time steps
 
     ! Poincare cut
     integer :: npoicut = 10000
@@ -35,7 +35,7 @@ module potato_input_mod
 
     ! Energy grid
     integer :: nenerg = 60
-    double precision :: thermen_max = 6d0   ! Max kinetic energy [T units]
+    double precision :: thermen_max = 6d0 ! Max kinetic energy [T units]
     ! Lowest slice starts at this kinetic energy [T units] when set.
     double precision :: enkin_min_over_temp = 0d0
 
@@ -58,16 +58,16 @@ module potato_input_mod
 
     ! Single-orbit trace (itest_type=4): start point on the poloidal plane and
     ! pitch cosine of one guiding-center orbit, traced over one bounce period.
-    double precision :: orbit_Rstart = 210d0   ! start major radius [cm]
-    double precision :: orbit_Zstart = 0d0     ! start height [cm]
-    double precision :: orbit_lambda = 0.4d0   ! pitch cosine v_par/v at start
+    double precision :: orbit_Rstart = 210d0 ! start major radius [cm]
+    double precision :: orbit_Zstart = 0d0 ! start height [cm]
+    double precision :: orbit_lambda = 0.4d0 ! pitch cosine v_par/v at start
 
     ! Frequency radial scan (itest_type=5): trace one bounce at each of freq_n
     ! midplane start radii from freq_Rmin to freq_Rmax (pitch orbit_lambda),
     ! and write rho_pol, omega_b, omega_phi to freq_scan.dat.
-    double precision :: freq_Rmin = 178d0      ! inner start radius [cm]
-    double precision :: freq_Rmax = 221d0      ! outer start radius [cm], into SOL
-    integer          :: freq_n = 40            ! number of surfaces
+    double precision :: freq_Rmin = 178d0 ! inner start radius [cm]
+    double precision :: freq_Rmax = 221d0 ! outer start radius [cm], into SOL
+    integer          :: freq_n = 40 ! number of surfaces
 
     ! Resonance probe diagnostic
     double precision :: probe_rho_pol = 0.9d0
@@ -142,8 +142,8 @@ contains
         close(iunit)
 
         if (.not. potato_input_is_valid()) then
-            error stop 'invalid POTATO input: check radial domain and positive ' &
-                // 'sampler tolerances/iteration limits'
+            error stop 'invalid POTATO input: check radial/mode/quadrature ' &
+                // 'domains and positive sampler controls'
         endif
 
         inquire(file='field_divB0.inp', exist=field_input_exists)
@@ -163,7 +163,14 @@ contains
             .and. class_eps_sampling > 0.d0 .and. class_itermax_sampling > 0
         if (itest_type == 3) then
             potato_input_is_valid = potato_input_is_valid &
-                .and. rho_pol < rho_pol_max
+                .and. rho_pol < rho_pol_max &
+                .and. m_min <= m_max .and. n_tor /= 0 &
+                .and. nbox >= 2 .and. npoi_init >= 2 &
+                .and. nenerg >= 1
+            if (enkin_min_over_temp <= 0.d0) then
+                potato_input_is_valid = potato_input_is_valid &
+                    .and. nenerg >= 2
+            endif
         endif
     end function potato_input_is_valid
 

--- a/POTATO/SRC/potato_input_mod.f90
+++ b/POTATO/SRC/potato_input_mod.f90
@@ -48,6 +48,8 @@ module potato_input_mod
     integer :: nlagr_sampling = 3
     double precision :: eps_sampling = 1d-2
     integer :: itermax_sampling = 5
+    double precision :: class_eps_sampling = 1d-3
+    integer :: class_itermax_sampling = 20
     logical :: clip_resonance_classes = .true.
 
     ! Orbit plotting
@@ -100,7 +102,8 @@ module potato_input_mod
         m_min, m_max, n_tor, &
         nenerg, thermen_max, enkin_min_over_temp, nbox, &
         adaptive_jperp, npoi_init, nlagr_sampling, eps_sampling, &
-        itermax_sampling, clip_resonance_classes, &
+        itermax_sampling, class_eps_sampling, class_itermax_sampling, &
+        clip_resonance_classes, &
         toten_plot, perpinv_plot, enkin_over_temp, &
         profile_file, edge_extension, &
         orbit_Rstart, orbit_Zstart, orbit_lambda, &
@@ -139,8 +142,8 @@ contains
         close(iunit)
 
         if (.not. potato_input_is_valid()) then
-            error stop 'invalid POTATO input: resonant-torque rho_pol_max must ' &
-                // 'extend strictly beyond rho_pol and remain below one'
+            error stop 'invalid POTATO input: check radial domain and positive ' &
+                // 'sampler tolerances/iteration limits'
         endif
 
         inquire(file='field_divB0.inp', exist=field_input_exists)
@@ -155,6 +158,9 @@ contains
     logical function potato_input_is_valid()
         potato_input_is_valid = 0.d0 < rho_pol .and. rho_pol <= rho_pol_max &
             .and. rho_pol_max < 1.d0
+        potato_input_is_valid = potato_input_is_valid &
+            .and. eps_sampling > 0.d0 .and. itermax_sampling > 0 &
+            .and. class_eps_sampling > 0.d0 .and. class_itermax_sampling > 0
         if (itest_type == 3) then
             potato_input_is_valid = potato_input_is_valid &
                 .and. rho_pol < rho_pol_max
@@ -188,6 +194,9 @@ contains
         write(iunit, '(A,I0)') '  nlagr_sampling   = ', nlagr_sampling
         write(iunit, '(A,ES12.5)') '  eps_sampling     = ', eps_sampling
         write(iunit, '(A,I0)') '  itermax_sampling = ', itermax_sampling
+        write(iunit, '(A,ES12.5)') '  class_eps_sampling = ', class_eps_sampling
+        write(iunit, '(A,I0)') &
+            '  class_itermax_sampling = ', class_itermax_sampling
         write(iunit, '(A,L1)') '  clip_resonance_classes = ', clip_resonance_classes
         write(iunit, '(A,ES12.5)') '  toten_plot       = ', toten_plot
         write(iunit, '(A,ES12.5)') '  perpinv_plot     = ', perpinv_plot

--- a/POTATO/SRC/potato_input_mod.f90
+++ b/POTATO/SRC/potato_input_mod.f90
@@ -71,6 +71,8 @@ module potato_input_mod
     double precision :: probe_rho_pol = 0.9d0
     double precision :: probe_ux = 1.5d0
     double precision :: probe_eta = 4.1d-5
+    double precision :: probe_toten = -1.0d0
+    double precision :: probe_perpinv = -1.0d0
     integer :: probe_m = 0
     integer :: probe_n = 2
 
@@ -103,7 +105,8 @@ module potato_input_mod
         profile_file, edge_extension, &
         orbit_Rstart, orbit_Zstart, orbit_lambda, &
         freq_Rmin, freq_Rmax, freq_n, &
-        probe_rho_pol, probe_ux, probe_eta, probe_m, probe_n
+        probe_rho_pol, probe_ux, probe_eta, probe_toten, probe_perpinv, &
+        probe_m, probe_n
 
 contains
 
@@ -135,6 +138,11 @@ contains
 
         close(iunit)
 
+        if (.not. potato_input_is_valid()) then
+            error stop 'invalid POTATO input: resonant-torque rho_pol_max must ' &
+                // 'extend strictly beyond rho_pol and remain below one'
+        endif
+
         inquire(file='field_divB0.inp', exist=field_input_exists)
         if (field_input_exists) then
             call read_field_input('field_divB0.inp')
@@ -143,6 +151,15 @@ contains
             call load_wall('convexwall.dat')
         endif
     end subroutine read_potato_input
+
+    logical function potato_input_is_valid()
+        potato_input_is_valid = 0.d0 < rho_pol .and. rho_pol <= rho_pol_max &
+            .and. rho_pol_max < 1.d0
+        if (itest_type == 3) then
+            potato_input_is_valid = potato_input_is_valid &
+                .and. rho_pol < rho_pol_max
+        endif
+    end function potato_input_is_valid
 
     subroutine print_potato_input(iunit)
         integer, intent(in) :: iunit
@@ -186,6 +203,8 @@ contains
         write(iunit, '(A,ES12.5)') '  probe_rho_pol    = ', probe_rho_pol
         write(iunit, '(A,ES12.5)') '  probe_ux         = ', probe_ux
         write(iunit, '(A,ES12.5)') '  probe_eta        = ', probe_eta
+        write(iunit, '(A,ES12.5)') '  probe_toten      = ', probe_toten
+        write(iunit, '(A,ES12.5)') '  probe_perpinv    = ', probe_perpinv
         write(iunit, '(A,I0)') '  probe_m          = ', probe_m
         write(iunit, '(A,I0)') '  probe_n          = ', probe_n
         write(iunit, '(A)') '================================'

--- a/POTATO/SRC/potato_poicut_probe.f90
+++ b/POTATO/SRC/potato_poicut_probe.f90
@@ -1,0 +1,20 @@
+program potato_poicut_probe
+    use potato_input_mod, only: read_potato_input, rho_pol, rho_pol_max, &
+        npoicut, edge_extension
+    use field_eq_mod, only: allow_sol
+    use poicut_mod, only: npc, rpc_arr, zpc_arr, rmagaxis, zmagaxis, &
+        Rbou_lfs, Zbou_lfs, Rbou_hfs, Zbou_hfs
+
+    implicit none
+
+    call read_potato_input('potato.in')
+    allow_sol = edge_extension
+
+    call find_poicut(rho_pol_max, npoicut)
+    call rhopol_boundary(rho_pol)
+
+    write(*, '(a,1x,*(es24.16e3,1x))') 'POTATO_POICUT', &
+        rpc_arr(0), zpc_arr(0), rpc_arr(npc), zpc_arr(npc), &
+        rmagaxis, zmagaxis, Rbou_hfs, Zbou_hfs, Rbou_lfs, Zbou_lfs
+
+end program potato_poicut_probe

--- a/POTATO/SRC/potato_resonance_probe.f90
+++ b/POTATO/SRC/potato_resonance_probe.f90
@@ -12,7 +12,7 @@ program potato_resonance_probe
     use potato_input_mod, only : read_potato_input, E_alpha, A_alpha, Z_alpha, &
         rho_pol, rho_pol_max, scalfac_energy, scalfac_efield, Rmax_orbit, &
         ntimstep, npoicut, profile_file, edge_extension, probe_rho_pol, &
-        probe_ux, probe_eta, probe_m, probe_n, &
+        probe_ux, probe_eta, probe_toten, probe_perpinv, probe_m, probe_n, &
         input_clip_resonance_classes => clip_resonance_classes
     use field_eq_mod, only : allow_sol, psi_axis, psi_sep
     implicit none
@@ -48,9 +48,18 @@ program potato_resonance_probe
     psi = psi_axis + probe_rho_pol**2*(psi_sep - psi_axis)
     call denstemp_of_psi(psi, dens, temp, ddens, dtemp)
     call phielec_of_psi(psi, phi_elec, dPhi_dpsi)
-    enkin = probe_ux**2*temp
-    toten = enkin + phi_elec
-    perpinv = probe_eta*enkin
+    if (probe_toten >= 0.d0 .or. probe_perpinv >= 0.d0) then
+        if (probe_toten < 0.d0 .or. probe_perpinv < 0.d0) then
+            error stop 'probe_toten and probe_perpinv must be supplied together'
+        endif
+        toten = probe_toten
+        perpinv = probe_perpinv
+        enkin = toten - phi_elec
+    else
+        enkin = probe_ux**2*temp
+        toten = enkin + phi_elec
+        perpinv = probe_eta*enkin
+    endif
 
     call find_bounds_fixpoints(regions, ierr)
 
@@ -80,6 +89,7 @@ program potato_resonance_probe
         if (ierr /= 0) then
             write(unit_out, '(A,I0,A,I0)') "# class_error iclass=", iclass, &
                 " ierr=", ierr
+            call write_partial_class_grid(unit_out)
             cycle
         endif
         call write_class_probe(unit_out)
@@ -130,6 +140,20 @@ contains
             have_prev = .true.
         enddo
     end subroutine write_class_probe
+
+    subroutine write_partial_class_grid(iunit)
+        use sample_matrix_mod, only : amat_arr
+
+        integer, intent(in) :: iunit
+        integer :: i
+
+        write(iunit, '(A)') &
+            "# partial iclass i x psiast taub delphi"
+        do i = 1, npoi
+            write(iunit, '(A,2I8,4ES24.15)') "# partial", iclass, i, xarr(i), &
+                amat_arr(1:3,1,i)
+        enddo
+    end subroutine write_partial_class_grid
 
     subroutine write_regions(iunit, regions_in)
         integer, intent(in) :: iunit

--- a/POTATO/SRC/potato_resonance_probe.f90
+++ b/POTATO/SRC/potato_resonance_probe.f90
@@ -6,7 +6,8 @@ program potato_resonance_probe
     use bounds_fixpoints_mod, only : region_set_t
     use form_classes_doublecount_mod, only : nclasses, ifuntype, sigma_class, &
         R_class_beg, R_class_end
-    use get_matrix_mod, only : iclass
+    use get_matrix_mod, only : iclass, delphi_max
+    use resonance_mode_bounds_mod, only : resonant_delphi_bound
     use sample_matrix_mod, only : n1, npoi, xarr
     use phielec_of_psi_mod, only : polyphi, polydens, polytemp
     use potato_input_mod, only : read_potato_input, E_alpha, A_alpha, Z_alpha, &
@@ -25,6 +26,7 @@ program potato_resonance_probe
 
     type(region_set_t) :: regions
     integer :: ierr, unit_out
+    integer, dimension(1) :: probe_modes_m, probe_modes_n
     double precision :: psi, dens, temp, ddens, dtemp, phi_elec, dPhi_dpsi
     double precision :: enkin, v0, bmod_ref
 
@@ -44,6 +46,9 @@ program potato_resonance_probe
     call load_profiles
     call find_poicut(rho_pol_max, npoicut)
     call rhopol_boundary(rho_pol)
+    probe_modes_m = probe_m
+    probe_modes_n = probe_n
+    delphi_max = resonant_delphi_bound(probe_modes_m, probe_modes_n)
 
     psi = psi_axis + probe_rho_pol**2*(psi_sep - psi_axis)
     call denstemp_of_psi(psi, dens, temp, ddens, dtemp)

--- a/POTATO/SRC/resonance_mode_bounds_mod.f90
+++ b/POTATO/SRC/resonance_mode_bounds_mod.f90
@@ -3,6 +3,15 @@ module resonance_mode_bounds_mod
 
 contains
 
+    pure double precision function toroidal_torque_mode_factor(n_mode)
+        integer, intent(in) :: n_mode
+
+        ! The signed n_mode remains in the resonance and Fourier phase. The
+        ! torque prefactor is |m_3| in the quasilinear action-space formula,
+        ! so conjugate representations of one real field have the same factor.
+        toroidal_torque_mode_factor = abs(dble(n_mode))
+    end function toroidal_torque_mode_factor
+
     pure function resonant_delphi_bound(m_modes, n_modes) result(bound)
         integer, intent(in) :: m_modes(:), n_modes(:)
         double precision :: bound

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -738,6 +738,11 @@ subroutine resonant_torque
             !
             call sample_matrix_out(get_matrix_res,ierr)
             if(ierr.ne.0) then
+                write(unit1902, '(A)') &
+                    '# rejected partial J_perp grid: perpinv mode_integrands'
+                do i=1,npoi
+                    write(unit1902,*) xarr(i),amat_arr(:,1,i)
+                enddo
                 write(msg, '(A,I0,A,I0)') &
                     'FATAL: incomplete energy slice ', ienerg, &
                     ', callback/status = ', ierr

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -5,18 +5,26 @@
 !
 module resint_mod
     !
+    integer, parameter :: root_disposition_unclassified = -1
+    integer, parameter :: root_disposition_complete = 0
+    integer, parameter :: root_disposition_explicit_sol_zero = 1
+    !
     type respoints_fix_jperp_mode_class
     integer :: nrespoi
     double precision :: toten_res,perpinv_res
     double precision, dimension(:),   allocatable :: w_res
     double precision, dimension(:,:), allocatable :: z_res
     double precision, dimension(:),   allocatable :: taub
+    double precision, dimension(:),   allocatable :: psiast
+    integer, dimension(:),            allocatable :: disposition
 end type
 !
 type respoint_single
 double precision :: toten_res,perpinv_res,w_res
 double precision, dimension(5) :: z_res
-double precision :: taub
+double precision :: taub,psiast
+integer :: energy_index,jperp_index,class_index,root_index
+integer :: m_mode,n_mode,disposition
 end type
 !
 type respoints_fix_jperp
@@ -175,7 +183,9 @@ subroutine integrate_class_resonances
     use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
     use resint_mod,         only : nmodes,marr,narr,twopim2,rm3,delint_mode,respoints_jp, &
         psiast_res,taub_res,delphi_res,resline_unit, &
-        resline_unit_is_private,resline_diag_unit
+        resline_unit_is_private,resline_diag_unit, &
+        root_disposition_unclassified,root_disposition_complete, &
+        root_disposition_explicit_sol_zero
     use orbit_dim_mod,      only : neqm
     use global_invariants,  only : dtau,toten,perpinv,cE_ref,Phi_eff
     use sample_matrix_mod,  only : npoi,xarr
@@ -183,7 +193,8 @@ subroutine integrate_class_resonances
     use interp_cache_mod,   only : interp_cache_reset
     use field_sub,          only : psif
     use field_eq_mod,       only : psi_axis,psi_sep
-    use resonance_mode_bounds_mod, only : canonical_flux_outside_lcfs
+    use resonance_mode_bounds_mod, only : canonical_flux_outside_lcfs, &
+        toroidal_torque_mode_factor
     use matrix_callback_status_mod, only : &
         matrix_callback_resonance_search_failed, &
         matrix_callback_resonance_orbit_failed, &
@@ -269,12 +280,20 @@ subroutine integrate_class_resonances
         if(nroots.eq.0) cycle
         allocate(respoints_jp(mode,iclass)%w_res(nroots), &
             respoints_jp(mode,iclass)%z_res(5,nroots), &
-            respoints_jp(mode,iclass)%taub(nroots))
+            respoints_jp(mode,iclass)%taub(nroots), &
+            respoints_jp(mode,iclass)%psiast(nroots), &
+            respoints_jp(mode,iclass)%disposition(nroots))
+        respoints_jp(mode,iclass)%w_res=0.d0
+        respoints_jp(mode,iclass)%z_res=0.d0
+        respoints_jp(mode,iclass)%taub=0.d0
+        respoints_jp(mode,iclass)%psiast=0.d0
+        respoints_jp(mode,iclass)%disposition=root_disposition_unclassified
         !
         do iroot=1,nroots
             !
             resonance_root_attempted=resonance_root_attempted+1
             call get_rescond(roots(iroot),rescond,dresconddx)
+            respoints_jp(mode,iclass)%psiast(iroot)=psiast_res
             call xi_func(ifuntype(iclass),roots(iroot),xi,dxi_dx)
             !
             Rst=R_class_beg(iclass)+delta_R*xi
@@ -323,6 +342,8 @@ subroutine integrate_class_resonances
                 ! the integrator cap before returning zero.  It is also outside
                 ! the comparison domain, so weight it zero without the integration.
                 absHn2=0.d0
+                respoints_jp(mode,iclass)%disposition(iroot)= &
+                    root_disposition_explicit_sol_zero
                 resonance_root_zeroed=resonance_root_zeroed+1
             else
                 call pertham(z,absHn2,ierr)
@@ -330,6 +351,8 @@ subroutine integrate_class_resonances
                     resonance_root_failed=resonance_root_failed+1
                     cycle
                 endif
+                respoints_jp(mode,iclass)%disposition(iroot)= &
+                    root_disposition_complete
             endif
             call equilmaxw(psiast_res,fmaxw)
             call denstemp_of_psi(psiast_res,dens,temp,ddens,dtemp)
@@ -355,7 +378,8 @@ subroutine integrate_class_resonances
             !
             ! multiply expression under summation over modes with toroidal mode number, with factor $-\pi^{3/2}/4$
             ! and with reference energy:
-            one_res=one_res*abs(rm3)*pi32_over4m*cE_ref
+            one_res=one_res*toroidal_torque_mode_factor(narr(mode)) &
+                *pi32_over4m*cE_ref
             !
             ! A near-tangent root (dresconddx -> 0) gives an infinite
             ! dpsiastdx/dresconddx; for a wall-crossing resonance absHn2=0, so the
@@ -572,26 +596,33 @@ subroutine resonant_torque
         eps_sampling, itermax_sampling
     use logging_mod,       only : tee_message
     use matrix_callback_status_mod, only : matrix_callback_error, &
-        matrix_callback_ok, reset_torque_completeness, &
+        matrix_callback_ok, matrix_callback_box_count_failed, &
+        reset_torque_completeness, &
         jperp_attempted,jperp_succeeded,jperp_failed, &
         class_attempted,class_succeeded,class_failed, &
         orbit_attempted,orbit_failed,resonance_search_attempted, &
         resonance_search_failed,resonance_root_attempted, &
-        resonance_root_succeeded,resonance_root_failed,resonance_root_zeroed
+        resonance_root_succeeded,resonance_root_failed,resonance_root_zeroed, &
+        box_count_attempted,box_count_succeeded,box_count_failed, &
+        box_count_skipped_zero_weight
+    use box_counting_status_mod, only : box_count_skipped => &
+        box_count_skipped_zero_weight, box_count_ok
     !$ use omp_lib, only : omp_set_max_active_levels, omp_set_num_threads
 
     implicit none
     !
     double precision, parameter :: pi=3.14159265358979d0
-    integer, parameter :: ncompleteness=14
+    integer, parameter :: ncompleteness=18
     integer :: nr,nz,ir,iz,i,k,iperp,nperp,ierr,nprof,ienerg,nenerg
     integer :: omp_threads_env_len
-    integer :: nrespoints,unit1901,unit1902,ienerg_begin
+    integer :: nrespoints,unit1901,unit1902,unit1903,ienerg_begin
     double precision :: rbeg,hr,zbeg,hz,weight,psi,psipow
     double precision :: bmod,phi_elec,phi_elec_min,phi_elec_max
     double precision :: toten_min,toten_max,thermen_max,toten_range
     double precision :: omdens,trapez_fac,perpinv_max
     double precision :: torque_int,torque_int_loc
+    double precision :: torquebox_outside,torquebox_outside_loc
+    double precision :: outside_fraction
     double precision :: xjperp,xenerg,totxint,step_energ
     double precision :: time_beg,time_end
     double precision :: dens, temp, ddens, dtemp
@@ -605,11 +636,14 @@ subroutine resonant_torque
     double precision, dimension(:), allocatable :: torque_int_energy
     double precision, dimension(:,:), allocatable :: torque_int_modes_energy
     double precision, dimension(:,:), allocatable :: torquebox_energy
+    double precision, dimension(:), allocatable :: torquebox_outside_energy
     integer, dimension(:), allocatable :: energy_status
     integer, dimension(:,:), allocatable :: completeness_counts
     ! Per-resonance-point box times, filled by the parallel time_in_box pass and
     ! consumed by the serial accumulate/write pass below.
     double precision, dimension(:,:), allocatable :: taubox_all
+    double precision, dimension(:), allocatable :: taubox_outside_all
+    integer, dimension(:), allocatable :: box_status_all
     !
     external :: get_matrix_res
     !
@@ -672,11 +706,13 @@ subroutine resonant_torque
     allocate(torque_int_modes(nmodes))
     torque_int_modes=0.d0
     allocate(torque_int_energy(nenerg),torque_int_modes_energy(nmodes,nenerg), &
-        torquebox_energy(nbox,nenerg),energy_status(nenerg), &
+        torquebox_energy(nbox,nenerg),torquebox_outside_energy(nenerg), &
+        energy_status(nenerg), &
         completeness_counts(ncompleteness,nenerg))
     torque_int_energy=0.d0
     torque_int_modes_energy=0.d0
     torquebox_energy=0.d0
+    torquebox_outside_energy=0.d0
     energy_status=-1
     completeness_counts=0
     !
@@ -692,7 +728,9 @@ subroutine resonant_torque
     !$omp parallel do default(shared) schedule(dynamic) &
     !$omp   private(xenerg,perpinv_max,trapez_fac,nrespoints,i,k,iperp,ierr,nperp) &
     !$omp   private(time_beg,time_end,xjperp,torque_int_loc,msg,taubox_all) &
-    !$omp   private(unit1901,unit1902,torque_int_modes_loc,torquebox_loc) &
+    !$omp   private(taubox_outside_all,box_status_all,torquebox_outside_loc) &
+    !$omp   private(unit1901,unit1902,unit1903,outside_fraction) &
+    !$omp   private(torque_int_modes_loc,torquebox_loc) &
     !$omp   copyin(dtau)
     do ienerg=ienerg_begin,nenerg
         call reset_torque_completeness
@@ -711,9 +749,10 @@ subroutine resonant_torque
         allocate(torque_int_modes_loc(nmodes),torquebox_loc(nbox))
         torque_int_modes_loc=0.d0
         torquebox_loc=0.d0
+        torquebox_outside_loc=0.d0
         resline_unit_is_private=.true.
         resline_diag_unit_is_private=.true.
-        call open_energy_outputs(ienerg,adaptive_jperp,unit1901,unit1902)
+        call open_energy_outputs(ienerg,adaptive_jperp,unit1901,unit1902,unit1903)
         !toten =   -3.1211921097605737d0
         write(msg, '(A,ES22.14)') 'toten = ', toten
         call tee_message(trim(msg))
@@ -755,6 +794,7 @@ subroutine resonant_torque
                 close(resline_diag_unit)
                 close(unit1901)
                 close(unit1902)
+                close(unit1903)
                 deallocate(torque_int_modes_loc,torquebox_loc)
                 cycle
             endif
@@ -815,6 +855,16 @@ subroutine resonant_torque
                                 =respoints_all(iperp)%respoints_jp(i,iclass)%z_res(:,k)
                             respoint(nrespoints)%taub &
                                 =respoints_all(iperp)%respoints_jp(i,iclass)%taub(k)
+                            respoint(nrespoints)%psiast &
+                                =respoints_all(iperp)%respoints_jp(i,iclass)%psiast(k)
+                            respoint(nrespoints)%energy_index=ienerg
+                            respoint(nrespoints)%jperp_index=iperp
+                            respoint(nrespoints)%class_index=iclass
+                            respoint(nrespoints)%root_index=k
+                            respoint(nrespoints)%m_mode=marr(i)
+                            respoint(nrespoints)%n_mode=narr(i)
+                            respoint(nrespoints)%disposition= &
+                                respoints_all(iperp)%respoints_jp(i,iclass)%disposition(k)
                         enddo
                     enddo
                 enddo
@@ -827,34 +877,77 @@ subroutine resonant_torque
             ! boxes via dvode -- the dominant per-point cost.  Points are independent and
             ! dvode_f90_m is threadprivate/thread-safe, so run them in parallel into the
             ! per-point taubox_all.  z_res(1:5) is the orbit start at the Poincare cut.
-            allocate(taubox_all(nbox,nrespoints))
+            allocate(taubox_all(nbox,nrespoints), &
+                taubox_outside_all(nrespoints),box_status_all(nrespoints))
             !$omp parallel do default(shared) private(i) schedule(dynamic)
             do i=1,nrespoints
                 if(respoint(i)%w_res.eq.0.d0) then
                     ! Zero-weight (SOL / unintegrable) point: no torque to deposit,
                     ! and its orbit is the expensive one to trace.  Skip it.
                     taubox_all(:,i)=0.d0
+                    taubox_outside_all(i)=0.d0
+                    box_status_all(i)=box_count_skipped
                 else
                     call time_in_box(respoint(i)%z_res(1:5), nbox, sbox, &
-                        respoint(i)%taub, taubox_all(:,i))
+                        respoint(i)%taub, taubox_all(:,i), &
+                        taubox_outside_all(i),box_status_all(i))
                 endif
             enddo
             !$omp end parallel do
+            box_count_attempted=count(box_status_all.ne.box_count_skipped)
+            box_count_succeeded=count(box_status_all.eq.box_count_ok)
+            box_count_failed=count(box_status_all.gt.box_count_ok)
+            box_count_skipped_zero_weight=count( &
+                box_status_all.eq.box_count_skipped)
+            if(box_count_failed.gt.0) then
+                ierr=matrix_callback_box_count_failed
+                write(msg, '(A,I0,A,I0)') &
+                    'FATAL: incomplete box disposition in energy slice ', &
+                    ienerg, ', failed resonant points = ', box_count_failed
+                call tee_message(trim(msg))
+                call snapshot_completeness(ienerg,ierr)
+                deallocate(taubox_all,taubox_outside_all,box_status_all)
+                deallocate(respoint)
+                if(allocated(respoints_jp)) deallocate(respoints_jp)
+                if(allocated(respoints_all)) deallocate(respoints_all)
+                if(allocated(respoints_all_tmp)) deallocate(respoints_all_tmp)
+                close(resline_unit)
+                close(resline_diag_unit)
+                close(unit1901)
+                close(unit1902)
+                close(unit1903)
+                deallocate(torque_int_modes_loc,torquebox_loc)
+                cycle
+            endif
             !
             ! Serial accumulate/write pass: torque_int_loc is a running prefix sum written
             ! per row to fort.1901, so it stays serial and in order; torquebox sums the
             ! per-point box times.  Width of the energy interval is already in the weight.
             do i=1,nrespoints
                 torque_int_loc=torque_int_loc+respoint(i)%w_res
+                if(box_status_all(i).eq.box_count_ok) then
+                    outside_fraction=taubox_outside_all(i)/respoint(i)%taub
+                else
+                    outside_fraction=-1.d0
+                endif
+                write(unit1903,*) respoint(i)%energy_index, &
+                    respoint(i)%jperp_index,respoint(i)%class_index, &
+                    respoint(i)%root_index,respoint(i)%m_mode, &
+                    respoint(i)%n_mode,respoint(i)%disposition, &
+                    box_status_all(i),respoint(i)%toten_res, &
+                    respoint(i)%perpinv_res,respoint(i)%psiast, &
+                    respoint(i)%taub,respoint(i)%w_res,outside_fraction
                 write(unit1901,*) respoint(i)%toten_res, &
                     respoint(i)%perpinv_res, &
                     torque_int_loc
                 if(respoint(i)%w_res.ne.0.d0 .and. respoint(i)%taub.gt.0.d0) then
                     torquebox_loc=torquebox_loc &
                         +respoint(i)%w_res*taubox_all(:,i)/respoint(i)%taub
+                    torquebox_outside_loc=torquebox_outside_loc &
+                        +respoint(i)%w_res*taubox_outside_all(i)/respoint(i)%taub
                 endif
             enddo
-            deallocate(taubox_all)
+            deallocate(taubox_all,taubox_outside_all,box_status_all)
             write(unit1901,*) ' '
             !
             deallocate(respoint)
@@ -865,6 +958,7 @@ subroutine resonant_torque
             ! Sum up contributions of energy levels:
             torque_int_energy(ienerg)=torque_int_loc
             torquebox_energy(:,ienerg)=torquebox_loc
+            torquebox_outside_energy(ienerg)=torquebox_outside_loc
             write(msg, '(A,ES22.14)') &
                 'method 1, torque_int_loc = ', torque_int_loc
             call tee_message(trim(msg))
@@ -940,7 +1034,9 @@ subroutine resonant_torque
             if(allocated(respoints_all_tmp)) deallocate(respoints_all_tmp)
             close(resline_unit)
             close(resline_diag_unit)
+            if(adaptive_jperp) close(unit1901)
             close(unit1902)
+            close(unit1903)
             deallocate(torque_int_modes_loc,torquebox_loc)
             cycle
         endif
@@ -956,6 +1052,7 @@ subroutine resonant_torque
         close(resline_diag_unit)
         if(adaptive_jperp) close(unit1901)
         close(unit1902)
+        close(unit1903)
         deallocate(torque_int_modes_loc,torquebox_loc)
         !
     enddo
@@ -968,15 +1065,19 @@ subroutine resonant_torque
     torque_int=0.d0
     torque_int_modes=0.d0
     torquebox=0.d0
+    torquebox_outside=0.d0
     do ienerg=1,nenerg
         torque_int=torque_int+torque_int_energy(ienerg)
         torque_int_modes=torque_int_modes+torque_int_modes_energy(:,ienerg)
         torquebox=torquebox+torquebox_energy(:,ienerg)
+        torquebox_outside=torquebox_outside+torquebox_outside_energy(ienerg)
     enddo
     !
     call merge_energy_files('fort.31415.energy.', 'fort.31415', nenerg)
     call merge_energy_files('fort.31415.diagnostics.energy.', &
         'fort.31415.diagnostics', nenerg)
+    call merge_energy_files('potato_resonance_weights.dat.energy.', &
+        'potato_resonance_weights.dat', nenerg)
     if(adaptive_jperp) then
         call merge_energy_files('subint_ofH0int_104_vsJperp_fromresp.dat.energy.', &
             'subint_ofH0int_104_vsJperp_fromresp.dat', nenerg)
@@ -1003,6 +1104,10 @@ subroutine resonant_torque
             write(1,*) torquebox(i), sbox(i-1), sbox(i)
         enddo
         close(1)
+        open(1,file='boxcounted_torque_outside.dat')
+        write(1,'(A)') '# torque_erg s_pol_lower_bound'
+        write(1,*) torquebox_outside, sbox(nbox)
+        close(1)
     endif
     !
 contains
@@ -1017,7 +1122,9 @@ contains
             class_attempted,class_succeeded,class_failed,orbit_attempted, &
             orbit_failed,resonance_search_attempted,resonance_search_failed, &
             resonance_root_attempted,resonance_root_succeeded, &
-            resonance_root_failed,resonance_root_zeroed]
+            resonance_root_failed,resonance_root_zeroed, &
+            box_count_attempted,box_count_succeeded,box_count_failed, &
+            box_count_skipped_zero_weight]
         !
     end subroutine snapshot_completeness
     !
@@ -1033,7 +1140,9 @@ contains
             'class_attempted class_succeeded class_failed orbit_attempted ' // &
             'orbit_failed resonance_search_attempted resonance_search_failed ' // &
             'resonance_root_attempted resonance_root_succeeded ' // &
-            'resonance_root_failed resonance_root_explicit_SOL_zero'
+            'resonance_root_failed resonance_root_explicit_SOL_zero ' // &
+            'box_count_attempted box_count_succeeded box_count_failed ' // &
+            'box_count_skipped_zero_weight'
         do idx=ienerg_begin,nenerg
             write(unit_complete,'(*(I0,1X))') idx,energy_status(idx), &
                 completeness_counts(:,idx)
@@ -1054,13 +1163,14 @@ contains
         !
     end subroutine energy_path
     !
-    subroutine open_energy_outputs(idx, adaptive, unit_fromresp, unit_jperp)
+    subroutine open_energy_outputs(idx, adaptive, unit_fromresp, unit_jperp, &
+            unit_weights)
         !
         implicit none
         !
         integer, intent(in) :: idx
         logical, intent(in) :: adaptive
-        integer, intent(out) :: unit_fromresp, unit_jperp
+        integer, intent(out) :: unit_fromresp, unit_jperp, unit_weights
         character(len=256) :: path
         !
         call energy_path('fort.31415.energy.', idx, path)
@@ -1069,6 +1179,12 @@ contains
         open(newunit=resline_diag_unit,file=trim(path),status='replace',action='write')
         write(resline_diag_unit,'(A)') &
             '# toten perpinv psiast m n Rst Zst psif psiast_minus_psif x iclass taub delphi p lambda bmod phi_elec'
+        call energy_path('potato_resonance_weights.dat.energy.', idx, path)
+        open(newunit=unit_weights,file=trim(path),status='replace',action='write')
+        write(unit_weights,'(A)') &
+            '# energy_index jperp_index class_index root_index m2 n3 ' // &
+            'root_disposition box_disposition H0_over_Eref Jperp ' // &
+            'psiast taub final_weight_erg outside_s_pol_fraction'
         !
         unit_fromresp=-1
         if(adaptive) then

--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -95,7 +95,7 @@ end subroutine velo_res
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-subroutine pertham(z,absHn2)
+subroutine pertham(z,absHn2,ierr_out)
     !
     ! Computes modulus squared of the Fourier amplitude of the normalized perturbed
     ! Hamiltoninan, $|\hat H_\bm|^2$, with $\hat H_\bm$ defined by Eq.(102) (former Eq.(93)).
@@ -103,19 +103,22 @@ subroutine pertham(z,absHn2)
     use orbit_dim_mod,     only : neqm,next     ,write_orb,iunit1
     use global_invariants, only : dtau
     use resint_mod,        only : taub_new,delphi_new,toten_orb,perpinv_orb
+    use matrix_callback_status_mod, only : matrix_callback_bounce_failed, &
+        set_matrix_callback_error, orbit_attempted, orbit_failed
     !
     !
     implicit none
     !
     complex(8), parameter :: imun=(0.d0,1.d0)
     !
-    integer :: ierr
+    integer :: ierr,ierr_out
     double precision :: absHn2,bmod,phi_elec,taub,delphi
     double precision, dimension(neqm) :: z
     double precision, dimension(:), allocatable :: extraset
     !
     external :: velo,velo_res
     !
+    ierr_out=0
     call get_bmod_and_Phi(z(1:3),bmod,phi_elec)
     !
     toten_orb=z(4)**2+phi_elec
@@ -124,9 +127,13 @@ subroutine pertham(z,absHn2)
     next=0
     allocate(extraset(next))
     !
+    orbit_attempted=orbit_attempted+1
     call find_bounce(next,velo,dtau,z,taub,delphi,extraset,ierr)
     if(ierr.ne.0) then
         absHn2 = 0.d0
+        ierr_out=ierr
+        orbit_failed=orbit_failed+1
+        call set_matrix_callback_error(matrix_callback_bounce_failed)
         deallocate(extraset)
         return
     endif
@@ -139,9 +146,13 @@ subroutine pertham(z,absHn2)
     allocate(extraset(next))
     extraset=0.d0
     !
+    orbit_attempted=orbit_attempted+1
     call find_bounce(next,velo_res,dtau,z,taub,delphi,extraset,ierr)
     if(ierr.ne.0) then
         absHn2 = 0.d0
+        ierr_out=ierr
+        orbit_failed=orbit_failed+1
+        call set_matrix_callback_error(matrix_callback_bounce_failed)
         deallocate(extraset)
         return
     endif
@@ -173,6 +184,13 @@ subroutine integrate_class_resonances
     use field_sub,          only : psif
     use field_eq_mod,       only : psi_axis,psi_sep
     use resonance_mode_bounds_mod, only : canonical_flux_outside_lcfs
+    use matrix_callback_status_mod, only : &
+        matrix_callback_resonance_search_failed, &
+        matrix_callback_resonance_orbit_failed, &
+        matrix_callback_nonfinite_weight, set_matrix_callback_error, &
+        resonance_search_attempted, resonance_search_failed, &
+        resonance_root_attempted, resonance_root_succeeded, &
+        resonance_root_failed, resonance_root_zeroed
     use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
     !
     implicit none
@@ -186,6 +204,7 @@ subroutine integrate_class_resonances
     double precision :: one_res,sigma,delta_R,Rst,xi,dxi_dx,dpsiast_dRst,absHn2
     double precision :: bmod_st,phi_elec_st
     double precision :: fmaxw,A1ast,A2ast
+    logical :: outside_lcfs
     double precision :: dens,temp,ddens,dtemp,phi_elec,dPhi_dpsi
     double precision, dimension(neqm) :: z
     !
@@ -227,9 +246,13 @@ subroutine integrate_class_resonances
         rm3=dble(narr(mode))
         delint_mode(mode)=0.d0
         !
+        resonance_search_attempted=resonance_search_attempted+1
         call find_all_roots_bracketed(get_rescond,xbeg,xend,ierr)
         !
         if(ierr.ne.0) then
+            resonance_search_failed=resonance_search_failed+1
+            call set_matrix_callback_error( &
+                matrix_callback_resonance_search_failed)
             !$omp critical (reslines_log)
             call tee_message( &
                 'integrate_class_resonances: error in find_all_roots')
@@ -250,6 +273,7 @@ subroutine integrate_class_resonances
         !
         do iroot=1,nroots
             !
+            resonance_root_attempted=resonance_root_attempted+1
             call get_rescond(roots(iroot),rescond,dresconddx)
             call xi_func(ifuntype(iclass),roots(iroot),xi,dxi_dx)
             !
@@ -259,6 +283,9 @@ subroutine integrate_class_resonances
                 psiast_res,dpsiast_dRst,z,ierr)
             !
             if(ierr.ne.0) then
+                resonance_root_failed=resonance_root_failed+1
+                call set_matrix_callback_error( &
+                    matrix_callback_resonance_orbit_failed)
                 !$omp critical (reslines_log)
                 call tee_message( &
                     'integrate_class_resonances: error in starter_doublecount')
@@ -288,14 +315,21 @@ subroutine integrate_class_resonances
             !
             dpsiastdx=dpsiast_dRst*delta_R*dxi_dx !$\difp{\psi^\ast}{x}$
             !
-            if(canonical_flux_outside_lcfs(psiast_res,psi_axis,psi_sep)) then
+            outside_lcfs=canonical_flux_outside_lcfs( &
+                psiast_res,psi_axis,psi_sep)
+            if(outside_lcfs) then
                 ! SOL resonance (rho_pol > 1): the orbit leaves the field domain,
                 ! so pertham/find_bounce cannot close it and would only grind to
                 ! the integrator cap before returning zero.  It is also outside
                 ! the comparison domain, so weight it zero without the integration.
                 absHn2=0.d0
+                resonance_root_zeroed=resonance_root_zeroed+1
             else
-                call pertham(z,absHn2)
+                call pertham(z,absHn2,ierr)
+                if(ierr.ne.0) then
+                    resonance_root_failed=resonance_root_failed+1
+                    cycle
+                endif
             endif
             call equilmaxw(psiast_res,fmaxw)
             call denstemp_of_psi(psiast_res,dens,temp,ddens,dtemp)
@@ -327,11 +361,21 @@ subroutine integrate_class_resonances
             ! dpsiastdx/dresconddx; for a wall-crossing resonance absHn2=0, so the
             ! product is Inf*0 = NaN.  Such a degenerate resonance carries no
             ! physical weight -- zero it so one bad root cannot poison the torque.
-            if (.not. ieee_is_finite(one_res)) one_res=0.d0
+            if (.not. ieee_is_finite(one_res)) then
+                if(outside_lcfs .and. absHn2.eq.0.d0) then
+                    one_res=0.d0
+                else
+                    resonance_root_failed=resonance_root_failed+1
+                    call set_matrix_callback_error( &
+                        matrix_callback_nonfinite_weight)
+                    cycle
+                endif
+            endif
             !
             respoints_jp(mode,iclass)%w_res(iroot)=one_res
             respoints_jp(mode,iclass)%taub(iroot)=taub_res
             delint_mode(mode)=delint_mode(mode)+one_res
+            resonance_root_succeeded=resonance_root_succeeded+1
         enddo
     enddo
     !$omp end do
@@ -378,7 +422,8 @@ subroutine get_matrix_res
     !
     use sample_matrix_out_mod,        only : n1,n2,x,amat,icount
     use global_invariants,            only : toten,perpinv
-    use form_classes_doublecount_mod, only : nclasses
+    use form_classes_doublecount_mod, only : nclasses,ifuntype, &
+        R_class_beg,R_class_end
     use get_matrix_mod,               only : iclass
     use resint_mod,                   only : nmodes,nperp_max,respoints_jp, &
         respoints_all,respoints_all_tmp
@@ -386,6 +431,11 @@ subroutine get_matrix_res
     use orbit_dim_mod,                only : write_orb
     use logging_mod,                  only : tee_message, close_logging
     use bounds_fixpoints_mod,         only : region_set_t
+    use matrix_callback_status_mod,   only : matrix_callback_error, &
+        matrix_callback_ok, matrix_callback_bounds_failed, &
+        matrix_callback_classes_failed, matrix_callback_class_sampling_failed, &
+        set_matrix_callback_error, jperp_attempted, jperp_succeeded, &
+        jperp_failed, class_attempted, class_succeeded, class_failed
     !
     logical :: classes_talk
     !
@@ -398,7 +448,9 @@ subroutine get_matrix_res
     write_orb=.false.
     classes_talk=.false.
     !
+    jperp_attempted=jperp_attempted+1
     perpinv=x
+    amat=0.d0
     !
     call find_bounds_fixpoints(regions,ierr)
     !
@@ -406,8 +458,9 @@ subroutine get_matrix_res
         write(msg, '(A,I0)') &
             'get_matrix_res: find_bounds_fixpoints ierr = ', ierr
         call tee_message(trim(msg))
-        call close_logging()
-        stop
+        call set_matrix_callback_error(matrix_callback_bounds_failed)
+        jperp_failed=jperp_failed+1
+        return
     endif
     !
     call form_classes_doublecount(regions,classes_talk,ierr)
@@ -416,8 +469,9 @@ subroutine get_matrix_res
         write(msg, '(A,I0)') &
             'get_matrix_res: form_classes ierr = ', ierr
         call tee_message(trim(msg))
-        call close_logging()
-        stop
+        call set_matrix_callback_error(matrix_callback_classes_failed)
+        jperp_failed=jperp_failed+1
+        return
     endif
     !
     allocate(respoints_jp(nmodes,nclasses))
@@ -425,11 +479,18 @@ subroutine get_matrix_res
     !
     do iclass=1,nclasses
         !
+        class_attempted=class_attempted+1
         call sample_class_doublecount(1,ierr)
         !
         if(ierr.eq.0) then
             !
             call integrate_class_resonances
+            if(matrix_callback_error.ne.matrix_callback_ok) then
+                class_failed=class_failed+1
+                jperp_failed=jperp_failed+1
+                if(allocated(respoints_jp)) deallocate(respoints_jp)
+                return
+            endif
             !
             do mode=1,nmodes
                 ! amat(:,1) - sum over classes and resonances within each class:
@@ -437,15 +498,26 @@ subroutine get_matrix_res
                     amat(mode,1)=amat(mode,1)+sum(respoints_jp(mode,iclass)%w_res)
                 endif
             enddo
+            class_succeeded=class_succeeded+1
         else
-            write(msg, '(A,I0)') &
-                'get_matrix_res: sample_class_doublecount error ', ierr
+            write(msg, '(A,I0,A,I0,A,I0,A,ES14.6,A,ES14.6,A,ES14.6)') &
+                'get_matrix_res: sample_class error=', ierr, &
+                ' class=',iclass,' type=',ifuntype(iclass), &
+                ' toten=',toten,' perpinv=',perpinv, &
+                ' R_beg=',R_class_beg(iclass)
             call tee_message(trim(msg))
-            do mode=1,nmodes
-                respoints_jp(mode,iclass)%nrespoi=0
-                respoints_jp(mode,iclass)%toten_res=toten
-                respoints_jp(mode,iclass)%perpinv_res=perpinv
-            enddo
+            write(msg, '(A,ES14.6,A,I0)') &
+                'get_matrix_res: failed class R_end=',R_class_end(iclass), &
+                ' nclasses=',nclasses
+            call tee_message(trim(msg))
+            class_failed=class_failed+1
+            jperp_failed=jperp_failed+1
+            if(matrix_callback_error.eq.matrix_callback_ok) then
+                call set_matrix_callback_error( &
+                    matrix_callback_class_sampling_failed)
+            endif
+            if(allocated(respoints_jp)) deallocate(respoints_jp)
+            return
         endif
     enddo
     !
@@ -469,6 +541,7 @@ subroutine get_matrix_res
     allocate(respoints_all(icount)%respoints_jp(nmodes,nclasses))
     respoints_all(icount)%respoints_jp=respoints_jp
     deallocate(respoints_jp)
+    jperp_succeeded=jperp_succeeded+1
     !print *,icount  !uncomment to see some life
     !
 end subroutine get_matrix_res
@@ -498,11 +571,19 @@ subroutine resonant_torque
         adaptive_jperp, npoi_init, nlagr_sampling, &
         eps_sampling, itermax_sampling
     use logging_mod,       only : tee_message
+    use matrix_callback_status_mod, only : matrix_callback_error, &
+        matrix_callback_ok, reset_torque_completeness, &
+        jperp_attempted,jperp_succeeded,jperp_failed, &
+        class_attempted,class_succeeded,class_failed, &
+        orbit_attempted,orbit_failed,resonance_search_attempted, &
+        resonance_search_failed,resonance_root_attempted, &
+        resonance_root_succeeded,resonance_root_failed,resonance_root_zeroed
     !$ use omp_lib, only : omp_set_max_active_levels, omp_set_num_threads
 
     implicit none
     !
     double precision, parameter :: pi=3.14159265358979d0
+    integer, parameter :: ncompleteness=14
     integer :: nr,nz,ir,iz,i,k,iperp,nperp,ierr,nprof,ienerg,nenerg
     integer :: omp_threads_env_len
     integer :: nrespoints,unit1901,unit1902,ienerg_begin
@@ -524,6 +605,8 @@ subroutine resonant_torque
     double precision, dimension(:), allocatable :: torque_int_energy
     double precision, dimension(:,:), allocatable :: torque_int_modes_energy
     double precision, dimension(:,:), allocatable :: torquebox_energy
+    integer, dimension(:), allocatable :: energy_status
+    integer, dimension(:,:), allocatable :: completeness_counts
     ! Per-resonance-point box times, filled by the parallel time_in_box pass and
     ! consumed by the serial accumulate/write pass below.
     double precision, dimension(:,:), allocatable :: taubox_all
@@ -589,10 +672,13 @@ subroutine resonant_torque
     allocate(torque_int_modes(nmodes))
     torque_int_modes=0.d0
     allocate(torque_int_energy(nenerg),torque_int_modes_energy(nmodes,nenerg), &
-        torquebox_energy(nbox,nenerg))
+        torquebox_energy(nbox,nenerg),energy_status(nenerg), &
+        completeness_counts(ncompleteness,nenerg))
     torque_int_energy=0.d0
     torque_int_modes_energy=0.d0
     torquebox_energy=0.d0
+    energy_status=-1
+    completeness_counts=0
     !
     torquebox=0.d0
     !
@@ -609,6 +695,8 @@ subroutine resonant_torque
     !$omp   private(unit1901,unit1902,torque_int_modes_loc,torquebox_loc) &
     !$omp   copyin(dtau)
     do ienerg=ienerg_begin,nenerg
+        call reset_torque_completeness
+        ierr=0
         xenerg=(dble(ienerg)-0.5d0)/dble(nenerg)
         toten=toten_min+toten_range*xenerg
         ! size of result matrix in get_matrix_res:
@@ -649,6 +737,22 @@ subroutine resonant_torque
             ! Generate J_perp grid with function values:
             !
             call sample_matrix_out(get_matrix_res,ierr)
+            if(ierr.ne.0) then
+                write(msg, '(A,I0,A,I0)') &
+                    'FATAL: incomplete energy slice ', ienerg, &
+                    ', callback/status = ', ierr
+                call tee_message(trim(msg))
+                call snapshot_completeness(ienerg,ierr)
+                if(allocated(respoints_jp)) deallocate(respoints_jp)
+                if(allocated(respoints_all)) deallocate(respoints_all)
+                if(allocated(respoints_all_tmp)) deallocate(respoints_all_tmp)
+                close(resline_unit)
+                close(resline_diag_unit)
+                close(unit1901)
+                close(unit1902)
+                deallocate(torque_int_modes_loc,torquebox_loc)
+                cycle
+            endif
             !
             allocate(respoints_all_tmp(npoi))
             !
@@ -801,6 +905,10 @@ subroutine resonant_torque
                 x=perpinv_max*(1.d0-xjperp**2)
                 !
                 call get_matrix_res
+                if(matrix_callback_error.ne.matrix_callback_ok) then
+                    ierr=matrix_callback_error
+                    exit
+                endif
                 !
                 torque_int_loc=torque_int_loc &
                     +perpinv_max*trapez_fac*sum(amat(:,1))*step_energ
@@ -816,12 +924,28 @@ subroutine resonant_torque
             torque_int_energy(ienerg)=torque_int_loc
             torque_int_modes_energy(:,ienerg)=torque_int_modes_loc
         endif
+        if(ierr.ne.0) then
+            write(msg, '(A,I0,A,I0)') &
+                'FATAL: incomplete energy slice ', ienerg, &
+                ', callback/status = ', ierr
+            call tee_message(trim(msg))
+            call snapshot_completeness(ienerg,ierr)
+            if(allocated(respoints_jp)) deallocate(respoints_jp)
+            if(allocated(respoints_all)) deallocate(respoints_all)
+            if(allocated(respoints_all_tmp)) deallocate(respoints_all_tmp)
+            close(resline_unit)
+            close(resline_diag_unit)
+            close(unit1902)
+            deallocate(torque_int_modes_loc,torquebox_loc)
+            cycle
+        endif
         !
         call cpu_time(time_end)
         write(msg, '(A,I0,A,I0,A,F10.2,A)') &
             ' toten:', ienerg, '/', nenerg, &
             ' cpu time = ', time_end-time_beg, ' sec'
         call tee_message(trim(msg))
+        call snapshot_completeness(ienerg,0)
         !
         close(resline_unit)
         close(resline_diag_unit)
@@ -831,6 +955,10 @@ subroutine resonant_torque
         !
     enddo
     !$omp end parallel do
+    call write_completeness
+    if(any(energy_status(ienerg_begin:nenerg).ne.0)) then
+        error stop 'resonant_torque: incomplete energy slice; torque rejected'
+    endif
     !
     torque_int=0.d0
     torque_int_modes=0.d0
@@ -873,6 +1001,41 @@ subroutine resonant_torque
     endif
     !
 contains
+    !
+    subroutine snapshot_completeness(idx,status)
+        !
+        implicit none
+        integer, intent(in) :: idx,status
+        !
+        energy_status(idx)=status
+        completeness_counts(:,idx)=[jperp_attempted,jperp_succeeded,jperp_failed, &
+            class_attempted,class_succeeded,class_failed,orbit_attempted, &
+            orbit_failed,resonance_search_attempted,resonance_search_failed, &
+            resonance_root_attempted,resonance_root_succeeded, &
+            resonance_root_failed,resonance_root_zeroed]
+        !
+    end subroutine snapshot_completeness
+    !
+    subroutine write_completeness
+        !
+        implicit none
+        integer :: idx,unit_complete
+        !
+        open(newunit=unit_complete,file='potato_completeness.dat', &
+            status='replace',action='write')
+        write(unit_complete,'(A)') &
+            '# energy_index status jperp_attempted jperp_succeeded jperp_failed ' // &
+            'class_attempted class_succeeded class_failed orbit_attempted ' // &
+            'orbit_failed resonance_search_attempted resonance_search_failed ' // &
+            'resonance_root_attempted resonance_root_succeeded ' // &
+            'resonance_root_failed resonance_root_explicit_SOL_zero'
+        do idx=ienerg_begin,nenerg
+            write(unit_complete,'(*(I0,1X))') idx,energy_status(idx), &
+                completeness_counts(:,idx)
+        enddo
+        close(unit_complete)
+        !
+    end subroutine write_completeness
     !
     subroutine energy_path(prefix, idx, path)
         !

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -3,6 +3,8 @@
   SUBROUTINE sample_matrix(get_matrix,ierr)
 !
   USE sample_matrix_mod
+  USE matrix_callback_status_mod, ONLY : matrix_callback_error, &
+      matrix_callback_ok, reset_matrix_callback_error
   USE form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
 ! next is threadprivate (the resonance mode loop writes it); copyin it into the
 ! grid-build regions, which never write it, so each worker starts from the master
@@ -26,6 +28,7 @@
   external :: get_matrix
 !
   ierr=0
+  call reset_matrix_callback_error
 !
   npoilag=nlagr+1
   nshift=nlagr/2
@@ -44,12 +47,20 @@
 !
   x=xbeg
   CALL get_matrix
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
 !
   xarr(1)=x
   amat_arr(:,:,1)=amat
 !
   x=xend
   CALL get_matrix
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
   xarr(npoi)=x
   amat_arr(:,:,npoi)=amat
 !
@@ -66,9 +77,17 @@
     if(.not.allocated(amat)) allocate(amat(n1,n2))
     x=xarr(i)
     CALL get_matrix
+    if(matrix_callback_error.ne.matrix_callback_ok) then
+      ierr=matrix_callback_error
+      cycle
+    endif
     amat_arr(:,:,i)=amat
   ENDDO
   !$omp end parallel do
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
 !
   ALLOCATE(amat1(n1,n2),amat2(n1,n2),amat_maxmod(n1,n2))
 !
@@ -116,6 +135,13 @@
     IF(iter.GT.itermax) THEN
       ierr=2
       PRINT *,'sample_matrix : maximum number of iterations exceeded'
+      PRINT *,'sample_matrix : npoi, unresolved intervals, eps = ', &
+          npoi,COUNT(isplit.eq.1),eps
+      if(COUNT(isplit.eq.1).gt.0) then
+        PRINT *,'sample_matrix : unresolved x range = ', &
+            MINVAL(xarr(1:npoi-1),MASK=isplit(1:npoi-1).eq.1), &
+            MAXVAL(xarr(2:npoi),MASK=isplit(1:npoi-1).eq.1)
+      endif
       RETURN
     ENDIF
 !
@@ -161,9 +187,17 @@
       if(.not.allocated(amat)) allocate(amat(n1,n2))
       x=xarr(newslots(k))
       CALL get_matrix
+      if(matrix_callback_error.ne.matrix_callback_ok) then
+        ierr=matrix_callback_error
+        cycle
+      endif
       amat_arr(:,:,newslots(k))=amat
     ENDDO
     !$omp end parallel do
+    if(matrix_callback_error.ne.matrix_callback_ok) then
+      ierr=matrix_callback_error
+      return
+    endif
     DEALLOCATE(newslots)
 !
 ! check which intervals should be splitted

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -1,15 +1,15 @@
-  module sample_matrix_mod
+module sample_matrix_mod
     integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
     double precision :: x,xbeg,xend,eps
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
-! The class-grid state is per energy slice. Inner node-fill loops copy the
-! current grid config into their workers before filling disjoint slots.
+    ! The class-grid state is per energy slice. Inner node-fill loops copy the
+    ! current grid config into their workers before filling disjoint slots.
     !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
-  end module sample_matrix_mod
+end module sample_matrix_mod
 
-  module matrix_callback_status_mod
+module matrix_callback_status_mod
     implicit none
 
     integer, parameter :: matrix_callback_ok = 0
@@ -21,6 +21,7 @@
     integer, parameter :: matrix_callback_resonance_search_failed = 106
     integer, parameter :: matrix_callback_resonance_orbit_failed = 107
     integer, parameter :: matrix_callback_nonfinite_weight = 108
+    integer, parameter :: matrix_callback_box_count_failed = 109
 
     integer :: matrix_callback_error = matrix_callback_ok
     integer :: jperp_attempted = 0
@@ -37,41 +38,51 @@
     integer :: resonance_root_succeeded = 0
     integer :: resonance_root_failed = 0
     integer :: resonance_root_zeroed = 0
+    integer :: box_count_attempted = 0
+    integer :: box_count_succeeded = 0
+    integer :: box_count_failed = 0
+    integer :: box_count_skipped_zero_weight = 0
     !$omp threadprivate(matrix_callback_error,jperp_attempted,jperp_succeeded, &
     !$omp               jperp_failed,class_attempted,class_succeeded, &
     !$omp               class_failed,orbit_attempted,orbit_failed, &
     !$omp               resonance_search_attempted,resonance_search_failed, &
     !$omp               resonance_root_attempted,resonance_root_succeeded, &
-    !$omp               resonance_root_failed,resonance_root_zeroed)
+    !$omp               resonance_root_failed,resonance_root_zeroed, &
+    !$omp               box_count_attempted,box_count_succeeded, &
+    !$omp               box_count_failed,box_count_skipped_zero_weight)
 
-  contains
+contains
 
     subroutine reset_matrix_callback_error
-      matrix_callback_error = matrix_callback_ok
+        matrix_callback_error = matrix_callback_ok
     end subroutine reset_matrix_callback_error
 
     subroutine set_matrix_callback_error(code)
-      integer, intent(in) :: code
+        integer, intent(in) :: code
 
-      if (matrix_callback_error == matrix_callback_ok) matrix_callback_error = code
+        if (matrix_callback_error == matrix_callback_ok) matrix_callback_error = code
     end subroutine set_matrix_callback_error
 
     subroutine reset_torque_completeness
-      matrix_callback_error = matrix_callback_ok
-      jperp_attempted = 0
-      jperp_succeeded = 0
-      jperp_failed = 0
-      class_attempted = 0
-      class_succeeded = 0
-      class_failed = 0
-      orbit_attempted = 0
-      orbit_failed = 0
-      resonance_search_attempted = 0
-      resonance_search_failed = 0
-      resonance_root_attempted = 0
-      resonance_root_succeeded = 0
-      resonance_root_failed = 0
-      resonance_root_zeroed = 0
+        matrix_callback_error = matrix_callback_ok
+        jperp_attempted = 0
+        jperp_succeeded = 0
+        jperp_failed = 0
+        class_attempted = 0
+        class_succeeded = 0
+        class_failed = 0
+        orbit_attempted = 0
+        orbit_failed = 0
+        resonance_search_attempted = 0
+        resonance_search_failed = 0
+        resonance_root_attempted = 0
+        resonance_root_succeeded = 0
+        resonance_root_failed = 0
+        resonance_root_zeroed = 0
+        box_count_attempted = 0
+        box_count_succeeded = 0
+        box_count_failed = 0
+        box_count_skipped_zero_weight = 0
     end subroutine reset_torque_completeness
 
-  end module matrix_callback_status_mod
+end module matrix_callback_status_mod

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -8,3 +8,70 @@
 ! current grid config into their workers before filling disjoint slots.
     !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
   end module sample_matrix_mod
+
+  module matrix_callback_status_mod
+    implicit none
+
+    integer, parameter :: matrix_callback_ok = 0
+    integer, parameter :: matrix_callback_starter_failed = 101
+    integer, parameter :: matrix_callback_bounce_failed = 102
+    integer, parameter :: matrix_callback_bounds_failed = 103
+    integer, parameter :: matrix_callback_classes_failed = 104
+    integer, parameter :: matrix_callback_class_sampling_failed = 105
+    integer, parameter :: matrix_callback_resonance_search_failed = 106
+    integer, parameter :: matrix_callback_resonance_orbit_failed = 107
+    integer, parameter :: matrix_callback_nonfinite_weight = 108
+
+    integer :: matrix_callback_error = matrix_callback_ok
+    integer :: jperp_attempted = 0
+    integer :: jperp_succeeded = 0
+    integer :: jperp_failed = 0
+    integer :: class_attempted = 0
+    integer :: class_succeeded = 0
+    integer :: class_failed = 0
+    integer :: orbit_attempted = 0
+    integer :: orbit_failed = 0
+    integer :: resonance_search_attempted = 0
+    integer :: resonance_search_failed = 0
+    integer :: resonance_root_attempted = 0
+    integer :: resonance_root_succeeded = 0
+    integer :: resonance_root_failed = 0
+    integer :: resonance_root_zeroed = 0
+    !$omp threadprivate(matrix_callback_error,jperp_attempted,jperp_succeeded, &
+    !$omp               jperp_failed,class_attempted,class_succeeded, &
+    !$omp               class_failed,orbit_attempted,orbit_failed, &
+    !$omp               resonance_search_attempted,resonance_search_failed, &
+    !$omp               resonance_root_attempted,resonance_root_succeeded, &
+    !$omp               resonance_root_failed,resonance_root_zeroed)
+
+  contains
+
+    subroutine reset_matrix_callback_error
+      matrix_callback_error = matrix_callback_ok
+    end subroutine reset_matrix_callback_error
+
+    subroutine set_matrix_callback_error(code)
+      integer, intent(in) :: code
+
+      if (matrix_callback_error == matrix_callback_ok) matrix_callback_error = code
+    end subroutine set_matrix_callback_error
+
+    subroutine reset_torque_completeness
+      matrix_callback_error = matrix_callback_ok
+      jperp_attempted = 0
+      jperp_succeeded = 0
+      jperp_failed = 0
+      class_attempted = 0
+      class_succeeded = 0
+      class_failed = 0
+      orbit_attempted = 0
+      orbit_failed = 0
+      resonance_search_attempted = 0
+      resonance_search_failed = 0
+      resonance_root_attempted = 0
+      resonance_root_succeeded = 0
+      resonance_root_failed = 0
+      resonance_root_zeroed = 0
+    end subroutine reset_torque_completeness
+
+  end module matrix_callback_status_mod

--- a/POTATO/SRC/sample_matrix_out.f90
+++ b/POTATO/SRC/sample_matrix_out.f90
@@ -18,8 +18,11 @@
 ! Generates adaptive grid with values of matrix function on this grid.
 ! Matrix function a_ij(x) is computed by external function "get_matrix".
 ! For grid refinement, Lagrange polynomial interpolations at two shifted stencils
-! are compared in the middle of the examined grid interval. If the difference is above
-! given tolerance such an interval is split in two.
+! are compared in the middle of the examined grid interval. Their difference is
+! integrated over the grid and compared with the absolute integral scale. This
+! integral-error criterion can converge physical resonance-onset cusps that are
+! not pointwise-polynomial; intervals carrying more than an equal share of the
+! requested error budget are split.
 !
 !  Formal input/output:
 ! get_matrix (in)  - external subroutine for computation of matrix function
@@ -51,7 +54,8 @@
 !
   DOUBLE PRECISION :: h,hh
   DOUBLE PRECISION, DIMENSION(:),     ALLOCATABLE :: xold
-  DOUBLE PRECISION, DIMENSION(:,:),   ALLOCATABLE :: coef,amat_maxmod
+  DOUBLE PRECISION, DIMENSION(:,:),   ALLOCATABLE :: coef,integral_scale
+  DOUBLE PRECISION, DIMENSION(:,:,:), ALLOCATABLE :: interval_error
   COMPLEX(8),   DIMENSION(:,:),   ALLOCATABLE :: amat1,amat2
   COMPLEX(8),   DIMENSION(:,:,:), ALLOCATABLE :: amat_old
 !
@@ -111,21 +115,28 @@
     ind_hist(i)=icount
   ENDDO
 !
-  ALLOCATE(amat1(n1,n2),amat2(n1,n2),amat_maxmod(n1,n2))
+  ALLOCATE(amat1(n1,n2),amat2(n1,n2),integral_scale(n1,n2))
 !
 ! first check which intervals should be splitted
   ALLOCATE(isplit(npoi))
   isplit=0
+  ALLOCATE(interval_error(n1,n2,npoi-1))
+  interval_error=0.d0
+  integral_scale=0.d0
   DO inew=1,npoi-1
+    DO i=1,n1
+      DO j=1,n2
+        integral_scale(i,j)=integral_scale(i,j) &
+            +0.5d0*(ABS(amat_arr(i,j,inew))+ABS(amat_arr(i,j,inew+1))) &
+            *(xarr(inew+1)-xarr(inew))
+      ENDDO
+    ENDDO
     x=0.5d0*(xarr(inew)+xarr(inew+1))
     ibeg=MAX(1,MIN(npoi-nlagr-1,inew-nshift-1))
     iend=ibeg+nlagr
     CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
     DO i=1,n1
       amat1(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
-      DO j=1,n2
-        amat_maxmod(i,j)=MAXVAL(ABS(amat_arr(i,j,ibeg:iend)))
-      ENDDO
     ENDDO
     ibeg=MAX(2,MIN(npoi-nlagr,inew-nshift+1))
     iend=ibeg+nlagr
@@ -133,15 +144,22 @@
     DO i=1,n1
       amat2(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
       DO j=1,n2
-        amat_maxmod(i,j)=MAX(amat_maxmod(i,j),ABS(amat_arr(i,j,iend)))
-      ENDDO
-    ENDDO
-    DO i=1,n1
-      DO j=1,n2
-        IF(ABS(amat1(i,j)-amat2(i,j)).GT.eps*amat_maxmod(i,j)) isplit(inew)=1
+        interval_error(i,j,inew)=ABS(amat1(i,j)-amat2(i,j)) &
+            *(xarr(inew+1)-xarr(inew))
       ENDDO
     ENDDO
   ENDDO
+  DO i=1,n1
+    DO j=1,n2
+      IF(SUM(interval_error(i,j,:)).GT.eps*integral_scale(i,j)) THEN
+        DO inew=1,npoi-1
+          IF(interval_error(i,j,inew).GE. &
+              eps*integral_scale(i,j)/dble(npoi-1)) isplit(inew)=1
+        ENDDO
+      ENDIF
+    ENDDO
+  ENDDO
+  DEALLOCATE(interval_error)
   IF(MAXVAL(isplit).GT.0) THEN
     npoi_old=npoi
     ALLOCATE(xold(npoi),amat_old(n1,n2,npoi),ind_hist_old(npoi))
@@ -158,6 +176,11 @@
     IF(iter.GT.itermax) THEN
       ierr=2
       PRINT *,'sample_matrix_out : maximum number of iterations exceeded'
+      PRINT *,'sample_matrix_out : npoi, unresolved intervals, eps = ', &
+          npoi,COUNT(isplit.eq.1),eps
+      PRINT *,'sample_matrix_out : unresolved x range = ', &
+          MINVAL(xarr(1:npoi-1),MASK=isplit(1:npoi-1).eq.1), &
+          MAXVAL(xarr(2:npoi),MASK=isplit(1:npoi-1).eq.1)
       RETURN
     ENDIF
 !
@@ -199,16 +222,23 @@
 ! check which intervals should be splitted
     ALLOCATE(isplit(npoi))
     isplit=0
+    ALLOCATE(interval_error(n1,n2,npoi-1))
+    interval_error=0.d0
+    integral_scale=0.d0
     DO inew=1,npoi-1
+      DO i=1,n1
+        DO j=1,n2
+          integral_scale(i,j)=integral_scale(i,j) &
+              +0.5d0*(ABS(amat_arr(i,j,inew))+ABS(amat_arr(i,j,inew+1))) &
+              *(xarr(inew+1)-xarr(inew))
+        ENDDO
+      ENDDO
       x=0.5d0*(xarr(inew)+xarr(inew+1))
       ibeg=MAX(1,MIN(npoi-nlagr-1,inew-nshift-1))
       iend=ibeg+nlagr
       CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
       DO i=1,n1
         amat1(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
-        DO j=1,n2
-          amat_maxmod(i,j)=MAXVAL(ABS(amat_arr(i,j,ibeg:iend)))
-        ENDDO
       ENDDO
       ibeg=MAX(2,MIN(npoi-nlagr,inew-nshift+1))
       iend=ibeg+nlagr
@@ -216,15 +246,22 @@
       DO i=1,n1
         amat2(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
         DO j=1,n2
-          amat_maxmod(i,j)=MAX(amat_maxmod(i,j),ABS(amat_arr(i,j,iend)))
-        ENDDO
-      ENDDO
-      DO i=1,n1
-        DO j=1,n2
-          IF(ABS(amat1(i,j)-amat2(i,j)).GT.eps*amat_maxmod(i,j)) isplit(inew)=1
+          interval_error(i,j,inew)=ABS(amat1(i,j)-amat2(i,j)) &
+              *(xarr(inew+1)-xarr(inew))
         ENDDO
       ENDDO
     ENDDO
+    DO i=1,n1
+      DO j=1,n2
+        IF(SUM(interval_error(i,j,:)).GT.eps*integral_scale(i,j)) THEN
+          DO inew=1,npoi-1
+            IF(interval_error(i,j,inew).GE. &
+                eps*integral_scale(i,j)/dble(npoi-1)) isplit(inew)=1
+          ENDDO
+        ENDIF
+      ENDDO
+    ENDDO
+    DEALLOCATE(interval_error)
     IF(MAXVAL(isplit).GT.0) THEN
       npoi_old=npoi
       DEALLOCATE(xold,amat_old,ind_hist_old)

--- a/POTATO/SRC/sample_matrix_out.f90
+++ b/POTATO/SRC/sample_matrix_out.f90
@@ -39,6 +39,8 @@
 ! amat_arr(n1,n2,npoi) (out)   - matrix function on the refined grid
 !
   USE sample_matrix_out_mod
+  USE matrix_callback_status_mod, ONLY : matrix_callback_error, &
+      matrix_callback_ok, reset_matrix_callback_error
 !
   IMPLICIT NONE
 !
@@ -56,6 +58,7 @@
   external :: get_matrix
 !
   ierr=0
+  call reset_matrix_callback_error
 !
   npoilag=nlagr+1
   nshift=nlagr/2
@@ -75,12 +78,20 @@
 !
   x=xbeg
   CALL get_matrix
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
   xarr(1)=x
   amat_arr(:,:,1)=amat
   ind_hist(1)=icount
 !
   x=xend
   CALL get_matrix
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
   xarr(npoi)=x
   amat_arr(:,:,npoi)=amat
   ind_hist(npoi)=icount
@@ -92,6 +103,10 @@
   DO i=2,npoi-1
     x=xarr(i)
     CALL get_matrix
+    if(matrix_callback_error.ne.matrix_callback_ok) then
+      ierr=matrix_callback_error
+      return
+    endif
     amat_arr(:,:,i)=amat
     ind_hist(i)=icount
   ENDDO
@@ -166,6 +181,10 @@
         inew=inew+1
         x=0.5d0*(xold(iold)+xold(iold+1))
         CALL get_matrix
+        if(matrix_callback_error.ne.matrix_callback_ok) then
+          ierr=matrix_callback_error
+          return
+        endif
         xarr(inew)=x
         amat_arr(:,:,inew)=amat
         ind_hist(inew)=icount

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2638,6 +2638,9 @@
   use get_matrix_mod,    only : iclass
   use global_invariants, only : dtau,toten,perpinv
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end,sigma_class
+  use matrix_callback_status_mod, only : matrix_callback_starter_failed, &
+      matrix_callback_bounce_failed, set_matrix_callback_error, &
+      orbit_attempted, orbit_failed
 !
   implicit none
 !
@@ -2650,6 +2653,8 @@
 !
   external :: velo,velo_pphint
 !
+  orbit_attempted=orbit_attempted+1
+  amat=(0.d0,0.d0)
   sigma=sigma_class(iclass)
   delta_R=R_class_end(iclass)-R_class_beg(iclass)
 !
@@ -2662,6 +2667,8 @@
 !
   if(ierr.ne.0) then
     print *,'get_matrix: error in starter'
+    orbit_failed=orbit_failed+1
+    call set_matrix_callback_error(matrix_callback_starter_failed)
     return
   endif
 !
@@ -2672,12 +2679,26 @@
     if(fullbounce) then
 !
       call find_bounce(next,velo,dtau,z,taub,delphi,extraset,ierr)
-      if(ierr.ne.0) return
+      if(ierr.ne.0) then
+        orbit_failed=orbit_failed+1
+        call set_matrix_callback_error(matrix_callback_bounce_failed)
+        return
+      endif
 !
     else
 !
       call first_return_map(sigma,Rst,sigma,Rst,taub,delphi,ierr)
+      if(ierr.ne.0) then
+        orbit_failed=orbit_failed+1
+        call set_matrix_callback_error(matrix_callback_bounce_failed)
+        return
+      endif
       call first_return_map(sigma,Rst,sigma,Rst,tau_fr,dphi_fr,ierr)
+      if(ierr.ne.0) then
+        orbit_failed=orbit_failed+1
+        call set_matrix_callback_error(matrix_callback_bounce_failed)
+        return
+      endif
 !
       taub=taub+tau_fr
       delphi=delphi+dphi_fr
@@ -2686,7 +2707,11 @@
     extraset=0.d0
 !
     call find_bounce(next,velo_pphint,dtau,z,taub,delphi,extraset,ierr)
-    if(ierr.ne.0) return
+    if(ierr.ne.0) then
+      orbit_failed=orbit_failed+1
+      call set_matrix_callback_error(matrix_callback_bounce_failed)
+      return
+    endif
 !
   endif
 !
@@ -2716,6 +2741,8 @@
   use form_classes_doublecount_mod, only : ifuntype,R_class_beg,R_class_end
   use cc_mod, only : dowrite
   use interp_cache_mod,  only : interp_cache_reset
+  use matrix_callback_status_mod, only : matrix_callback_error, &
+      matrix_callback_ok
 !
   implicit none
 !
@@ -2748,6 +2775,10 @@
   if(delphi_max.gt.0.d0) call bound_class_delphi(ifuntype(iclass),xbeg,xend)
 !
   call bound_class_wall(xbeg,xend)
+  if(matrix_callback_error.ne.matrix_callback_ok) then
+    ierr=matrix_callback_error
+    return
+  endif
 !
   eps=relerror
 !

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2743,6 +2743,7 @@
   use interp_cache_mod,  only : interp_cache_reset
   use matrix_callback_status_mod, only : matrix_callback_error, &
       matrix_callback_ok
+  use potato_input_mod, only : class_eps_sampling, class_itermax_sampling
 !
   implicit none
 !
@@ -2752,9 +2753,9 @@
   external :: get_matrix_doublecount
 !
   nlagr=7         !<= temporary place, should be moved out for centralized input
-  relerror=1.d-3  !<= temporary place, should be moved out for centralized input
+  relerror=class_eps_sampling
   relmargin=1.d-7 !<= temporary place, should be moved out for centralized input
-  itermax=20      !<= temporary place, should be moved out for centralized input
+  itermax=class_itermax_sampling
 !
   next=2*numbasef
   n1=3+next

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -721,85 +721,171 @@
 ! used as a Poincare cut.
 !
   use field_sub, only : psif,dpsidr,dpsidz
-  use field_eq_mod, only : psi_axis,psi_sep,rtf
+  use field_eq_mod, only : psi_axis,psi_sep,rtf,psi,rad,zet
   use poicut_mod, only   : npc,rpc_beg,h_rpc,rpc_arr,zpc_arr
+  use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
 !
   implicit none
 !
   integer, parameter :: nsplit=100,niter=100
   double precision, parameter :: relerr=1d-12
   integer :: i,j,npline
-  double precision :: rho_pol,psils,sigpsi
+  integer, dimension(2) :: axis_seed_index
+  logical :: bracketed,converged
+  double precision :: rho_pol,psils
   double precision :: h_R,det,delR,delZ,stepfac,err_dist,stepmod
   double precision :: R,Z,gpgb,dgpgb_dr,dgpgb_dz
-  double precision :: Rb,Zb,Re,Ze
+  double precision :: Raxis_seed,Zaxis_seed,Rb,Zb,Re,Ze
 !
+  if(rho_pol.le.0.d0 .or. rho_pol.ge.1.d0) then
+    error stop 'find_poicut: rho_pol must lie strictly between zero and one'
+  endif
+  if(npline.lt.4) then
+    error stop 'find_poicut: at least four interpolation points are required'
+  endif
+  if(allocated(rpc_arr)) deallocate(rpc_arr)
+  if(allocated(zpc_arr)) deallocate(zpc_arr)
   npc=npline
   allocate(rpc_arr(0:npc),zpc_arr(0:npc))
 !
-!
+! Trigger the lazy equilibrium reader. The evaluation is discarded; field_eq
+! clamps it to the loaded rectangular grid. Only after this call are psi, rad,
+! and zet available, so no physical seed may be chosen before it.
   R=1.d0
   Z=0.d0
 !
   call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
+  if(.not.allocated(psi) .or. .not.allocated(rad) .or. .not.allocated(zet)) then
+    error stop 'find_poicut: equilibrium grid initialization failed'
+  endif
+  if(size(rad).lt.2 .or. size(zet).lt.2) then
+    error stop 'find_poicut: equilibrium grid is too small'
+  endif
   err_dist=rtf*relerr
-  h_R=rtf/dble(nsplit)
-  sigpsi=sign(1.d0,psi_sep-psi_axis)
   psils=psi_axis+rho_pol**2*(psi_sep-psi_axis)
-  R=rtf
+  axis_seed_index=minloc(abs(psi-psi_axis))
+  Raxis_seed=rad(axis_seed_index(1))
+  Zaxis_seed=zet(axis_seed_index(2))
+  if(.not.ieee_is_finite(Raxis_seed) .or. &
+     .not.ieee_is_finite(Zaxis_seed)) then
+    error stop 'find_poicut: magnetic-axis grid seed is not finite'
+  endif
+  R=Raxis_seed
+  Z=Zaxis_seed
+  h_R=(Raxis_seed-rad(1))/dble(nsplit)
+  if(h_R.le.0.d0) then
+    error stop 'find_poicut: magnetic-axis seed is not inside radial grid'
+  endif
 !
-  do i=2,nsplit
+  bracketed=.false.
+  do i=1,nsplit
     R=R-h_R
 !
     call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
-    if((psif-psils)*(psi_sep-psi_axis).gt.0.d0) exit
+    if((psif-psils)*(psi_sep-psi_axis).gt.0.d0) then
+      bracketed=.true.
+      exit
+    endif
   enddo
+  if(.not.bracketed) then
+    error stop 'find_poicut: HFS target surface was not bracketed'
+  endif
 !
+  converged=.false.
   do i=1,niter
 !
     call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
     det=dpsidr*dgpgb_dz-dpsidz*dgpgb_dr
+    if(.not.ieee_is_finite(det) .or. abs(det).le.tiny(1.d0)) then
+      error stop 'find_poicut: singular HFS endpoint Newton system'
+    endif
     delR=((psif-psils)*dgpgb_dz-dpsidz*gpgb)/det
     delZ=(dpsidr*gpgb-(psif-psils)*dgpgb_dr)/det
     stepmod=sqrt(delR**2+delZ**2)
+    if(.not.ieee_is_finite(stepmod)) then
+      error stop 'find_poicut: non-finite HFS endpoint Newton step'
+    endif
     stepfac=h_R/max(h_R,stepmod)
     R=R-delR*stepfac
     Z=Z-delZ*stepfac
-    if(stepmod.lt.err_dist) exit
+    if(R.lt.rad(1) .or. R.gt.rad(size(rad)) .or. &
+       Z.lt.zet(1) .or. Z.gt.zet(size(zet))) then
+      error stop 'find_poicut: HFS endpoint Newton step left field grid'
+    endif
+    if(stepmod.lt.err_dist) then
+      converged=.true.
+      exit
+    endif
   enddo
+  if(.not.converged) then
+    error stop 'find_poicut: HFS endpoint Newton solve did not converge'
+  endif
 !
   Rb=R
   Zb=Z
 !
-  R=rtf
+  R=Raxis_seed
+  Z=Zaxis_seed
+  h_R=(rad(size(rad))-Raxis_seed)/dble(nsplit)
+  if(h_R.le.0.d0) then
+    error stop 'find_poicut: magnetic-axis seed is not inside radial grid'
+  endif
 !
-  do i=2,nsplit
+  bracketed=.false.
+  do i=1,nsplit
     R=R+h_R
 !
     call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
-    if((psif-psils)*(psi_sep-psi_axis).gt.0.d0) exit
+    if((psif-psils)*(psi_sep-psi_axis).gt.0.d0) then
+      bracketed=.true.
+      exit
+    endif
   enddo
+  if(.not.bracketed) then
+    error stop 'find_poicut: LFS target surface was not bracketed'
+  endif
 !
+  converged=.false.
   do i=1,niter
 !
     call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
     det=dpsidr*dgpgb_dz-dpsidz*dgpgb_dr
+    if(.not.ieee_is_finite(det) .or. abs(det).le.tiny(1.d0)) then
+      error stop 'find_poicut: singular LFS endpoint Newton system'
+    endif
     delR=((psif-psils)*dgpgb_dz-dpsidz*gpgb)/det
     delZ=(dpsidr*gpgb-(psif-psils)*dgpgb_dr)/det
     stepmod=sqrt(delR**2+delZ**2)
+    if(.not.ieee_is_finite(stepmod)) then
+      error stop 'find_poicut: non-finite LFS endpoint Newton step'
+    endif
     stepfac=h_R/max(h_R,stepmod)
     R=R-delR*stepfac
     Z=Z-delZ*stepfac
-    if(stepmod.lt.err_dist) exit
+    if(R.lt.rad(1) .or. R.gt.rad(size(rad)) .or. &
+       Z.lt.zet(1) .or. Z.gt.zet(size(zet))) then
+      error stop 'find_poicut: LFS endpoint Newton step left field grid'
+    endif
+    if(stepmod.lt.err_dist) then
+      converged=.true.
+      exit
+    endif
   enddo
+  if(.not.converged) then
+    error stop 'find_poicut: LFS endpoint Newton solve did not converge'
+  endif
 !
   Re=R
   Ze=Z
+  if(.not.ieee_is_finite(Rb) .or. .not.ieee_is_finite(Zb) .or. &
+     .not.ieee_is_finite(Re) .or. .not.ieee_is_finite(Ze) .or. Re.le.Rb) then
+    error stop 'find_poicut: invalid endpoint geometry'
+  endif
 !
   rpc_beg=Rb
   h_rpc=(Re-Rb)/dble(npc)
@@ -814,18 +900,40 @@
   do j=1,npline-1
     R=R+h_rpc
 !
+    converged=.false.
     do i=1,niter
 !
       call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
+      if(.not.ieee_is_finite(dgpgb_dz) .or. &
+         abs(dgpgb_dz).le.tiny(1.d0)) then
+        error stop 'find_poicut: singular interior cut Newton derivative'
+      endif
       delZ=gpgb/dgpgb_dz
+      if(.not.ieee_is_finite(delZ)) then
+        error stop 'find_poicut: non-finite interior cut Newton step'
+      endif
       Z=Z-delZ
-      if(abs(delZ).lt.err_dist) exit
+      if(Z.lt.zet(1) .or. Z.gt.zet(size(zet))) then
+        error stop 'find_poicut: interior cut Newton step left field grid'
+      endif
+      if(abs(delZ).lt.err_dist) then
+        converged=.true.
+        exit
+      endif
     enddo
+    if(.not.converged) then
+      error stop 'find_poicut: interior cut Newton solve did not converge'
+    endif
 !
     rpc_arr(j)=R
     zpc_arr(j)=Z
   enddo
+  if(any(.not.ieee_is_finite(rpc_arr)) .or. &
+     any(.not.ieee_is_finite(zpc_arr)) .or. &
+     any(rpc_arr(1:npc).le.rpc_arr(0:npc-1))) then
+    error stop 'find_poicut: non-finite or non-monotone cut'
+  endif
 !
   call find_magaxis
 !
@@ -873,59 +981,66 @@
 ! Find cylindrical coordinates of the magnetic axis
 !
   use field_sub, only : psif,dpsidr,dpsidz,d2psidr2,d2psidrdz,d2psidz2
-  use poicut_mod, only   : npc,rpc_arr,rmagaxis,zmagaxis,psimagaxis
+  use field_eq_mod, only : psi_axis,psi,rad,zet
+  use poicut_mod, only   : rmagaxis,zmagaxis,psimagaxis
+  use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
 !
   implicit none
 !
-  integer, parameter :: nsplit=100,niter=100
+  integer, parameter :: niter=100
   double precision, parameter :: relerr=1d-12
-  integer :: i,iter
-  double precision :: R,Z,dZ_dR,bmod,phi_elec
-  double precision :: errdist2,h_R,dpsi_dl,dpsi_dl_prev,del_R,del_Z,det
+  integer :: iter
+  integer, dimension(2) :: axis_seed_index
+  logical :: converged
+  double precision :: R,Z,bmod,phi_elec
+  double precision :: errdist,del_R,del_Z,det,stepmod,stepfac,step_limit
   double precision,dimension(3) :: x
 !
-  errdist2=(relerr*rpc_arr(npc))**2
-  h_R=(rpc_arr(npc)-rpc_arr(0))/dble(nsplit)
-  R=rpc_arr(0)
-!
-  call get_poicut(R,Z,dZ_dR)
-!
+  axis_seed_index=minloc(abs(psi-psi_axis))
+  R=rad(axis_seed_index(1))
+  Z=zet(axis_seed_index(2))
+  errdist=relerr*maxval(abs(rad))
+  step_limit=0.1d0*min(rad(size(rad))-rad(1),zet(size(zet))-zet(1))
   x(1)=R
   x(2)=0.d0
   x(3)=Z
 !
   call get_bmod_and_Phi(x,bmod,phi_elec)
 !
-  dpsi_dl=dpsidr+dpsidz*dZ_dR
-!
-  do i=1,nsplit
-    dpsi_dl_prev=dpsi_dl
-    R=rpc_arr(0)+h_R*dble(i)
-!
-    call get_poicut(R,Z,dZ_dR)
-!
-    x(1)=R
-    x(3)=Z
-!
-    call get_bmod_and_Phi(x,bmod,phi_elec)
-!
-    dpsi_dl=dpsidr+dpsidz*dZ_dR
-    if(dpsi_dl_prev*dpsi_dl.lt.0.d0) exit
-  enddo
-!
+  converged=.false.
   do iter=1,niter
-    x(1)=R
-    x(3)=Z
-!
-    call get_bmod_and_Phi(x,bmod,phi_elec)
-!
     det=d2psidr2*d2psidz2-d2psidrdz**2
+    if(.not.ieee_is_finite(det) .or. abs(det).le.tiny(1.d0)) then
+      error stop 'find_magaxis: singular Newton system'
+    endif
     del_R=(d2psidrdz*dpsidz-d2psidz2*dpsidr)/det
     del_Z=(d2psidrdz*dpsidr-d2psidr2*dpsidz)/det
-    R=R+del_R
-    Z=Z+del_Z
-    if(del_R**2+del_Z**2.lt.errdist2) exit
+    stepmod=sqrt(del_R**2+del_Z**2)
+    if(.not.ieee_is_finite(stepmod)) then
+      error stop 'find_magaxis: non-finite Newton step'
+    endif
+    stepfac=step_limit/max(step_limit,stepmod)
+    R=R+stepfac*del_R
+    Z=Z+stepfac*del_Z
+    if(R.lt.rad(1) .or. R.gt.rad(size(rad)) .or. &
+       Z.lt.zet(1) .or. Z.gt.zet(size(zet))) then
+      error stop 'find_magaxis: Newton step left field grid'
+    endif
+    x(1)=R
+    x(3)=Z
+    call get_bmod_and_Phi(x,bmod,phi_elec)
+    if(stepmod.lt.errdist) then
+      converged=.true.
+      exit
+    endif
   enddo
+  if(.not.converged) then
+    error stop 'find_magaxis: Newton solve did not converge'
+  endif
+  if(.not.ieee_is_finite(R) .or. .not.ieee_is_finite(Z) .or. &
+     .not.ieee_is_finite(psif)) then
+    error stop 'find_magaxis: non-finite magnetic axis'
+  endif
 !
   rmagaxis=R
   zmagaxis=Z
@@ -950,25 +1065,34 @@
   use field_eq_mod, only : psi_axis,psi_sep
   use poicut_mod, only   : npc,rpc_arr,rmagaxis,zmagaxis,psimagaxis, &
                            rhopol_bou,psi_bou,Rbou_lfs,Zbou_lfs,Rbou_hfs,Zbou_hfs
+  use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
 !
   implicit none
 !
   integer, parameter :: niter=100
   double precision, parameter :: relerr=1d-12
-  integer :: i,iter
-  double precision :: rho_pol,psipol,R_rhopol,Z_rhopol
+  integer :: iter
+  logical :: converged
+  double precision :: rho_pol
   double precision :: R,Z,dZ_dR,bmod,phi_elec
-  double precision :: errdist,dpsi_dl,del_R
+  double precision :: errdist,dpsi_dl,del_R,R_inner,R_outer,R_trial
+  double precision :: flux_side
   double precision,dimension(3) :: x
 !
+  if(rho_pol.le.0.d0 .or. rho_pol.ge.1.d0) then
+    error stop 'rhopol_boundary: rho_pol must lie strictly between zero and one'
+  endif
   rhopol_bou=rho_pol
   psi_bou=psimagaxis+(psi_sep-psimagaxis)*rho_pol**2
 !
   errdist=relerr*rpc_arr(npc)
 !
+  R_inner=rmagaxis
+  R_outer=rpc_arr(npc)
   Rbou_lfs=rmagaxis+(rpc_arr(npc)-rmagaxis)*rho_pol
   x(2)=0.d0
 !
+  converged=.false.
   do iter=1,niter
 !
     call get_poicut(Rbou_lfs,Zbou_lfs,dZ_dR)
@@ -978,16 +1102,46 @@
 !
     call get_bmod_and_Phi(x,bmod,phi_elec)
 !
+    flux_side=(psif-psi_bou)*(psi_sep-psimagaxis)
+    if(flux_side.gt.0.d0) then
+      R_outer=Rbou_lfs
+    else
+      R_inner=Rbou_lfs
+    endif
     dpsi_dl=dpsidr+dpsidz*dZ_dR
+    if(.not.ieee_is_finite(dpsi_dl) .or. &
+       abs(dpsi_dl).le.tiny(1.d0)) then
+      error stop 'rhopol_boundary: singular LFS Newton derivative'
+    endif
     del_R=(psi_bou-psif)/dpsi_dl
-    Rbou_lfs=Rbou_lfs+del_R
-    if(abs(del_R).lt.errdist) exit
+    if(ieee_is_finite(del_R) .and. abs(del_R).lt.errdist) then
+      converged=.true.
+      exit
+    endif
+    R_trial=Rbou_lfs+del_R
+    if(.not.ieee_is_finite(R_trial) .or. &
+       R_trial.le.R_inner .or. R_trial.ge.R_outer) then
+      R_trial=0.5d0*(R_inner+R_outer)
+    endif
+    if(abs(R_trial-Rbou_lfs).lt.errdist .or. &
+       abs(R_outer-R_inner).lt.errdist) then
+      converged=.true.
+      Rbou_lfs=R_trial
+      exit
+    endif
+    Rbou_lfs=R_trial
   enddo
+  if(.not.converged) then
+    error stop 'rhopol_boundary: LFS Newton solve did not converge'
+  endif
 !
   call get_poicut(Rbou_lfs,Zbou_lfs,dZ_dR)
 !
+  R_outer=rpc_arr(0)
+  R_inner=rmagaxis
   Rbou_hfs=rmagaxis+(rpc_arr(0)-rmagaxis)*rho_pol
 !
+  converged=.false.
   do iter=1,niter
 !
     call get_poicut(Rbou_hfs,Zbou_hfs,dZ_dR)
@@ -997,13 +1151,46 @@
 !
     call get_bmod_and_Phi(x,bmod,phi_elec)
 !
+    flux_side=(psif-psi_bou)*(psi_sep-psimagaxis)
+    if(flux_side.gt.0.d0) then
+      R_outer=Rbou_hfs
+    else
+      R_inner=Rbou_hfs
+    endif
     dpsi_dl=dpsidr+dpsidz*dZ_dR
+    if(.not.ieee_is_finite(dpsi_dl) .or. &
+       abs(dpsi_dl).le.tiny(1.d0)) then
+      error stop 'rhopol_boundary: singular HFS Newton derivative'
+    endif
     del_R=(psi_bou-psif)/dpsi_dl
-    Rbou_hfs=Rbou_hfs+del_R
-    if(abs(del_R).lt.errdist) exit
+    if(ieee_is_finite(del_R) .and. abs(del_R).lt.errdist) then
+      converged=.true.
+      exit
+    endif
+    R_trial=Rbou_hfs+del_R
+    if(.not.ieee_is_finite(R_trial) .or. &
+       R_trial.le.R_outer .or. R_trial.ge.R_inner) then
+      R_trial=0.5d0*(R_outer+R_inner)
+    endif
+    if(abs(R_trial-Rbou_hfs).lt.errdist .or. &
+       abs(R_inner-R_outer).lt.errdist) then
+      converged=.true.
+      Rbou_hfs=R_trial
+      exit
+    endif
+    Rbou_hfs=R_trial
   enddo
+  if(.not.converged) then
+    error stop 'rhopol_boundary: HFS Newton solve did not converge'
+  endif
 !
   call get_poicut(Rbou_hfs,Zbou_hfs,dZ_dR)
+  if(.not.ieee_is_finite(Rbou_lfs) .or. &
+     .not.ieee_is_finite(Zbou_lfs) .or. &
+     .not.ieee_is_finite(Rbou_hfs) .or. &
+     .not.ieee_is_finite(Zbou_hfs) .or. Rbou_hfs.ge.Rbou_lfs) then
+    error stop 'rhopol_boundary: invalid boundary geometry'
+  endif
 !
   if(.true.) then
     print *,'outer boundary LFS:'

--- a/POTATO/SRC/test_box_counting_status.f90
+++ b/POTATO/SRC/test_box_counting_status.f90
@@ -1,0 +1,43 @@
+program test_box_counting_status
+    use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+    use box_counting_status_mod, only: box_count_ok, &
+        box_count_nonpositive_bounce, box_count_vode_mxstep, &
+        box_count_vode_failed, box_count_nonfinite, &
+        box_count_negative_residence, box_count_residence_mismatch, &
+        box_count_vode_status, box_count_residence_status
+    implicit none
+
+    real(8) :: tau(3), nan_value
+
+    ! Independent arithmetic oracle: 1/4 + 1/2 + 1/8 inside plus 1/8 outside
+    ! is exactly one complete bounce.
+    tau = [0.25d0, 0.5d0, 0.125d0]
+    if (box_count_residence_status(1d0, tau, 0.125d0) /= box_count_ok) &
+        error stop "complete residence rejected"
+
+    if (box_count_residence_status(-1d0, tau, 0d0) /= &
+        box_count_nonpositive_bounce) &
+        error stop "nonpositive bounce accepted"
+
+    tau = [0.25d0, -0.5d0, 1.25d0]
+    if (box_count_residence_status(1d0, tau, 0d0) /= &
+        box_count_negative_residence) &
+        error stop "negative residence accepted"
+
+    tau = [0.2d0, 0.2d0, 0.2d0]
+    if (box_count_residence_status(1d0, tau, 0d0) /= &
+        box_count_residence_mismatch) &
+        error stop "incomplete residence accepted"
+
+    nan_value = ieee_value(0d0, ieee_quiet_nan)
+    tau = [0.25d0, nan_value, 0.75d0]
+    if (box_count_residence_status(1d0, tau, 0d0) /= box_count_nonfinite) &
+        error stop "nonfinite residence accepted"
+
+    if (box_count_vode_status(2) /= box_count_ok) &
+        error stop "successful VODE state rejected"
+    if (box_count_vode_status(-1) /= box_count_vode_mxstep) &
+        error stop "VODE mxstep state misclassified"
+    if (box_count_vode_status(-3) /= box_count_vode_failed) &
+        error stop "generic VODE failure state accepted"
+end program test_box_counting_status

--- a/POTATO/SRC/test_matrix_callback_status.f90
+++ b/POTATO/SRC/test_matrix_callback_status.f90
@@ -1,0 +1,88 @@
+program test_matrix_callback_status
+    use matrix_callback_status_mod, only: matrix_callback_bounce_failed
+
+    implicit none
+
+    integer :: ierr
+    external :: failing_class_matrix, valid_class_matrix
+    external :: failing_outer_matrix, valid_outer_matrix
+
+    call configure_class_sampler
+    call sample_matrix(failing_class_matrix, ierr)
+    if (ierr /= matrix_callback_bounce_failed) then
+        error stop 'sample_matrix did not propagate callback failure'
+    endif
+
+    call configure_class_sampler
+    call sample_matrix(valid_class_matrix, ierr)
+    if (ierr /= 0) error stop 'sample_matrix rejected valid callback'
+
+    call configure_outer_sampler
+    call sample_matrix_out(failing_outer_matrix, ierr)
+    if (ierr /= matrix_callback_bounce_failed) then
+        error stop 'sample_matrix_out did not propagate callback failure'
+    endif
+
+    call configure_outer_sampler
+    call sample_matrix_out(valid_outer_matrix, ierr)
+    if (ierr /= 0) error stop 'sample_matrix_out rejected valid callback'
+
+contains
+
+    subroutine configure_class_sampler
+        use sample_matrix_mod, only: nlagr, n1, n2, itermax, eps, xbeg, xend
+
+        nlagr = 2
+        n1 = 1
+        n2 = 1
+        itermax = 2
+        eps = 1.0d6
+        xbeg = 0.0d0
+        xend = 1.0d0
+    end subroutine configure_class_sampler
+
+    subroutine configure_outer_sampler
+        use sample_matrix_out_mod, only: nlagr, n1, n2, npoi, itermax, &
+            eps, xbeg, xend
+
+        nlagr = 2
+        n1 = 1
+        n2 = 1
+        npoi = 5
+        itermax = 2
+        eps = 1.0d6
+        xbeg = 0.0d0
+        xend = 1.0d0
+    end subroutine configure_outer_sampler
+
+end program test_matrix_callback_status
+
+subroutine failing_class_matrix
+    use sample_matrix_mod, only: x, amat
+    use matrix_callback_status_mod, only: matrix_callback_bounce_failed, &
+        set_matrix_callback_error
+
+    amat(1,1) = cmplx(x, 0.0d0, kind=8)
+    if (x > 0.4d0) call set_matrix_callback_error(matrix_callback_bounce_failed)
+end subroutine failing_class_matrix
+
+subroutine valid_class_matrix
+    use sample_matrix_mod, only: x, amat
+
+    amat(1,1) = cmplx(x, 0.0d0, kind=8)
+end subroutine valid_class_matrix
+
+subroutine failing_outer_matrix
+    use sample_matrix_out_mod, only: x, amat
+    use matrix_callback_status_mod, only: matrix_callback_bounce_failed, &
+        set_matrix_callback_error
+
+    amat(1,1) = cmplx(x, 0.0d0, kind=8)
+    if (x > 0.4d0) call set_matrix_callback_error(matrix_callback_bounce_failed)
+end subroutine failing_outer_matrix
+
+subroutine valid_outer_matrix
+    use sample_matrix_out_mod, only: x, amat
+
+    amat(1,1) = cmplx(x, 0.0d0, kind=8)
+end subroutine valid_outer_matrix

--- a/POTATO/SRC/test_matrix_callback_status.f90
+++ b/POTATO/SRC/test_matrix_callback_status.f90
@@ -4,8 +4,11 @@ program test_matrix_callback_status
     implicit none
 
     integer :: ierr
+    integer :: i
+    double precision :: integral, exact
     external :: failing_class_matrix, valid_class_matrix
     external :: failing_outer_matrix, valid_outer_matrix
+    external :: cusp_outer_matrix
 
     call configure_class_sampler
     call sample_matrix(failing_class_matrix, ierr)
@@ -26,6 +29,15 @@ program test_matrix_callback_status
     call configure_outer_sampler
     call sample_matrix_out(valid_outer_matrix, ierr)
     if (ierr /= 0) error stop 'sample_matrix_out rejected valid callback'
+
+    call configure_cusp_sampler
+    call sample_matrix_out(cusp_outer_matrix, ierr)
+    if (ierr /= 0) error stop 'sample_matrix_out did not converge a valid cusp'
+    call integrate_outer_grid(integral)
+    exact = (2.d0/3.d0)*(1.d0-0.37d0)**1.5d0
+    if (abs(integral-exact) > 2.d-3*exact) then
+        error stop 'sample_matrix_out cusp integral missed analytic oracle'
+    endif
 
 contains
 
@@ -54,6 +66,31 @@ contains
         xbeg = 0.0d0
         xend = 1.0d0
     end subroutine configure_outer_sampler
+
+    subroutine configure_cusp_sampler
+        use sample_matrix_out_mod, only: nlagr, n1, n2, npoi, itermax, &
+            eps, xbeg, xend
+
+        nlagr = 3
+        n1 = 1
+        n2 = 1
+        npoi = 11
+        itermax = 10
+        eps = 1.d-3
+        xbeg = 0.d0
+        xend = 1.d0
+    end subroutine configure_cusp_sampler
+
+    subroutine integrate_outer_grid(result)
+        use sample_matrix_out_mod, only: npoi, xarr, amat_arr
+        double precision, intent(out) :: result
+
+        result = 0.d0
+        do i = 2, npoi
+            result = result + 0.5d0*(amat_arr(1,1,i-1)+amat_arr(1,1,i)) &
+                *(xarr(i)-xarr(i-1))
+        enddo
+    end subroutine integrate_outer_grid
 
 end program test_matrix_callback_status
 
@@ -86,3 +123,9 @@ subroutine valid_outer_matrix
 
     amat(1,1) = cmplx(x, 0.0d0, kind=8)
 end subroutine valid_outer_matrix
+
+subroutine cusp_outer_matrix
+    use sample_matrix_out_mod, only: x, amat
+
+    amat(1,1) = sqrt(max(0.d0, x-0.37d0))
+end subroutine cusp_outer_matrix

--- a/POTATO/SRC/test_potato_input_validation.f90
+++ b/POTATO/SRC/test_potato_input_validation.f90
@@ -1,6 +1,7 @@
 program test_potato_input_validation
     use potato_input_mod, only : itest_type, rho_pol, rho_pol_max, &
-        potato_input_is_valid
+        eps_sampling, itermax_sampling, class_eps_sampling, &
+        class_itermax_sampling, potato_input_is_valid
     implicit none
 
     itest_type = 3
@@ -12,6 +13,26 @@ program test_potato_input_validation
     rho_pol_max = 0.99d0
     call require(potato_input_is_valid(), &
         'extended torque topology domain was rejected')
+
+    class_itermax_sampling = 0
+    call require(.not. potato_input_is_valid(), &
+        'nonpositive class sampler iteration limit was accepted')
+    class_itermax_sampling = 20
+
+    class_eps_sampling = 0.d0
+    call require(.not. potato_input_is_valid(), &
+        'nonpositive class sampler tolerance was accepted')
+    class_eps_sampling = 1.d-3
+
+    itermax_sampling = 0
+    call require(.not. potato_input_is_valid(), &
+        'nonpositive outer sampler iteration limit was accepted')
+    itermax_sampling = 5
+
+    eps_sampling = 0.d0
+    call require(.not. potato_input_is_valid(), &
+        'nonpositive outer sampler tolerance was accepted')
+    eps_sampling = 1.d-2
 
     rho_pol_max = 1.d0
     call require(.not. potato_input_is_valid(), &

--- a/POTATO/SRC/test_potato_input_validation.f90
+++ b/POTATO/SRC/test_potato_input_validation.f90
@@ -1,7 +1,8 @@
 program test_potato_input_validation
     use potato_input_mod, only : itest_type, rho_pol, rho_pol_max, &
         eps_sampling, itermax_sampling, class_eps_sampling, &
-        class_itermax_sampling, potato_input_is_valid
+        class_itermax_sampling, m_min, m_max, n_tor, nbox, npoi_init, &
+        nenerg, enkin_min_over_temp, potato_input_is_valid
     implicit none
 
     itest_type = 3
@@ -33,6 +34,36 @@ program test_potato_input_validation
     call require(.not. potato_input_is_valid(), &
         'nonpositive outer sampler tolerance was accepted')
     eps_sampling = 1.d-2
+
+    n_tor = 0
+    call require(.not. potato_input_is_valid(), &
+        'axisymmetric n_tor=0 accepted by resonant torque')
+    n_tor = 3
+
+    m_min = 1
+    m_max = -1
+    call require(.not. potato_input_is_valid(), &
+        'reversed canonical harmonic range was accepted')
+    m_min = -1
+    m_max = 1
+
+    nbox = 1
+    call require(.not. potato_input_is_valid(), &
+        'single radial box was accepted')
+    nbox = 200
+
+    npoi_init = 1
+    call require(.not. potato_input_is_valid(), &
+        'single initial J_perp point was accepted')
+    npoi_init = 5
+
+    enkin_min_over_temp = 0.d0
+    nenerg = 1
+    call require(.not. potato_input_is_valid(), &
+        'empty legacy energy quadrature was accepted')
+    nenerg = 2
+    call require(potato_input_is_valid(), &
+        'minimal nonempty legacy energy quadrature was rejected')
 
     rho_pol_max = 1.d0
     call require(.not. potato_input_is_valid(), &

--- a/POTATO/SRC/test_potato_input_validation.f90
+++ b/POTATO/SRC/test_potato_input_validation.f90
@@ -1,0 +1,36 @@
+program test_potato_input_validation
+    use potato_input_mod, only : itest_type, rho_pol, rho_pol_max, &
+        potato_input_is_valid
+    implicit none
+
+    itest_type = 3
+    rho_pol = 0.9d0
+    rho_pol_max = 0.9d0
+    call require(.not. potato_input_is_valid(), &
+        'torque topology domain equal to deposition boundary was accepted')
+
+    rho_pol_max = 0.99d0
+    call require(potato_input_is_valid(), &
+        'extended torque topology domain was rejected')
+
+    rho_pol_max = 1.d0
+    call require(.not. potato_input_is_valid(), &
+        'rho_pol_max at the separatrix was accepted')
+
+    itest_type = 1
+    rho_pol_max = rho_pol
+    call require(potato_input_is_valid(), &
+        'non-torque orbit cut at rho_pol was rejected')
+
+contains
+
+    subroutine require(ok, message)
+        logical, intent(in) :: ok
+        character(len=*), intent(in) :: message
+
+        if (ok) return
+        print *, trim(message)
+        error stop 1
+    end subroutine require
+
+end program test_potato_input_validation

--- a/POTATO/SRC/test_signed_toroidal_bound.f90
+++ b/POTATO/SRC/test_signed_toroidal_bound.f90
@@ -1,6 +1,6 @@
 program test_signed_toroidal_bound
     use resonance_mode_bounds_mod, only: resonant_delphi_bound, &
-        canonical_flux_outside_lcfs
+        canonical_flux_outside_lcfs, toroidal_torque_mode_factor
     implicit none
 
     integer, parameter :: m_modes(7) = [-3, -2, -1, 0, 1, 2, 3]
@@ -15,6 +15,10 @@ program test_signed_toroidal_bound
     if (negative_bound <= 0.d0) error stop "negative n produced nonpositive bound"
     if (positive_bound /= negative_bound) &
         error stop "search bound depends on toroidal-mode sign"
+    if (toroidal_torque_mode_factor(3) /= 3.d0) &
+        error stop "positive toroidal torque factor is not |n|"
+    if (toroidal_torque_mode_factor(-3) /= 3.d0) &
+        error stop "negative toroidal torque factor is not |n|"
 
     if (canonical_flux_outside_lcfs(0.5d0, 0.d0, 1.d0)) &
         error stop "inside point rejected for increasing flux"

--- a/POTATO/test/golden_record_resonance/golden_reslines.json
+++ b/POTATO/test/golden_record_resonance/golden_reslines.json
@@ -1,9 +1,8 @@
 {
-  "_comment": "Golden record for the public-safe circular-equilibrium resonance gate. Per-energy-slice resonance-line counts produced by potato.x on the committed circular case. Each slice is keyed by its total-energy value (toten, first column of fort.31415); the count is the number of resonance lines written for that slice. Regenerated for the configurable uniform-energy grid (enkin_min_over_temp default 0.1; toten starts at phi_max + 0.1*T) after making libneo's ierrfield threadprivate, which removed the OpenMP race that the new energy slices exposed. The OMP-determinism half of the gate checks the sorted reslines are identical at 1 and 4 threads; a privatization regression in the resonance weights drops the counts well below these numbers.",
-  "total_reslines": 660,
+  "_comment": "Golden record for the public-safe circular-equilibrium resonance gate. Per-energy-slice resonance-line counts produced by potato.x on the committed circular case. The zero kinetic-energy cutoff preserves the legacy grid and skips its first midpoint, leaving the two serialized slices below. The outer J_perp sampler uses enough refinement cycles to satisfy its integral-error gate rather than silently dropping an unconverged slice. The OMP-determinism half checks that sorted reslines are identical at one and four threads.",
+  "total_reslines": 429,
   "slices": [
-    {"toten": 18.220600840510961, "count": 200},
-    {"toten": 18.607267507177632, "count": 191},
-    {"toten": 18.993934173844298, "count": 269}
+    {"toten": 16.338859068780405, "count": 223},
+    {"toten": 18.23779802771189, "count": 206}
   ]
 }

--- a/POTATO/test/golden_record_resonance/potato.in
+++ b/POTATO/test/golden_record_resonance/potato.in
@@ -21,6 +21,6 @@
   npoi_init = 9
   nlagr_sampling = 3
   eps_sampling = 1.5d-1
-  itermax_sampling = 1
+  itermax_sampling = 10
   profile_file = 'profile_poly.in'
 /

--- a/POTATO/test/golden_record_resonance/test_resonance_golden.py
+++ b/POTATO/test/golden_record_resonance/test_resonance_golden.py
@@ -32,6 +32,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 HERE = Path(__file__).resolve().parent
@@ -172,6 +173,67 @@ def test_omp_determinism(reslines_runs) -> None:
         f"than OMP_NUM_THREADS=1 ({len(sorted1)} vs {len(sorted4)} lines); "
         "the parallel solver is not deterministic."
     )
+
+
+def test_torque_weight_and_residence_ledgers_close(tmp_path) -> None:
+    """Independent sums recover the accepted scalar, modes, and box measure."""
+    ensure_inputs()
+    run_dir = tmp_path / "ledger"
+    run_case(find_executable(), run_dir, threads=1)
+
+    torque = float(np.loadtxt(run_dir / "integral_torque.dat"))
+    weights = np.loadtxt(run_dir / "potato_resonance_weights.dat", ndmin=2)
+    boxes = np.loadtxt(run_dir / "boxcounted_torque.dat", ndmin=2)
+    outside = np.loadtxt(
+        run_dir / "boxcounted_torque_outside.dat", ndmin=2
+    )
+    completeness = np.loadtxt(
+        run_dir / "potato_completeness.dat", dtype=int, ndmin=2
+    )
+    mode_integral = np.loadtxt(
+        run_dir / "subint_ofH0int_104_vsJperp_adapt.dat", ndmin=2
+    )
+
+    # Ledger columns are independently parsed from the executable schema.
+    assert weights.shape[1] == 14
+    assert np.isclose(weights[:, 12].sum(), torque, rtol=2e-13, atol=1e-10)
+    assert np.isclose(
+        boxes[:, 0].sum() + outside[:, 0].sum(),
+        torque,
+        rtol=2e-13,
+        atol=1e-10,
+    )
+
+    root_disposition = weights[:, 6].astype(int)
+    box_disposition = weights[:, 7].astype(int)
+    assert set(root_disposition) <= {0, 1}
+    assert set(box_disposition) <= {-1, 0}
+    assert np.all(weights[root_disposition == 1, 12] == 0.0)
+    assert np.all(weights[box_disposition == -1, 12] == 0.0)
+    traced_fraction = weights[box_disposition == 0, 13]
+    assert np.all(traced_fraction >= -1e-12)
+    assert np.all(traced_fraction <= 1.0 + 1e-12)
+
+    # One row per accepted root and no failed box disposition in any energy.
+    for row in completeness:
+        energy_index = row[0]
+        status = row[1]
+        root_succeeded = row[13]
+        box_attempted, box_succeeded, box_failed, box_skipped = row[16:20]
+        energy_rows = weights[weights[:, 0] == energy_index]
+        assert status == 0
+        assert energy_rows.shape[0] == root_succeeded
+        assert box_failed == 0
+        assert box_attempted == box_succeeded
+        assert box_attempted + box_skipped == root_succeeded
+
+    # Final adaptive-integral columns are ordered by canonical m2.
+    final_modes = mode_integral[-1, 2:]
+    mode_labels = np.arange(-3, 4)
+    weight_modes = np.array(
+        [weights[weights[:, 4] == mode, 12].sum() for mode in mode_labels]
+    )
+    assert np.allclose(weight_modes, final_modes, rtol=2e-13, atol=1e-10)
 
 
 if __name__ == "__main__":

--- a/POTATO/test/poicut_translation/test_poicut_translation.py
+++ b/POTATO/test/poicut_translation/test_poicut_translation.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Behavioral gate for the POTATO Poincare-cut equilibrium seed.
+
+A rigid vertical translation of an axisymmetric equilibrium cannot change any
+radial cut coordinate. Every vertical cut coordinate must change by exactly the
+same translation. This catches origin-dependent seeds such as the historical
+hard-coded Z=0 without encoding the implementation used to find the cut.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+SHIFT_M = 2.0
+SHIFT_CM = 100.0 * SHIFT_M
+
+
+def _parse_fixed_reals(lines: list[str]) -> list[float]:
+    values: list[float] = []
+    for line in lines:
+        for start in range(0, len(line.rstrip("\n")), 16):
+            token = line[start : start + 16].strip()
+            if token:
+                values.append(float(token.replace("D", "E")))
+    return values
+
+
+def _write_fixed_reals(stream, values: list[float]) -> None:
+    for start in range(0, len(values), 5):
+        stream.write("".join(f"{value:16.9E}" for value in values[start : start + 5]))
+        stream.write("\n")
+
+
+def translate_geqdsk(source: Path, destination: Path, shift_m: float) -> None:
+    lines = source.read_text().splitlines(keepends=True)
+    header = lines[0]
+    fields = header.split()
+    nw, nh = int(fields[-2]), int(fields[-1])
+    prefix_count = 20 + 5 * nw + nw * nh
+
+    # Locate the conventional integer boundary-count record independently of
+    # line wrapping in the floating-point payload.
+    float_lines = (prefix_count + 4) // 5
+    count_line_index = 1 + float_lines
+    count_fields = lines[count_line_index].split()
+    if len(count_fields) != 2:
+        raise AssertionError("missing GEQDSK boundary-count record")
+    n_boundary, n_limiter = map(int, count_fields)
+
+    equilibrium = _parse_fixed_reals(lines[1:count_line_index])
+    if len(equilibrium) != prefix_count:
+        raise AssertionError("unexpected GEQDSK equilibrium record length")
+    geometry = _parse_fixed_reals(lines[count_line_index + 1 :])
+    if len(geometry) != 2 * (n_boundary + n_limiter):
+        raise AssertionError("unexpected GEQDSK boundary geometry length")
+
+    # GEQDSK duplicates Zmaxis in the third and fifth scalar records.
+    equilibrium[4] += shift_m
+    equilibrium[6] += shift_m
+    equilibrium[15] += shift_m
+    geometry[1::2] = [value + shift_m for value in geometry[1::2]]
+
+    with destination.open("w") as stream:
+        stream.write(header)
+        _write_fixed_reals(stream, equilibrium)
+        stream.write(f"{n_boundary:5d}{n_limiter:5d}\n")
+        _write_fixed_reals(stream, geometry)
+
+
+def translate_wall(source: Path, destination: Path, shift_cm: float) -> None:
+    wall = np.loadtxt(source)
+    wall[:, 1] += shift_cm
+    np.savetxt(destination, wall, fmt="%24.16e")
+
+
+def run_probe(executable: Path, case_dir: Path) -> np.ndarray:
+    completed = subprocess.run(
+        [str(executable)],
+        cwd=case_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=120,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"Poincare-cut probe failed with {completed.returncode}:\n"
+            f"{completed.stdout}"
+        )
+    records = [
+        line for line in completed.stdout.splitlines() if line.startswith("POTATO_POICUT ")
+    ]
+    if len(records) != 1:
+        raise AssertionError(f"missing unique POTATO_POICUT record:\n{completed.stdout}")
+    values = np.fromstring(records[0].removeprefix("POTATO_POICUT "), sep=" ")
+    if values.size != 10 or not np.all(np.isfinite(values)):
+        raise AssertionError(f"invalid POTATO_POICUT record: {records[0]}")
+    return values
+
+
+def stage_case(fixture: Path, destination: Path) -> None:
+    destination.mkdir()
+    for name in ("potato.in", "field_divB0.inp", "profile_poly.in"):
+        shutil.copy2(fixture / name, destination / name)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: test_poicut_translation.py PROBE FIXTURE_DIR")
+    executable = Path(sys.argv[1]).resolve()
+    fixture = Path(sys.argv[2]).resolve()
+
+    with tempfile.TemporaryDirectory(prefix="potato-poicut-") as tmp:
+        root = Path(tmp)
+        base = root / "base"
+        shifted = root / "shifted"
+        stage_case(fixture, base)
+        stage_case(fixture, shifted)
+        shutil.copy2(fixture / "circ.eqdsk", base / "circ.eqdsk")
+        shutil.copy2(fixture / "convexwall.dat", base / "convexwall.dat")
+        translate_geqdsk(fixture / "circ.eqdsk", shifted / "circ.eqdsk", SHIFT_M)
+        translate_wall(
+            fixture / "convexwall.dat", shifted / "convexwall.dat", SHIFT_CM
+        )
+
+        original = run_probe(executable, base)
+        translated = run_probe(executable, shifted)
+
+    radial = np.array([0, 2, 4, 6, 8])
+    vertical = np.array([1, 3, 5, 7, 9])
+    np.testing.assert_allclose(translated[radial], original[radial], rtol=0.0, atol=2e-7)
+    np.testing.assert_allclose(
+        translated[vertical] - original[vertical],
+        SHIFT_CM,
+        rtol=0.0,
+        atol=2e-7,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Final fail-closed POTATO torque-accounting layer:

- make Poincare cuts and topology bounds equilibrium-relative
- propagate sampler, orbit, resonance, and box-disposition failures explicitly
- reject incomplete energy slices and nonpositive bounce times
- serialize and cross-check scalar, energy, canonical-mode, root, and radial-box torque sums
- expose sampler controls without silently loosening them

## Validation

The rebuilt cumulative stack passes the full `fo` pipeline. Corrected TC24 L0 closes every serialized sum; no L5 convergence claim is made.

Stack: #100 -> this PR. No cross-code sign, phase, gain, smoothing, normalization, or radial fit is selected.