### PR TITLE
Derive Boozer chart handedness at read time

### DIFF
--- a/src/do_magfie_standalone.f90
+++ b/src/do_magfie_standalone.f90
@@ -28,7 +28,8 @@ module do_magfie_mod
     ! Work arrays for booz_to_cyl (size=nmode)
     real(dp), private, allocatable :: rmnc(:), rmns(:), zmnc(:), zmns(:)
 
-    real(dp), parameter :: ItoB = 2.0e-1_dp * sign_theta  ! Covarient B (cgs) from I (SI)
+    real(dp), parameter :: current_to_covar = 2.0e-1_dp
+    real(dp) :: ItoB = current_to_covar * sign_theta ! Covariant B (cgs) from I (SI)
     ! Bcov=mu0/2pi*I,mu0->4pi/c,I->10^(-1)*c*I
 
     integer :: ncol1 = 0, ncol2 = 0 ! number of columns in input file
@@ -54,7 +55,8 @@ module do_magfie_mod
     !$omp threadprivate (q, dqds, iota, eps, B0h)
 
     ! Shared data (NOT threadprivate): bfac, params0, modes0, m0b, n0b, nflux,
-    ! nfp, nmode, spl_coeff1, spl_coeff2, ncol1, ncol2, inp_swi, a, B00, psi_pr, R0
+    ! nfp, nmode, spl_coeff1, spl_coeff2, ncol1, ncol2, inp_swi, a, B00, psi_pr,
+    ! R0, ItoB
 
     ! inp_swi == 10: Boozer chartmap (NetCDF) input via libneo reader.
     ! Shared read-only arrays; populated once by read_boozer_chartmap_file.
@@ -464,9 +466,94 @@ contains
             end do
         end do
         close (unit=18)
+        call set_bc_current_factor(filename)
         ! Set R0 to first harmonic
         R0 = modes0(1, 1, 3)*100
     end subroutine boozer_read
+
+    subroutine set_bc_current_factor(filename)
+        character(len=*), intent(in) :: filename
+
+        integer :: handedness, iota_sign, ksurf, orientation
+        integer :: reference_orientation
+        real(dp) :: area
+
+        reference_orientation = 0
+        do ksurf = 1, nflux
+            area = signed_poloidal_area(ksurf)
+            if (area == 0.0_dp .or. params0(ksurf, 2) == 0.0_dp) then
+                call fail_undetermined_handedness(filename, ksurf, area)
+            end if
+            orientation = int(sign(1.0_dp, area))
+            iota_sign = int(sign(1.0_dp, params0(ksurf, 2)))
+            ! area*iota is field-line winding; remove the field direction again
+            ! to obtain the orientation of the (s, theta, phi) coordinate triple.
+            handedness = -(orientation*iota_sign)*iota_sign
+            if (reference_orientation == 0) reference_orientation = orientation
+            if (orientation /= reference_orientation) then
+                call fail_inconsistent_handedness(filename, ksurf, orientation)
+            end if
+        end do
+        ItoB = current_to_covar*real(handedness, dp)
+    end subroutine set_bc_current_factor
+
+    function signed_poloidal_area(ksurf) result(area)
+        integer, intent(in) :: ksurf
+        real(dp) :: area
+
+        integer :: j, m, mode_sign
+        real(dp) :: Rcos(0:m0b), Rsin(0:m0b), Zcos(0:m0b), Zsin(0:m0b)
+
+        Rcos = 0.0_dp
+        Rsin = 0.0_dp
+        Zcos = 0.0_dp
+        Zsin = 0.0_dp
+        do j = 1, nmode
+            m = abs(nint(modes0(ksurf, j, 1)))
+            mode_sign = int(sign(1.0_dp, modes0(ksurf, j, 1)))
+            Rcos(m) = Rcos(m) + modes0(ksurf, j, 3)
+            if (inp_swi == 8) then
+                Zsin(m) = Zsin(m) + mode_sign*modes0(ksurf, j, 4)
+            else
+                Rsin(m) = Rsin(m) + mode_sign*modes0(ksurf, j, 4)
+                Zcos(m) = Zcos(m) + modes0(ksurf, j, 5)
+                Zsin(m) = Zsin(m) + mode_sign*modes0(ksurf, j, 6)
+            end if
+        end do
+        ! 1/2 integral(R*dZ - Z*dR) = pi*sum_m m*(Rc*Zs - Rs*Zc).
+        area = 0.0_dp
+        do m = 1, m0b
+            area = area + real(m, dp)*(Rcos(m)*Zsin(m) - Rsin(m)*Zcos(m))
+        end do
+        area = pi*area
+    end function signed_poloidal_area
+
+    subroutine fail_undetermined_handedness(filename, ksurf, area)
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: ksurf
+        real(dp), intent(in) :: area
+
+        character(len=1024) :: message
+
+        write (message, "(a,a,a,i0,a,es12.4,a,es12.4)") &
+            "Cannot determine Boozer handedness in '", trim(filename), &
+            "' at surface ", ksurf, ": signed area=", area, &
+            ", iota=", params0(ksurf, 2)
+        error stop trim(message)
+    end subroutine fail_undetermined_handedness
+
+    subroutine fail_inconsistent_handedness(filename, ksurf, orientation)
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: ksurf, orientation
+
+        character(len=1024) :: message
+
+        write (message, "(a,a,a,i0,a,i0,a,i0)") &
+            "Inconsistent Boozer handedness in '", trim(filename), &
+            "' at surface ", ksurf, ": poloidal orientation=", orientation, &
+            ", iota sign=", int(sign(1.0_dp, params0(ksurf, 2)))
+        error stop trim(message)
+    end subroutine fail_inconsistent_handedness
 
     subroutine booz_to_cyl(x, r)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,11 @@ add_test(NAME test_chartmap_input
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/base
 )
 
