### PR TITLE
Serialize opt-in native resonance torque ledgers

### DIFF
--- a/src/diag/diag_bounce_debug.f90
+++ b/src/diag/diag_bounce_debug.f90
@@ -1,178 +1,209 @@
 module diag_bounce_debug
-  use iso_fortran_env, only: dp => real64
-  use neort, only: init, check_magfie, write_magfie_data_to_files, &
-                   set_to_passing_region, set_to_trapped_region, vsteps
-  use neort_config, only: read_and_set_config
-  use neort_main, only: runname
-  use neort_datatypes, only: magfie_data_t
-  use neort_profiles, only: read_and_init_profile_input, read_and_init_plasma_input, init_profiles, vth, Om_tE
-  use neort_freq, only: Om_th
-  use neort_transport, only: timestep_transport
-  use neort_orbit, only: nvar
-  use neort_resonance, only: driftorbit_coarse, driftorbit_root
-  use driftorbit, only: mth, mph, mi, pertfile, etamin, etamax, sign_vpar, &
-                        etatp, etadt, efac
-  use do_magfie_mod, only: R0, s, q, bfac, do_magfie_init
-  use do_magfie_pert_mod, only: do_magfie_pert_init
-  use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
-  use fortnum_ode_dop853, only: ode_integrate_dop
-  use fortnum_status, only: fortnum_status_t, FORTNUM_OK
-  implicit none
+    use iso_fortran_env, only: dp => real64
+    use neort, only: init, check_magfie, write_magfie_data_to_files, &
+        set_to_passing_region, set_to_trapped_region, vsteps, &
+        vmax_over_vth
+    use neort_config, only: read_and_set_config
+    use neort_main, only: runname
+    use neort_datatypes, only: magfie_data_t
+    use neort_profiles, only: read_and_init_profile_input, read_and_init_plasma_input, init_profiles, vth, Om_tE
+    use neort_freq, only: Om_th, Om_ph
+    use neort_transport, only: timestep_transport
+    use neort_orbit, only: nvar
+    use neort_resonance, only: driftorbit_coarse, driftorbit_root
+    use driftorbit, only: mth, mph, pertfile, etamin, etamax, sign_vpar, &
+        etatp, etadt, efac
+    use do_magfie_mod, only: R0, s, q, bfac, do_magfie_init
+    use do_magfie_pert_mod, only: do_magfie_pert_init
+    use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
+    use fortnum_ode_dop853, only: ode_integrate_dop
+    use fortnum_status, only: fortnum_status_t, FORTNUM_OK
+    implicit none
 
 contains
 
-  subroutine run_bounce_debug(arg_runname)
-    character(*), intent(in) :: arg_runname
-    logical :: file_exists
-    integer :: i, j, mmin, mmax, nm, u
-    real(dp) :: vminp, vmaxp, vmint, vmaxt
-    real(dp) :: du, ux, v
-    real(dp) :: roots(100,3), eta_res(2), eta
-    integer :: nroots, kr
-    real(dp) :: Omth, dOmthdv, dOmthdeta, taub
-    integer :: istate
-    integer :: istats(50)
-    real(dp) :: rstats(50)
-    type(magfie_data_t) :: magfie_data
+    subroutine run_bounce_debug(arg_runname)
+        character(*), intent(in) :: arg_runname
+        character(32) :: arg_mth, arg_branch
+        logical :: file_exists
+        integer :: j, mmin, mmax, nm, u, target_mth
+        logical :: filter_mth
+        real(dp) :: vminp, vmaxp, vmint, vmaxt
+        real(dp) :: du, ux, v
+        real(dp) :: roots(100,3), eta_res(2), eta
+        integer :: nroots, kr
+        real(dp) :: Omth, dOmthdv, dOmthdeta, taub
+        integer :: istate
+        integer :: istats(50)
+        real(dp) :: rstats(50)
+        type(magfie_data_t) :: magfie_data
 
