### PR TITLE
Add an orbit-class magnetic-drift control

### DIFF
--- a/src/config.f90
+++ b/src/config.f90
@@ -15,6 +15,8 @@ module neort_config
         logical :: comptorque = .false.  ! compute torque
         logical :: supban = .false.  ! Shaing superbanana-plateau (trapped ell=0) only
         logical :: magdrift = .false.  ! consider magnetic drift
+        ! Negative means "follow magdrift", preserving every existing deck.
+        integer :: magdrift_passing = -1
         logical :: nopassing = .false.  ! neglect passing particles
         logical :: noshear = .false.  ! neglect magnetic shear term with dqds
         logical :: pertfile = .false.  ! read perturbation from file
@@ -35,7 +37,7 @@ contains
         ! Set global control parameters via config struct
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, &
+        use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
@@ -54,6 +56,8 @@ contains
         comptorque = config%comptorque
         supban = config%supban
         magdrift = config%magdrift
+        magdrift_passing = config%magdrift_passing
+        if (magdrift_passing < 0) magdrift_passing = merge(1, 0, magdrift)
         nopassing = config%nopassing
         noshear = config%noshear
         pertfile = config%pertfile
@@ -77,7 +81,7 @@ contains
         ! Set global control parameters directly from a file
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, nopassing, pertfile, &
+        use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
@@ -90,7 +94,7 @@ contains
         integer :: log_level = 0
 
         namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, supban, &
-            magdrift, nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, &
+            magdrift, magdrift_passing, nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, &
             vsteps, mth_max_abs, vmax_over_vth, log_level
 
         mth_max_abs = -1
@@ -99,6 +103,7 @@ contains
         read (9, nml=params)
         close (unit=9)
 
+        if (magdrift_passing < 0) magdrift_passing = merge(1, 0, magdrift)
         if (mth_max_abs < -1) error stop "mth_max_abs must be -1 or nonnegative"
         if (vmax_over_vth <= 0.0_dp) error stop "vmax_over_vth must be positive"
 

--- a/src/driftorbit.f90
+++ b/src/driftorbit.f90
@@ -22,6 +22,8 @@ module driftorbit
     integer :: m0 = 1                 ! Boozer poloidal perturbation mode
     integer :: mth = 1                ! canonical poloidal mode
     logical :: magdrift = .true.      ! consider magnetic drift
+    !> Passing magnetic drift; defaults to magdrift through the config layer.
+    integer :: magdrift_passing = -1
     logical :: nopassing = .false.    ! neglect passing particles
     logical :: pertfile = .false.     ! read perturbation from file with neo_magfie_pert
     logical :: comptorque = .true.    ! compute torque

--- a/src/freq.f90
+++ b/src/freq.f90
@@ -6,6 +6,7 @@ module neort_freq
     use neort_orbit, only: nvar, bounce_fast, bounce_time, timestep
     use neort_profiles, only: vth, Om_tE, dOm_tEds
     use driftorbit, only: etamin, etamax, etatp, etadt, epsst_spl, epst_spl, epst, magdrift, &
+        magdrift_passing, &
         epssp_spl, epsp_spl, sign_vpar, sign_vpar_htheta, mph, nonlin, supban
     use shaing, only: omph_shaing
     use do_magfie_mod, only: iota, s, Bthcov, Bphcov, q
@@ -223,17 +224,17 @@ contains
             if (get_log_level() >= LOG_TRACE) then
                 write(*,'(A,I4,A,ES12.5,A,ES12.5)') '[TRACE] init_canon_freq_passing_spline k=', k, ' eta=', eta, ' taub=', taub
             end if
-            if (magdrift) Om_tB_v(k + 1) = bounceavg(3)
+            if (magdrift_passing > 0) Om_tB_v(k + 1) = bounceavg(3)
             Omth_v(k + 1) = 2*pi/(v*taub)
             if (k == netaspl_pass - 2) then
                 leta0 = log(etatp - eta)
                 taub0 = v*taub