+add_test(NAME test_boozer_handedness
+    COMMAND ${CMAKE_BINARY_DIR}/test_boozer_handedness.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 add_test(NAME test_profile_collision_species
     COMMAND ${CMAKE_BINARY_DIR}/test_profile_collision_species.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/test_boozer_handedness.f90
+++ b/test/test_boozer_handedness.f90
@@ -1,0 +1,144 @@
+program test_boozer_handedness
+    ! Independent large-aspect-ratio circular oracle:
+    ! R = R0 + a*sqrt(s)*cos(theta), Z = sigma_theta*a*sqrt(s)*sin(theta).
+    ! The metric gives B_phi = sigma_phi*B0*R0,
+    ! B_theta = r**2*iota*sigma_phi*B0/R0, and
+    ! sqrt(g) = handedness*R0*a**2/2.
+    use iso_fortran_env, only: dp => real64
+    use do_magfie_mod, only: Bphcov, Bthcov, bfac, do_magfie, &
+        init_magfie_at_s, inp_swi, magfie_thread_init, &
+        read_boozer_file, set_s
+    use logger, only: set_log_level
+    use util, only: pi
+
+    implicit none
+
+    real(dp), parameter :: field_t = 2.0_dp
+    real(dp), parameter :: major_radius_m = 5.0_dp
+    real(dp), parameter :: minor_radius_m = 0.5_dp
+    real(dp), parameter :: iota_abs = 0.2_dp
+    real(dp), parameter :: evaluation_s = 0.5_dp
+    real(dp), parameter :: current_to_covar = 0.2_dp
+    real(dp), parameter :: meter_to_cm = 100.0_dp
+    real(dp), parameter :: tesla_to_gauss = 1.0e4_dp
+    real(dp), parameter :: tolerance = 1.0e-12_dp
+
+    call set_log_level(-1)
+    call write_chart("manufactured_left.bc", 1, -1, -1)
+    call write_chart("manufactured_left_positive_iota.bc", 1, 1, -1)
+    call write_chart("manufactured_right.bc", -1, 1, 1)
+    call check_chart("manufactured_left.bc", 1, -1, -1)
+    call check_chart("manufactured_left_positive_iota.bc", 1, 1, -1)
+    call check_chart("manufactured_right.bc", -1, 1, 1)
+
+contains
+
+    subroutine check_chart(path, orientation, iota_sign, handedness)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: orientation, iota_sign, handedness
+
+        real(dp) :: bder(3), bmod, hcovar(3), hctrvr(3), hcurl(3)
+        real(dp) :: expected_Bphcov, expected_Bthcov, expected_sqrtg
+        real(dp) :: iota_chart, radius_cm, sigma_phi, sqrtg, x(3)
+
+        sigma_phi = -real(handedness, dp)/real(orientation, dp)
+        iota_chart = real(iota_sign, dp)*iota_abs
+        radius_cm = minor_radius_m*meter_to_cm*sqrt(evaluation_s)
+        expected_Bphcov = sigma_phi*field_t*tesla_to_gauss*major_radius_m*meter_to_cm
+        expected_Bthcov = field_t*tesla_to_gauss*radius_cm**2*iota_chart*sigma_phi &
+            /(major_radius_m*meter_to_cm)
+        expected_sqrtg = real(handedness, dp)*major_radius_m*meter_to_cm &
+            *(minor_radius_m*meter_to_cm)**2/2.0_dp
+
+        inp_swi = 9
+        bfac = 1.0_dp
+        call magfie_thread_init()
+        call read_boozer_file(path)
+        call set_s(evaluation_s)
+        call init_magfie_at_s()
+        x = [evaluation_s, 0.0_dp, 0.0_dp]
+        call do_magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+
+        call assert_close(path//" B_theta", Bthcov, expected_Bthcov)
+        call assert_close(path//" B_phi", Bphcov, expected_Bphcov)
+        call assert_close(path//" h_theta", hcovar(3)*bmod, expected_Bthcov)
+        call assert_close(path//" h_phi", hcovar(2)*bmod, expected_Bphcov)
+        call assert_close(path//" sqrt(g)", sqrtg, expected_sqrtg)
+    end subroutine check_chart
+
+    subroutine write_chart(path, orientation, iota_sign, handedness)
+        character(len=*), intent(in) :: path
+        integer, intent(in) :: orientation, iota_sign, handedness
+
+        integer :: file_unit, surface_index
+        real(dp) :: Bph_si, Bth_si, flux, iota_chart, radius_m
+        real(dp) :: raw_Jpol, raw_Itor, s_surface, sigma_phi
+        real(dp), parameter :: surfaces(3) = [0.25_dp, 0.5_dp, 0.75_dp]
+
+        sigma_phi = -real(handedness, dp)/real(orientation, dp)
+        iota_chart = real(iota_sign, dp)*iota_abs
+        flux = -real(handedness, dp)*sigma_phi*pi*minor_radius_m**2*field_t
+        Bph_si = sigma_phi*field_t*major_radius_m
+
+        open (newunit=file_unit, file=path, status="replace", action="write")
+        call write_header(file_unit, flux)
+        do surface_index = 1, size(surfaces)
+            s_surface = surfaces(surface_index)
+            radius_m = minor_radius_m*sqrt(s_surface)
+            Bth_si = field_t*radius_m**2*iota_chart*sigma_phi/major_radius_m
+            raw_Jpol = Bph_si*tesla_to_gauss*meter_to_cm &
+                /(current_to_covar*real(handedness, dp))
+            raw_Itor = Bth_si*tesla_to_gauss*meter_to_cm &
+                /(current_to_covar*real(handedness, dp))
+            call write_surface(file_unit, s_surface, iota_chart, raw_Jpol, &
+                raw_Itor, radius_m, orientation)
+        end do
+        close (file_unit)
+    end subroutine write_chart
+
+    subroutine write_header(file_unit, flux)
+        integer, intent(in) :: file_unit
+        real(dp), intent(in) :: flux
+
+        write (file_unit, "(a)") "CC manufactured large-aspect-ratio circular chart"
+        write (file_unit, "(a)") "CC independent analytic field and geometry"
+        write (file_unit, "(a)") "CC m0b n0b nsurf nper flux a R"
+        write (file_unit, "(a)") "CC"
+        write (file_unit, "(a)") "CC"
+        write (file_unit, *) 1, 0, 3, 1, flux, minor_radius_m, major_radius_m
+    end subroutine write_header
+
+    subroutine write_surface(file_unit, s_surface, iota_chart, Jpol, Itor, &
+            radius_m, orientation)
+        integer, intent(in) :: file_unit
+        integer, intent(in) :: orientation
+        real(dp), intent(in) :: s_surface, iota_chart, Jpol, Itor, radius_m
+
+        real(dp) :: field_magnitude
+
+        field_magnitude = field_t*sqrt(1.0_dp + (radius_m*iota_abs/major_radius_m)**2)
+        write (file_unit, "(a)") "CC s iota Jpol Itor pprime sqrtg00"
+        write (file_unit, "(a)") "CC units A A Pa m3"
+        write (file_unit, *) s_surface, iota_chart, Jpol, Itor, 0.0_dp, 0.0_dp
+        write (file_unit, "(a)") "CC m n rmnc rmns zmnc zmns vmnc vmns bmnc bmns"
+        write (file_unit, *) 0, 0, major_radius_m, 0.0_dp, 0.0_dp, 0.0_dp, &
+            0.0_dp, 0.0_dp, field_magnitude, 0.0_dp
+        write (file_unit, *) 1, 0, radius_m, 0.0_dp, 0.0_dp, &
+            real(orientation, dp)*radius_m, &
+            0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp
+    end subroutine write_surface
+
+    subroutine assert_close(label, actual, expected)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected
+
+        real(dp) :: relative_error
+
+        relative_error = abs(actual - expected)/max(abs(expected), tiny(expected))
+        if (relative_error > tolerance) then
+            print *, trim(label), " expected", expected, "got", actual
+            error stop "manufactured Boozer oracle failed"
+        end if
+    end subroutine assert_close
+
+end program test_boozer_handedness


### PR DESCRIPTION
## Summary

- measure each Boozer surface orientation from its Fourier geometry
- combine that orientation with the executed iota direction before setting covariant-current signs
- fail closed on degenerate or surface-inconsistent charts
- retain the legacy result exactly for the supported left-handed chart

## Independent gate

The circular large-aspect-ratio test constructs both chart orientations and both iota signs, then checks the Cartesian field, both covariant components, and signed Jacobian. This separates a coordinate relabelling from a physical field reversal.

Closes #95.

## Charge-verified TC24 production evidence

The compiled convention gate and the final production matrix were executed from this exact head, `b90cb0037f831a52ca504079bc56b43603eb4343`. The validated binary SHA-256 is `7c975985f13cb321498faf16923175462cd22094b5efdb7e7027e311eb636c02`; the electric-frequency oracle closes to `2.273736754e-13 rad/s`.

Production uses Xingting's charge-verified source with `ni=ne=supplied density` and physical `Ti`/`Te`. The accepted inventory contains the fixed-MARS-field lanes and the full 16-lane GPEC-field sign-control matrix: `phiI000`/`phiI010`, L0/L5, both `M_t` signs, and both signed `n` values, with 151 surfaces in every GPEC lane. Raw harmonic sums reconstruct every serialized total.

Against the phase-matched PENTRC curves, the aggregate relative L2 ordering is `(-M_t,+n)=0.296`, `(-M_t,-n)=0.938`, `(+M_t,-n)=1.207`, `(+M_t,+n)=3.747`. This is evidence for the PENTRC-to-NEO electric-frequency bridge, not permission to flip an executable torque sign: MARS-field figures retain native signs and GPEC publication remains magnitude-only while the manufactured helicity gate is open. No phase, gain, smoothing, shift, or radial fit was applied.