-    ! Initialize environment just like main
-    runname = trim(arg_runname)
-    call read_and_set_config(trim(runname)//".in")
-    call do_magfie_init("in_file")
-    if (pertfile) call do_magfie_pert_init("in_file_pert")
-    call init_profiles(R0)
+        call get_command_argument(3, arg_mth)
+        call get_command_argument(4, arg_branch)
+        filter_mth = len_trim(arg_mth) > 0
+        if (filter_mth) then
+            read(arg_mth, *, err=900) target_mth
+        else
+            target_mth = 0
+        end if
+        if (len_trim(arg_branch) == 0) arg_branch = 'all'
+        if (all(trim(arg_branch) /= ['all ', 'cop ', 'ctr ', 'trap'])) then
+            error stop 'bounce_debug branch must be all, cop, ctr, or trap'
+        end if
 
-    inquire(file="plasma.in", exist=file_exists)
-    if (file_exists) call read_and_init_plasma_input("plasma.in", s)
+        ! Initialize environment just like main
+        runname = trim(arg_runname)
+        call read_and_set_config(trim(runname)//".in")
+        call do_magfie_init("in_file")
+        if (pertfile) call do_magfie_pert_init("in_file_pert")
+        call init_profiles(R0)
 
-    inquire(file="profile.in", exist=file_exists)
-    if (file_exists) call read_and_init_profile_input("profile.in", s, R0, efac, bfac)
+        inquire(file="plasma.in", exist=file_exists)
+        if (file_exists) call read_and_init_plasma_input("plasma.in", s)
 
-    call init
-    call check_magfie(magfie_data)
-    call write_magfie_data_to_files(magfie_data, runname)
+        inquire(file="profile.in", exist=file_exists)
+        if (file_exists) call read_and_init_profile_input("profile.in", s, R0, efac, bfac)
 
-    vminp = 1.0e-6_dp*vth
-    vmaxp = 3.0_dp*vth
-    vmint = vminp
-    vmaxt = vmaxp
+        call init
+        call check_magfie(magfie_data)
+        call write_magfie_data_to_files(magfie_data, runname)
 
-    mmin = -ceiling(2.0_dp*abs(mph*q))
-    mmax =  ceiling(2.0_dp*abs(mph*q))
-    nm = mmax - mmin + 1
+        vminp = 1.0e-6_dp*vth
+        vmaxp = vmax_over_vth*vth
+        vmint = vminp
+        vmaxt = vmaxp
 
-    open(newunit=u, file=trim(arg_runname)//'_bounce_debug.txt', status='replace', action='write')
-    write(u,'(A)') '# bounce debug: logs where integration stalls (MXSTEP)'
-    write(u,'(A,F10.6)') '# s = ', s
-    write(u,'(A)') '# cols: branch mth ux eta Omth taub istate nst accrej last_h'
+        mmin = -ceiling(2.0_dp*abs(mph*q))
+        mmax =  ceiling(2.0_dp*abs(mph*q))
+        nm = mmax - mmin + 1
 
-    do j = 1, nm
-      mth = mmin + (j - 1)
+        open(newunit=u, file=trim(arg_runname)//'_bounce_debug.txt', status='replace', action='write')
+        write(u,'(A)') '# bounce debug: logs where integration stalls (MXSTEP)'
+        write(u,'(A,F10.6)') '# s = ', s
+        write(u,'(A)') &
+            '# cols: branch mth ux eta Omth Omph residual dres_deta taub istate_probe nst_probe last_h_probe'
 
-      ! Passing co
-      sign_vpar = 1.0_dp
-      call set_to_passing_region(etamin, etamax)
-      call scan_branch('cop', vminp, vmaxp, vsteps, u)
+        do j = 1, nm
+            mth = mmin + (j - 1)
+            if (filter_mth .and. mth /= target_mth) cycle
 
-      ! Passing ctr
-      sign_vpar = -1.0_dp
-      call set_to_passing_region(etamin, etamax)
-      call scan_branch('ctr', vminp, vmaxp, vsteps, u)
+            ! Passing co
+            if (trim(arg_branch) == 'all' .or. trim(arg_branch) == 'cop') then
+                sign_vpar = 1.0_dp
+                call set_to_passing_region(etamin, etamax)
+                call scan_branch('cop', vminp, vmaxp, vsteps, u)
+            end if
 
-      ! Trapped
-      sign_vpar = 1.0_dp
-      call set_to_trapped_region(etamin, etamax)
-      call scan_branch('trap', vmint, vmaxt, vsteps, u)
-    end do
-    close(u)
-  end subroutine run_bounce_debug
+            ! Passing ctr
+            if (trim(arg_branch) == 'all' .or. trim(arg_branch) == 'ctr') then
+                sign_vpar = -1.0_dp
+                call set_to_passing_region(etamin, etamax)
+                call scan_branch('ctr', vminp, vmaxp, vsteps, u)
+            end if
 
-  subroutine scan_branch(label, vmin, vmax, vsteps_loc, u)
-    character(*), intent(in) :: label
-    real(dp), intent(in) :: vmin, vmax
-    integer, intent(in) :: vsteps_loc
-    integer, intent(in) :: u
-    real(dp) :: du, ux, v
-    real(dp) :: roots(100,3), eta_res(2), eta
-    integer :: nroots, kr
-    real(dp) :: Omth, dOmthdv, dOmthdeta, taub
-    integer :: istate
-    integer :: istats(50)
-    real(dp) :: rstats(50)
-
-    du = (vmax - vmin)/(real(vsteps_loc, dp)*vth)
-    ux = vmin/vth + du/2.0_dp
-    do while (ux*vth <= vmax + 1.0e-12_dp)
-      v = ux*vth
-      call driftorbit_coarse(v, etamin, etamax, roots, nroots)
-      if (nroots > 0) then
-        do kr = 1, nroots
-          eta_res = driftorbit_root(v, 1.0e-8_dp*abs(Om_tE), roots(kr,1), roots(kr,2))
-          if (eta_res(1) < 0.0_dp) cycle  ! bracket-failure sentinel
-          eta = eta_res(1)
-          call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
-          taub = 2.0_dp*acos(-1.0_dp)/abs(Omth)
-          call probe_bounce(v, eta, taub, istate, istats, rstats)
-          write(u,'(A,1X,I4,1X,F8.4,1X,ES12.5,1X,ES12.5,1X,ES12.5,1X,I4,1X,I9,1X,ES12.5)') &
-               trim(label), mth, ux, eta, Omth, taub, istate, istats(1), rstats(6)
+            ! Trapped
+            if (trim(arg_branch) == 'all' .or. trim(arg_branch) == 'trap') then
+                sign_vpar = 1.0_dp
+                call set_to_trapped_region(etamin, etamax)
+                call scan_branch('trap', vmint, vmaxt, vsteps, u)
+            end if
         end do
-      end if
-      ux = ux + du
-    end do
-  end subroutine scan_branch
+        close(u)
+        return
 
-  subroutine probe_bounce(v, eta, taub, istate, istats, rstats)
-    real(dp), intent(in) :: v, eta, taub
-    integer, intent(out) :: istate
-    integer, intent(out) :: istats(:)
-    real(dp), intent(out) :: rstats(:)
+        900 error stop 'bounce_debug mth must be an integer'
+    end subroutine run_bounce_debug
 
-    real(dp) :: y0(nvar)
-    type(ode_problem_t) :: problem
-    type(ode_workspace_t) :: workspace
-    type(ode_solution_t) :: solution
-    type(fortnum_status_t) :: status
+    subroutine scan_branch(label, vmin, vmax, vsteps_loc, u)
+        character(*), intent(in) :: label
+        real(dp), intent(in) :: vmin, vmax
+        integer, intent(in) :: vsteps_loc
+        integer, intent(in) :: u
+        real(dp) :: du, ux, v
+        real(dp) :: roots(100,3), eta_res(2), eta
+        integer :: nroots, kr
+        real(dp) :: Omth, dOmthdv, dOmthdeta, Omph, dOmphdv, dOmphdeta
+        real(dp) :: residual, taub
+        integer :: istate
+        integer :: istats(50)
+        real(dp) :: rstats(50)
 
-    istats = 0
-    rstats = 0.0_dp
+        du = (vmax - vmin)/(real(vsteps_loc, dp)*vth)
+        ux = vmin/vth + du/2.0_dp
+        do while (ux*vth <= vmax + 1.0e-12_dp)
+            v = ux*vth
+            call driftorbit_coarse(v, etamin, etamax, roots, nroots)
+            if (nroots > 0) then
+                do kr = 1, nroots
+                    eta_res = driftorbit_root(v, 1.0e-8_dp*abs(Om_tE), roots(kr,1), roots(kr,2))
+                    if (eta_res(1) < 0.0_dp) cycle ! bracket-failure sentinel
+                    eta = eta_res(1)
+                    call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
+                    call Om_ph(v, eta, Omph, dOmphdv, dOmphdeta)
+                    residual = real(mth, dp)*Omth + real(mph, dp)*Omph
+                    taub = 2.0_dp*acos(-1.0_dp)/abs(Omth)
+                    call probe_bounce(v, eta, taub, istate, istats, rstats)
+                    write(u,'(A,1X,I4,1X,F12.8,1X,6(ES22.14E3,1X),I4,1X,I9,1X,ES14.6E3)') &
+                        trim(label), mth, ux, eta, Omth, Omph, residual, eta_res(2), &
+                        taub, istate, istats(1), rstats(6)
+                end do
+            end if
+            ux = ux + du
+        end do
+    end subroutine scan_branch
 
-    y0 = 1.0e-15_dp
-    y0(1) = 0.0_dp
-    y0(2) = 0.0_dp
-    y0(3:6) = 0.0_dp
+    subroutine probe_bounce(v, eta, taub, istate, istats, rstats)
+        real(dp), intent(in) :: v, eta, taub
+        integer, intent(out) :: istate
+        integer, intent(out) :: istats(:)
+        real(dp), intent(out) :: rstats(:)
 
-    problem%rhs => probe_rhs
-    problem%t0 = 0.0_dp
-    problem%t1 = taub
-    problem%y0 = y0
-    problem%rtol = 1.0e-8_dp
-    problem%atol = 1.0e-9_dp
+        real(dp) :: y0(nvar)
+        type(ode_problem_t) :: problem
+        type(ode_workspace_t) :: workspace
+        type(ode_solution_t) :: solution
+        type(fortnum_status_t) :: status
 
-    call ode_integrate_dop(problem, workspace, solution, status)
+        istats = 0
+        rstats = 0.0_dp
 
-    ! Report the integrator diagnostics in the slots scan_branch prints:
-    ! istats(1) = accepted steps, rstats(6) = last step size.
-    if (status%code == FORTNUM_OK) then
-      istate = 2
-    else
-      istate = -1
-    end if
-    istats(1) = solution%nsteps
-    istats(2) = solution%nrejected
-    if (allocated(solution%h) .and. solution%nsteps > 0) then
-      rstats(6) = solution%h(solution%nsteps)
-    end if
+        y0 = 1.0e-15_dp
+        y0(1) = 0.0_dp
+        y0(2) = 0.0_dp
+        y0(3:6) = 0.0_dp
 
-  contains
-    subroutine probe_rhs(t_, y_, dydt_, ctx_)
-      real(dp), intent(in) :: t_
-      real(dp), intent(in) :: y_(:)
-      real(dp), intent(out) :: dydt_(:)
-      class(*), intent(in), optional :: ctx_
-      associate (dummy => ctx_)
-      end associate
-      call timestep_transport(v, eta, size(y_), t_, y_, dydt_)
-    end subroutine probe_rhs
-  end subroutine probe_bounce
+        problem%rhs => probe_rhs
+        problem%t0 = 0.0_dp
+        problem%t1 = taub
+        problem%y0 = y0
+        problem%rtol = 1.0e-8_dp
+        problem%atol = 1.0e-9_dp
+
+        call ode_integrate_dop(problem, workspace, solution, status)
+
+        ! Report the integrator diagnostics in the slots scan_branch prints:
+        ! istats(1) = accepted steps, rstats(6) = last step size.
+        if (status%code == FORTNUM_OK) then
+            istate = 2
+        else
+            istate = -1
+        end if
+        istats(1) = solution%nsteps
+        istats(2) = solution%nrejected
+        if (allocated(solution%h) .and. solution%nsteps > 0) then
+            rstats(6) = solution%h(solution%nsteps)
+        end if
+
+    contains
+        subroutine probe_rhs(t_, y_, dydt_, ctx_)
+            real(dp), intent(in) :: t_
+            real(dp), intent(in) :: y_(:)
+            real(dp), intent(out) :: dydt_(:)
+            class(*), intent(in), optional :: ctx_
+            associate (dummy => ctx_)
+            end associate
+            call timestep_transport(v, eta, size(y_), t_, y_, dydt_)
+        end subroutine probe_rhs
+    end subroutine probe_bounce
 
 end module diag_bounce_debug

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -15,42 +15,42 @@ module neort_transport
         etamin, etamax, A1, A2, nlev, pertfile, nonlin, m0, etatp, etadt, &
         sign_vpar_htheta, sign_vpar
 
-  implicit none
+    implicit none
 
-  real(dp) :: Omth, dOmthdv, dOmthdeta
+    real(dp) :: Omth, dOmthdv, dOmthdeta
 
 contains
 
-  pure function fmt_dbg(msg1, v1, msg2, v2, msg3, v3, msg4, v4) result(s)
-    ! Helper to compose a short debug line
-    character(*), intent(in) :: msg1, msg2
-    character(*), intent(in), optional :: msg3, msg4
-    real(dp), intent(in) :: v1, v2
-    real(dp), intent(in), optional :: v3, v4
-    character(len=256) :: s
-    character(len=64) :: a1, a2, a3, a4
-    a3 = ''; a4 = ''
-    write(a1,'(ES12.5)') v1
-    write(a2,'(ES12.5)') v2
-    if (present(v3)) write(a3,'(ES12.5)') v3
-    if (present(v4)) write(a4,'(ES12.5)') v4
-    if (present(msg4)) then
-      s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)//' '//trim(msg3)//trim(a3)//' '//trim(msg4)//trim(a4)
-    else if (present(msg3)) then
-      s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)//' '//trim(msg3)//trim(a3)
-    else
-      s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)
-    end if
-  end function fmt_dbg
+    pure function fmt_dbg(msg1, v1, msg2, v2, msg3, v3, msg4, v4) result(s)
+        ! Helper to compose a short debug line
+        character(*), intent(in) :: msg1, msg2
+        character(*), intent(in), optional :: msg3, msg4
+        real(dp), intent(in) :: v1, v2
+        real(dp), intent(in), optional :: v3, v4
+        character(len=256) :: s
+        character(len=64) :: a1, a2, a3, a4
+        a3 = ''; a4 = ''
+        write(a1,'(ES12.5)') v1
+        write(a2,'(ES12.5)') v2
+        if (present(v3)) write(a3,'(ES12.5)') v3
+        if (present(v4)) write(a4,'(ES12.5)') v4
+        if (present(msg4)) then
+            s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)//' '//trim(msg3)//trim(a3)//' '//trim(msg4)//trim(a4)
+        else if (present(msg3)) then
+            s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)//' '//trim(msg3)//trim(a3)
+        else
+            s = trim(msg1)//trim(a1)//' '//trim(msg2)//trim(a2)
+        end if
+    end function fmt_dbg
 