-                if (magdrift) OmtB0 = Om_tB_v(k + 1)/Omth_v(k + 1)
+                if (magdrift_passing > 0) OmtB0 = Om_tB_v(k + 1)/Omth_v(k + 1)
             end if
             if (k == netaspl_pass - 1) then
                 leta1 = log(etatp - eta)
                 taub1 = v*taub
-                if (magdrift) OmtB1 = Om_tB_v(k + 1)/Omth_v(k + 1)
+                if (magdrift_passing > 0) OmtB1 = Om_tB_v(k + 1)/Omth_v(k + 1)
             end if
         end do
 
@@ -241,7 +242,7 @@ contains
         d_taub_p = taub0 - k_taub_p*leta0
         Omth_pass_spl_coeff = spline_coeff(etarange, Omth_v)
 
-        if (magdrift) then
+        if (magdrift_passing > 0) then
             k_OmtB_p = (OmtB1 - OmtB0)/(leta1 - leta0)
             d_OmtB_p = OmtB0 - k_OmtB_p*leta0
             OmtB_pass_spl_coeff = spline_coeff(etarange, Om_tB_v)
@@ -266,6 +267,10 @@ contains
                                             dOmthdeta / v * (k_OmtB_t * log(eta - etatp) &
                                                 + d_OmtB_t))
             end if
+        else if (magdrift_passing <= 0) then
+            ! MARS-K has no passing magnetic-drift path; this reproduces that
+            ! scope exactly rather than approximately.
+            splineval = 0.0_dp
         else
             if (eta < etatp * (1 - epsp_spl)) then
                 splineval = spline_val_0(OmtB_pass_spl_coeff, eta)

--- a/test/golden_record/test_golden_record.py
+++ b/test/golden_record/test_golden_record.py
@@ -198,5 +198,45 @@ def test_golden(case: str, executable: Path, tmp_path: Path) -> None:
     assert golden_close(actual_magfie, golden_magfie), f"Magfie mismatch for {case}"
 
 
+@pytest.mark.fast_only
+def test_passing_magdrift_control_reproduces_the_two_run_class_sum(
+    executable: Path, tmp_path: Path
+) -> None:
+    """One mixed-scope run must equal the independent two-run composition."""
+
+    case = get_test_cases()[len(get_test_cases()) // 2]
+    outputs = {}
+    for label, magdrift, passing_control in (
+        ("full_drift", True, None),
+        ("no_drift", False, None),
+        ("mixed_scope", True, 0),
+    ):
+        work_dir = tmp_path / label
+        work_dir.mkdir()
+        setup_work_dir(work_dir)
+        namelist = f90nml.read(INPUT_DIR / "template.in")
+        namelist["params"]["s"] = s_from_case_name(case)
+        namelist["params"]["magdrift"] = magdrift
+        if passing_control is not None:
+            namelist["params"]["magdrift_passing"] = passing_control
+        namelist.write(work_dir / f"{label}.in", force=True)
+        run_neort(executable, work_dir, label)
+        outputs[label] = np.atleast_2d(load_torque(work_dir, label))[0]
+
+    # torque.out columns are s, dV/ds, M_t, T_co, T_counter, T_trapped.
+    np.testing.assert_allclose(
+        outputs["mixed_scope"][3:5],
+        outputs["no_drift"][3:5],
+        rtol=2.0e-14,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        outputs["mixed_scope"][5],
+        outputs["full_drift"][5],
+        rtol=2.0e-14,
+        atol=0.0,
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
MARS-K has no passing magnetic-drift path. This adds one narrowly scoped control so NEO-RT can reproduce that orbit-class physics in one run.

`magdrift_passing` is an integer namelist/API control: negative follows `magdrift` (the backward-compatible default), zero disables only the passing contribution, and positive enables it. The trapped branch and native torque signs are unchanged.

The independent behavioral oracle runs three real golden-record cases: full drift, no drift, and mixed scope. It verifies that the mixed run's passing contribution equals the no-drift run while its trapped contribution equals the full-drift run. This is the previous two-run composition, not an assertion of the new implementation's internal state.

Validation:
- `fo test`: 10/10
- targeted golden-record behavioral test: 1/1
- clean GNU build

This supersedes #94, whose branch accidentally contained unrelated stacked work.