-! original contains follows
+    ! original contains follows
 
     pure function D11int(ux, taub, Hmn2)
         real(dp) :: D11int
         real(dp), intent(in) :: ux, taub, Hmn2
 
         D11int = pi**(3.0_dp / 2.0_dp) * mph**2 * c**2 * q * vth &
-                 / (qi**2 * dVds * abs(psi_pr)) * ux**3 * exp(-ux**2) * taub * Hmn2
+            / (qi**2 * dVds * abs(psi_pr)) * ux**3 * exp(-ux**2) * taub * Hmn2
     end function D11int
 
     pure function D12int(ux, taub, Hmn2)
@@ -65,16 +65,16 @@ contains
         real(dp), intent(in) :: ux, taub, Hmn2
 
         Tphi_int = sign(1.0_dp, psi_pr * q * sign_theta) * pi**(3.0_dp / 2.0_dp) * mph**2 * ni1 * &
-                   c * vth / qi &
-                   * ux**3 * exp(-ux**2) * taub * Hmn2 * (A1 + A2 * ux**2)
+            c * vth / qi &
+            * ux**3 * exp(-ux**2) * taub * Hmn2 * (A1 + A2 * ux**2)
     end function Tphi_int
 
     subroutine compute_transport_integral(vmin, vmax, vsteps, D, T)
         ! compute transport integral via midpoint rule
         real(dp), intent(in) :: vmin, vmax
         integer, intent(in) :: vsteps
-        real(dp), intent(out) :: D(2), T  ! Transport coefficients D and torque density T
-        real(dp) :: D_plateau, dsdreff  ! Plateau diffusion coefficient and ds/dreff=<|grad s|>
+        real(dp), intent(out) :: D(2), T ! Transport coefficients D and torque density T
+        real(dp) :: D_plateau, dsdreff ! Plateau diffusion coefficient and ds/dreff=<|grad s|>
         real(dp) :: ux, du, dD11, dD12, dT, v, eta
         real(dp) :: eta_res(2)
         real(dp) :: taub, bounceavg(nvar)
@@ -82,11 +82,40 @@ contains
         real(dp) :: Hmn2, attenuation_factor
         real(dp) :: roots(nlev, 3)
         integer :: nroots, kr, ku
+        character(len=4096) :: ledger_path
+        character(len=4) :: orbit_branch
+        integer :: env_length, env_status, ledger_unit
+        logical :: ledger_enabled, ledger_exists
+        real(dp) :: Omph, dOmphdv, dOmphdeta, resonance_residual
 
         call debug(fmt_dbg('compute_transport_integral: vmin=', vmin, ' vmax=', vmax, ' vsteps=', dble(vsteps)))
 
         D = 0.0_dp
         T = 0.0_dp
+        ledger_path = ''
+        call get_environment_variable('NEORT_RESONANCE_LEDGER', ledger_path, &
+            length=env_length, status=env_status)
+        if (env_status == -1) error stop 'NEORT_RESONANCE_LEDGER path is too long'
+        ledger_enabled = env_status == 0 .and. env_length > 0
+        if (ledger_enabled) then
+            if (.not. comptorque) error stop 'NEORT_RESONANCE_LEDGER requires comptorque=.true.'
+            inquire(file=trim(ledger_path), exist=ledger_exists)
+            open(newunit=ledger_unit, file=trim(ledger_path), status='unknown', &
+                position='append', action='write')
+            if (.not. ledger_exists) then
+                write(ledger_unit, '(A)') &
+                    '# s mth mph branch ux eta Omth Omph residual dF_deta taub Hmn2 attenuation dTds_du istate'
+            end if
+            if (etamax < etatp) then
+                if (sign_vpar > 0.0_dp) then
+                    orbit_branch = 'cop'
+                else
+                    orbit_branch = 'ctr'
+                end if
+            else
+                orbit_branch = 'trap'
+            end if
+        end if
         du = (vmax - vmin) / (vsteps * vth)
         ux = vmin / vth + du / 2.0_dp
 
@@ -98,7 +127,7 @@ contains
             ! `ux = ux + du` velocity-grid increment and stall the sweep.
             do kr = 1, nroots
                 eta_res = driftorbit_root(v, 1.0e-8_dp * abs(Om_tE), roots(kr, 1), roots(kr, 2))
-                if (eta_res(1) < 0.0_dp) cycle  ! bracket-failure sentinel
+                if (eta_res(1) < 0.0_dp) cycle ! bracket-failure sentinel
                 eta = eta_res(1)
 
                 call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
@@ -116,7 +145,7 @@ contains
                 end if
                 Hmn2 = (bounceavg(3)**2 + bounceavg(4)**2) * (mi * (ux * vth)**2 / 2.0_dp)**2
                 attenuation_factor = nonlinear_attenuation(ux, eta, bounceavg, Omth, &
-                                                           dOmthdv, dOmthdeta, Hmn2)
+                    dOmthdv, dOmthdeta, Hmn2)
 
                 dD11 = du * D11int(ux, taub, Hmn2) / abs(eta_res(2))
                 dD12 = du * D12int(ux, taub, Hmn2) / abs(eta_res(2))
@@ -127,12 +156,20 @@ contains
                     dT = du * Tphi_int(ux, taub, Hmn2) / abs(eta_res(2))
                     T = T + dT * attenuation_factor
                 end if
+                if (ledger_enabled) then
+                    call Om_ph(v, eta, Omph, dOmphdv, dOmphdeta)
+                    resonance_residual = real(mth, dp) * Omth + real(mph, dp) * Omph
+                    write(ledger_unit, *) s, mth, mph, trim(orbit_branch), ux, eta, &
+                        Omth, Omph, resonance_residual, eta_res(2), taub, Hmn2, &
+                        attenuation_factor, dT / du, istate_dv
+                end if
             end do
             ux = ux + du
         end do
+        if (ledger_enabled) close(ledger_unit)
 
         D_plateau = pi * vth**3 / (16.0_dp * R0 * iota * (qi * B0 / (mi * c))**2)
-        dsdreff = 2.0_dp / a * sqrt(s)  ! TODO: Use exact value instead of this approximation
+        dsdreff = 2.0_dp / a * sqrt(s) ! TODO: Use exact value instead of this approximation
         D = dsdreff**(-2) * D / D_plateau
 
         call debug("compute_transport_integral complete")
@@ -177,10 +214,10 @@ contains
             !t0 = 0.25*2*pi/Omth ! Different starting position in orbit
             t0 = 0.0_dp
             Hn = (2.0_dp - eta * bmod) * epsn * exp(imun * (q * mph * (y(1)) - mth * (t - &
-                                                                                      t0) * Omth))
+                t0) * Omth))
         else
             Hn = (2.0_dp - eta * bmod) * epsn * exp(imun * (q * mph * (y(1)) - (mth + q * mph) &
-                                                            * t * Omth))
+                * t * Omth))
         end if
         ydot(3) = real(Hn)
         ydot(4) = aimag(Hn)

--- a/test/golden_record/test_golden_record.py
+++ b/test/golden_record/test_golden_record.py
@@ -120,13 +120,23 @@ def setup_work_dir(work_dir: Path) -> None:
             dst.symlink_to(src)
 
 
-def run_neort(executable: Path, work_dir: Path, case: str) -> None:
+def run_neort(
+    executable: Path,
+    work_dir: Path,
+    case: str,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> None:
     """Run neo_rt.x for a test case."""
+    env = os.environ.copy()
+    if extra_env is not None:
+        env.update(extra_env)
     result = subprocess.run(
         [str(executable), case],
         cwd=work_dir,
         capture_output=True,
         text=True,
+        env=env,
     )
     if result.returncode != 0:
         pytest.fail(
@@ -236,6 +246,62 @@ def test_passing_magdrift_control_reproduces_the_two_run_class_sum(
         rtol=2.0e-14,
         atol=0.0,
     )
+
+
+@pytest.mark.fast_only
+def test_resonance_ledger_reconstructs_native_harmonic_torque(
+    executable: Path, tmp_path: Path
+) -> None:
+    """Every serialized root contribution must reconstruct native output."""
+
+    case = get_test_cases()[len(get_test_cases()) // 2]
+    work_dir = tmp_path / "resonance_ledger"
+    work_dir.mkdir()
+    setup_work_dir(work_dir)
+
+    namelist = f90nml.read(INPUT_DIR / "template.in")
+    namelist["params"]["s"] = s_from_case_name(case)
+    runname = "ledger"
+    namelist.write(work_dir / f"{runname}.in", force=True)
+    ledger_path = work_dir / "roots.txt"
+    run_neort(
+        executable,
+        work_dir,
+        runname,
+        extra_env={"NEORT_RESONANCE_LEDGER": str(ledger_path)},
+    )
+
+    # Ledger columns after the branch label are:
+    # ux eta Omth Omph residual dF_deta taub Hmn2 attenuation dTds_du istate.
+    reconstructed: dict[tuple[int, str], float] = {}
+    with ledger_path.open(encoding="utf-8") as stream:
+        for line in stream:
+            if line.startswith("#"):
+                continue
+            fields = line.split()
+            mth = int(fields[1])
+            branch = fields[3]
+            attenuation = float(fields[12])
+            torque_density = float(fields[13])
+            key = (mth, branch)
+            reconstructed[key] = (
+                reconstructed.get(key, 0.0) + attenuation * torque_density
+            )
+
+    params = namelist["params"]
+    du = (float(params["vmax_over_vth"]) - 1.0e-6) / int(params["vsteps"])
+    native = np.atleast_2d(load_torque_integral(work_dir, runname))
+    branch_column = {"cop": 1, "ctr": 2, "trap": 3}
+    for row in native:
+        mth = int(row[0])
+        for branch, column in branch_column.items():
+            np.testing.assert_allclose(
+                du * reconstructed.get((mth, branch), 0.0),
+                row[column],
+                rtol=2.0e-13,
+                atol=1.0e-280,
+                err_msg=f"ledger mismatch for mth={mth}, branch={branch}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Adds an opt-in resonance ledger for diagnosing and independently reconstructing native torque contributions.

When `NEORT_RESONANCE_LEDGER` names an output file and `comptorque=.true.`, NEO-RT appends one row per resonance root with the surface, `mth/mph`, orbit branch, frequencies, resonance residual, derivative, bounce time, perturbation weight, attenuation, torque-density contribution, and integrator status. The default path and native torque result are unchanged when the environment variable is absent.

The bounce-debug diagnostic also accepts optional mode and branch filters, reports toroidal frequency/resonance residuals, and uses the configured `vmax_over_vth`.

## Validation

- `test_resonance_ledger_reconstructs_native_harmonic_torque` reconstructs each native branch contribution from the ledger.
- Existing golden-record tests remain the behavioral oracle.
- This PR is diagnostic infrastructure only; it does not change the production torque formula.
