### PR TITLE
Add independent direct-field and Fourier contract oracles

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -165,6 +165,13 @@ target_link_libraries(potato_drift_probe.x
    "$<LINK_GROUP:RESCAN,potato,potato_base>"
 )
 
+add_executable(potato_profile_serializer_probe.x
+   SRC/potato_profile_serializer_probe.f90
+)
+target_link_libraries(potato_profile_serializer_probe.x
+   potato
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -148,6 +148,16 @@ target_link_libraries(potato_resonance_probe.x
    potato
 )
 
+# Trace-only executable for the cross-code Cartesian coordinate audit.  The
+# project-side verifier supplies points and interprets native output; no
+# production physics, defaults, or file formats are changed here.
+add_executable(potato_coordinate_probe.x
+   SRC/potato_coordinate_probe.f90
+)
+target_link_libraries(potato_coordinate_probe.x
+   potato_base
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -158,6 +158,13 @@ target_link_libraries(potato_coordinate_probe.x
    potato_base
 )
 
+add_executable(potato_drift_probe.x
+   SRC/potato_drift_probe.f90
+)
+target_link_libraries(potato_drift_probe.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -174,6 +174,13 @@ target_link_libraries(potato_profile_serializer_probe.x
    potato
 )
 
+add_executable(potato_bmod_serializer_probe.x
+   SRC/potato_bmod_serializer_probe.f90
+)
+target_link_libraries(potato_bmod_serializer_probe.x
+   potato_base
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -181,6 +181,13 @@ target_link_libraries(potato_bmod_serializer_probe.x
    potato_base
 )
 
+add_executable(potato_hamiltonian_probe.x
+   SRC/potato_hamiltonian_probe.f90
+)
+target_link_libraries(potato_hamiltonian_probe.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_bmod_converter

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -44,6 +44,8 @@ FetchContent_MakeAvailable(fortplot)
 # libneo supplies the field, magfie and spline code POTATO used to carry as
 # relative symlinks into a sibling libneo checkout. Link the upstream library so
 # fixes (e.g. the stretch_coords convex-wall load) propagate instead of drifting.
+set(LIBNEO_RELEASE fix/field-eq-flux-units-401 CACHE STRING
+    "libneo branch carrying the field_eq flux-unit regression")
 find_or_fetch(libneo)
 
 # Hold POTATO's own sources to f2018, stop at the first diagnostic, and run the C

--- a/POTATO/SRC/potato_bmod_serializer_probe.f90
+++ b/POTATO/SRC/potato_bmod_serializer_probe.f90
@@ -1,0 +1,23 @@
+program potato_bmod_serializer_probe
+    implicit none
+
+    character(len=512) :: points_path
+    complex(8) :: amplitude
+    double precision :: radius, height
+    integer :: index, input_unit, status
+
+    call get_command_argument(1, points_path)
+    open(newunit=input_unit, file=trim(points_path), status="old", action="read")
+
+    index = 0
+    do
+        read(input_unit, *, iostat=status) radius, height
+        if (status < 0) exit
+        if (status > 0) error stop "invalid POTATO bmod probe point"
+        index = index + 1
+        call bmod_pert(radius, height, amplitude)
+        write(*, '(A,I0,4ES25.16)') "POTATO_BMOD_SAMPLE ", index, radius, height, &
+            real(amplitude), aimag(amplitude)
+    end do
+    close(input_unit)
+end program potato_bmod_serializer_probe

--- a/POTATO/SRC/potato_coordinate_probe.f90
+++ b/POTATO/SRC/potato_coordinate_probe.f90
@@ -1,0 +1,51 @@
+program potato_coordinate_probe
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use field_eq_mod, only: ierrfield, psi_axis, psi_sep
+    use field_sub, only: psif
+
+    implicit none
+
+    character(len=1024) :: points_file
+    integer :: input_unit, ios, sample, status
+    real(dp) :: x(3), bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+    real(dp) :: b_cartesian(3), cphi, sphi
+
+    interface
+        subroutine magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+            import dp
+            real(dp), intent(in) :: x(3)
+            real(dp), intent(out) :: bmod, sqrtg
+            real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        end subroutine magfie
+    end interface
+
+    call get_command_argument(1, points_file, status=status)
+    if (status /= 0 .or. len_trim(points_file) == 0) then
+        error stop 'usage: potato_coordinate_probe.x POINTS_FILE'
+    end if
+
+    open(newunit=input_unit, file=trim(points_file), status='old', action='read')
+    sample = 0
+    do
+        read(input_unit, *, iostat=ios) x
+        if (ios < 0) exit
+        if (ios > 0) error stop 'invalid coordinate-probe point'
+        sample = sample + 1
+
+        call magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        if (ierrfield /= 0) error stop 'coordinate-probe point outside field domain'
+
+        cphi = cos(x(2))
+        sphi = sin(x(2))
+        b_cartesian = bmod*[ &
+            hctrvr(1)*cphi - x(1)*hctrvr(2)*sphi, &
+            hctrvr(1)*sphi + x(1)*hctrvr(2)*cphi, &
+            hctrvr(3)]
+
+        write(*, '(a,1x,i0,1x,*(es24.16e3,1x))') 'POTATO_COORD_SAMPLE', sample, &
+            x, b_cartesian, bmod, sqrtg, psif, psi_axis, psi_sep, &
+            bder, hcovar, hctrvr, hcurl
+    end do
+    close(input_unit)
+
+end program potato_coordinate_probe

--- a/POTATO/SRC/potato_drift_probe.f90
+++ b/POTATO/SRC/potato_drift_probe.f90
@@ -1,0 +1,70 @@
+program potato_drift_probe
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use parmot_mod, only: rmu, ro0
+    use phielec_of_psi_mod, only: polyphi
+
+    implicit none
+
+    integer, parameter :: nstate = 6
+    character(len=16), parameter :: labels(nstate) = [character(len=16) :: &
+        'parallel', 'qplus_Ezero', 'qplus_Eplus', 'qplus_Eminus', &
+        'qminus_Ezero', 'qminus_Eplus']
+    real(dp), parameter :: rho0_probe = 1.0e-3_dp
+    real(dp), parameter :: potential_slope = 1.0e10_dp
+    real(dp), parameter :: p_probe = 1.0_dp
+    real(dp), parameter :: lambda_probe = 0.2_dp
+
+    character(len=1024) :: points_file
+    integer :: input_unit, ios, sample, state, status
+    real(dp) :: z(5), vz(5), vcart(3), state_ro0(nstate), state_slope(nstate)
+    real(dp) :: cphi, sphi
+
+    interface
+        subroutine velo(tau, z, vz)
+            import dp
+            real(dp), intent(in) :: tau, z(5)
+            real(dp), intent(out) :: vz(5)
+        end subroutine velo
+    end interface
+
+    call get_command_argument(1, points_file, status=status)
+    if (status /= 0 .or. len_trim(points_file) == 0) then
+        error stop 'usage: potato_drift_probe.x POINTS_FILE'
+    end if
+
+    state_ro0 = [0.0_dp, rho0_probe, rho0_probe, rho0_probe, &
+        -rho0_probe, -rho0_probe]
+    state_slope = [0.0_dp, 0.0_dp, potential_slope, -potential_slope, &
+        0.0_dp, -potential_slope]
+    rmu = 1.0e30_dp
+
+    open(newunit=input_unit, file=trim(points_file), status='old', action='read')
+    sample = 0
+    do
+        read(input_unit, *, iostat=ios) z(1:3)
+        if (ios < 0) exit
+        if (ios > 0) error stop 'invalid drift-probe point'
+        sample = sample + 1
+        z(4) = p_probe
+        z(5) = lambda_probe
+        cphi = cos(z(2))
+        sphi = sin(z(2))
+
+        do state = 1, nstate
+            ro0 = state_ro0(state)
+            polyphi = 0.0_dp
+            ! profile_input evaluates polyphi(8)*s_pol + polyphi(9).
+            polyphi(8) = state_slope(state)
+            call velo(0.0_dp, z, vz)
+            vcart = [ &
+                vz(1)*cphi - z(1)*vz(2)*sphi, &
+                vz(1)*sphi + z(1)*vz(2)*cphi, &
+                vz(3)]
+            write(*, '(a,1x,i0,1x,a,1x,*(es24.16e3,1x))') &
+                'POTATO_DRIFT_STATE', sample, trim(labels(state)), &
+                z, ro0, state_slope(state), vz, vcart
+        end do
+    end do
+    close(input_unit)
+
+end program potato_drift_probe

--- a/POTATO/SRC/potato_hamiltonian_probe.f90
+++ b/POTATO/SRC/potato_hamiltonian_probe.f90
@@ -1,0 +1,154 @@
+program potato_hamiltonian_probe
+    use parmot_mod, only: rmu, ro0
+    use orbit_dim_mod, only: neqm, next, numbasef
+    use global_invariants, only: dtau, cE_ref, Phi_eff
+    use phielec_of_psi_mod, only: polyphi, polydens, polytemp
+    use poicut_mod, only: npc, rpc_arr
+    use potato_input_mod, only: read_potato_input, E_alpha, A_alpha, Z_alpha, &
+        rho_pol_max, scalfac_energy, scalfac_efield, Rmax_orbit, ntimstep, &
+        npoicut, profile_file, edge_extension, probe_rho_pol, probe_ux, &
+        probe_eta, probe_m, probe_n
+    use field_eq_mod, only: allow_sol, psi_axis, psi_sep
+    use field_sub, only: psif
+    use resint_mod, only: twopim2, rm3, taub_new, delphi_new, &
+        toten_orb, perpinv_orb
+    implicit none
+
+    double precision, parameter :: c = 2.9979d10
+    double precision, parameter :: e_charge = 4.8032d-10
+    double precision, parameter :: p_mass = 1.6726d-24
+    double precision, parameter :: ev = 1.6022d-12
+    double precision, parameter :: pi = 3.14159265358979d0
+
+    character(len=128) :: argument
+    integer :: ierr, ierr_h
+    double precision :: phi_shift, psi, dens, temp, ddens, dtemp
+    double precision :: phi_elec, dPhi_dpsi, enkin, toten, perpinv
+    double precision :: Rst, psiast, dpsiast_dRst, v0, bmod_ref
+    double precision :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+    double precision :: taub, delphi, absHn2, absHn2_production
+    double precision :: extraset0(1), extraset3(3)
+    double precision :: z(neqm), z_work(neqm), zext(neqm + 3), vzext(neqm + 3)
+    complex(8) :: bmod_n, h_integral
+
+    external :: find_bounce, velo, velo_res, pertham
+
+    phi_shift = 0.d0
+    call get_command_argument(1, argument)
+    if (len_trim(argument) > 0) read(argument, *) phi_shift
+
+    call read_potato_input("potato.in")
+    allow_sol = edge_extension
+    E_alpha = E_alpha/scalfac_energy
+    rmu = 1.d30
+    v0 = sqrt(2.d0*E_alpha*ev/(p_mass*A_alpha))
+    bmod_ref = 1.d0
+    ro0 = v0*p_mass*A_alpha*c/(e_charge*Z_alpha*bmod_ref)
+    cE_ref = E_alpha*ev
+    Phi_eff = c*E_alpha*ev/(e_charge*Z_alpha*v0)
+    dtau = Rmax_orbit/dble(ntimstep)
+    numbasef = 0
+
+    call load_profiles
+    call find_poicut(rho_pol_max, npoicut)
+
+    psi = psi_axis + probe_rho_pol**2*(psi_sep - psi_axis)
+    call denstemp_of_psi(psi, dens, temp, ddens, dtemp)
+    call phielec_of_psi(psi, phi_elec, dPhi_dpsi)
+    enkin = probe_ux**2*temp
+    toten = enkin + phi_elec
+    perpinv = probe_eta*enkin
+    Rst = R_from_psi_lfs(psi)
+    call starter_doublecount(toten, perpinv, 1.d0, Rst, &
+        psiast, dpsiast_dRst, z, ierr)
+    if (ierr /= 0) error stop "starter_doublecount failed"
+    z(2) = phi_shift
+
+    call get_bmod_and_Phi(z(1:3), bmod, phi_elec)
+    call magfie(z(1:3), bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+    call bmod_pert(z(1), z(3), bmod_n)
+
+    toten_orb = z(4)**2 + phi_elec
+    perpinv_orb = z(4)**2*(1.d0 - z(5)**2)/bmod
+    twopim2 = 2.d0*pi*dble(probe_m)
+    rm3 = dble(probe_n)
+
+    next = 0
+    extraset0 = 0.d0
+    z_work = z
+    call find_bounce(next, velo, dtau, z_work, taub, delphi, extraset0, ierr)
+    if (ierr /= 0) error stop "unperturbed find_bounce failed"
+    taub_new = taub
+    delphi_new = delphi
+
+    next = 3
+    zext = 0.d0
+    zext(1:neqm) = z
+    call velo_res(0.d0, zext, vzext)
+    extraset3 = 0.d0
+    z_work = z
+    call find_bounce(next, velo_res, dtau, z_work, taub, delphi, &
+        extraset3, ierr_h)
+    if (ierr_h /= 0) error stop "Hamiltonian find_bounce failed"
+    h_integral = cmplx(extraset3(2)/taub, extraset3(3)/taub, kind=8)
+    absHn2 = abs(h_integral)**2
+
+    z_work = z
+    twopim2 = 2.d0*pi*dble(probe_m)
+    rm3 = dble(probe_n)
+    call pertham(z_work, absHn2_production)
+
+    write(*, '(A,2I8,12ES25.16)') "POTATO_HAMILTONIAN_STATE ", &
+        probe_m, probe_n, phi_shift, z, psi, psiast, bmod, phi_elec, &
+        taub_new, delphi_new
+    write(*, '(A,8ES25.16)') "POTATO_HAMILTONIAN_FIELD ", &
+        sqrtg, hctrvr, real(bmod_n), aimag(bmod_n), psif, psi_sep
+    write(*, '(A,6ES25.16)') "POTATO_HAMILTONIAN_NATIVE ", &
+        vzext(7), vzext(8), real(h_integral), aimag(h_integral), &
+        absHn2, absHn2_production
+
+contains
+
+    subroutine load_profiles
+        integer :: iunit
+
+        open(newunit=iunit, file=trim(profile_file), status="old", action="read")
+        read(iunit, *)
+        read(iunit, *)
+        read(iunit, *) polydens
+        read(iunit, *) polytemp
+        read(iunit, *) polytemp
+        read(iunit, *) polyphi
+        close(iunit)
+        polytemp = polytemp/scalfac_energy
+        polyphi = polyphi/scalfac_efield
+        polytemp = polytemp/E_alpha
+        polyphi = polyphi*Z_alpha*e_charge/(E_alpha*ev)
+    end subroutine load_profiles
+
+    double precision function R_from_psi_lfs(psi_target)
+        double precision, intent(in) :: psi_target
+        integer :: k, best
+        double precision :: height, dZ_dR, x(3), bmag, jacobian
+        double precision :: bder_local(3), hcov_local(3)
+        double precision :: hcon_local(3), hcurl_local(3)
+        double precision :: error, best_error
+
+        best = max(0, npc - 1)
+        best_error = huge(1.d0)
+        do k = 0, npc
+            if (rpc_arr(k) < rpc_arr(npc/2)) cycle
+            call get_poicut(rpc_arr(k), height, dZ_dR)
+            x = [rpc_arr(k), 0.d0, height]
+            call magfie(x, bmag, jacobian, bder_local, hcov_local, &
+                hcon_local, hcurl_local)
+            error = abs(psif - psi_target)
+            if (error < best_error) then
+                best = k
+                best_error = error
+            end if
+        end do
+        R_from_psi_lfs = rpc_arr(best)
+    end function R_from_psi_lfs
+
+end program potato_hamiltonian_probe

--- a/POTATO/SRC/potato_profile_serializer_probe.f90
+++ b/POTATO/SRC/potato_profile_serializer_probe.f90
@@ -1,0 +1,49 @@
+program potato_profile_serializer_probe
+    use field_eq_mod, only: psi_axis, psi_sep
+    use phielec_of_psi_mod, only: npolyphi, polydens, polyphi, polytemp
+    implicit none
+
+    double precision, parameter :: e_charge = 4.8032d-10
+    double precision, parameter :: ev = 1.6022d-12
+    character(len=512) :: argument, profile_path
+    double precision :: charge, ddens, dphi_dpsi, dtemp, energy_ev
+    double precision :: density, phi_elec, psi, s_pol, temperature
+    integer :: index, input_unit
+
+    call get_command_argument(1, profile_path)
+    call get_command_argument(2, argument)
+    read(argument, *) psi_axis
+    call get_command_argument(3, argument)
+    read(argument, *) psi_sep
+    call get_command_argument(4, argument)
+    read(argument, *) energy_ev
+    call get_command_argument(5, argument)
+    read(argument, *) charge
+
+    open(newunit=input_unit, file=trim(profile_path), status="old", action="read")
+    read(input_unit, *)
+    read(input_unit, *)
+    read(input_unit, *) polydens
+    read(input_unit, *) polytemp
+    read(input_unit, *) polytemp
+    read(input_unit, *) polyphi
+    close(input_unit)
+
+    ! Match the production ingestion in SRC/tt.f90 for unit scaling.
+    polytemp = polytemp/energy_ev
+    polyphi = polyphi*charge*e_charge/(energy_ev*ev)
+
+    write(*, '(A,2ES25.16)') "POTATO_PROFILE_FLUX ", psi_axis, psi_sep
+    write(*, '(A,10ES25.16)') "POTATO_PROFILE_DENSITY_COEFFICIENTS ", polydens
+    write(*, '(A,10ES25.16)') "POTATO_PROFILE_TEMPERATURE_COEFFICIENTS ", polytemp
+    write(*, '(A,10ES25.16)') "POTATO_PROFILE_POTENTIAL_COEFFICIENTS ", polyphi
+
+    do index = 0, 8
+        s_pol = dble(index)/8.0d0
+        psi = psi_axis + s_pol*(psi_sep - psi_axis)
+        call phielec_of_psi(psi, phi_elec, dphi_dpsi)
+        call denstemp_of_psi(psi, density, temperature, ddens, dtemp)
+        write(*, '(A,I0,7ES25.16)') "POTATO_PROFILE_SAMPLE ", index, s_pol, psi, &
+            density, temperature, phi_elec, dphi_dpsi, ddens
+    end do
+end program potato_profile_serializer_probe

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,10 @@ target_link_libraries(probe_neort_eqdsk_coordinate.x neo_rt)
 add_executable(probe_neort_eqdsk_drift.x probe_neort_eqdsk_drift.f90)
 target_link_libraries(probe_neort_eqdsk_drift.x neo_rt)
 
+add_executable(probe_neort_perturbation_nfp.x
+    probe_neort_perturbation_nfp.f90)
+target_link_libraries(probe_neort_perturbation_nfp.x neo_rt)
+
 add_test(NAME test_timestep
     COMMAND test_timestep.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -100,6 +104,10 @@ add_test(NAME test_resonance_bracket
 )
 add_test(NAME test_perturbation_fourier_kernel
     COMMAND ${CMAKE_BINARY_DIR}/probe_neort_perturbation_fourier_kernel.x
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+add_test(NAME test_perturbation_nfp
+    COMMAND ${CMAKE_BINARY_DIR}/probe_neort_perturbation_nfp.x
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 set_tests_properties(test_chartmap_input PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(probe_neort_perturbation_fourier_kernel.x neo_rt)
 add_executable(probe_neort_eqdsk_coordinate.x probe_neort_eqdsk_coordinate.f90)
 target_link_libraries(probe_neort_eqdsk_coordinate.x neo_rt)
 
+add_executable(probe_neort_eqdsk_drift.x probe_neort_eqdsk_drift.f90)
+target_link_libraries(probe_neort_eqdsk_drift.x neo_rt)
+
 add_test(NAME test_timestep
     COMMAND test_timestep.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,12 @@ add_executable(probe_neort_perturbation_fourier_kernel.x
     probe_neort_perturbation_fourier_kernel.f90)
 target_link_libraries(probe_neort_perturbation_fourier_kernel.x neo_rt)
 
+# Trace-only executable used by the cross-code coordinate-contract audit.  It
+# does not alter NEO-RT physics or I/O behavior and is intentionally not a CTest
+# pass/fail gate: the project-side verifier interprets its native trace.
+add_executable(probe_neort_eqdsk_coordinate.x probe_neort_eqdsk_coordinate.f90)
+target_link_libraries(probe_neort_eqdsk_coordinate.x neo_rt)
+
 add_test(NAME test_timestep
     COMMAND test_timestep.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/probe_neort_eqdsk_coordinate.f90
+++ b/test/probe_neort_eqdsk_coordinate.f90
@@ -1,0 +1,78 @@
+program probe_neort_eqdsk_coordinate
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use do_magfie_mod, only: inp_swi, bfac, read_boozer_file, set_s, &
+        init_magfie_at_s, do_magfie, q, iota, psi_pr, R0, a
+    use geoflux_coordinates, only: geoflux_to_cyl
+    use field_sub, only: field_eq
+
+    implicit none
+
+    integer, parameter :: nsample = 8
+    character(len=1024) :: eqdsk_file
+    real(dp), parameter :: sample_s(nsample) = &
+        [0.10_dp, 0.10_dp, 0.35_dp, 0.35_dp, 0.65_dp, 0.65_dp, 0.90_dp, 0.90_dp]
+    real(dp), parameter :: sample_phi(nsample) = &
+        [0.00_dp, 0.71_dp, 1.43_dp, 2.14_dp, 2.86_dp, 3.57_dp, 4.29_dp, 5.00_dp]
+    real(dp), parameter :: sample_theta(nsample) = &
+        [0.00_dp, 0.79_dp, 1.57_dp, 2.36_dp, 3.14_dp, 3.93_dp, 4.71_dp, 5.50_dp]
+
+    real(dp) :: x(3), xgeo(3), xcyl_cm(3), jac_cm(3, 3)
+    real(dp) :: bmod, sqrtg, bder(3), hcov(3), hcon(3), hcurl(3)
+    real(dp) :: b_native_g(3), b_from_hcon_g(3)
+    real(dp) :: derivs(12), det_rz_cm2, sqrtg_oriented_cm3
+    real(dp) :: phi, cphi, sphi
+    integer :: k, status
+
+    call get_command_argument(1, eqdsk_file, status=status)
+    if (status /= 0 .or. len_trim(eqdsk_file) == 0) then
+        error stop 'usage: probe_neort_eqdsk_coordinate.x EQDSK_FILE'
+    end if
+
+    inp_swi = 11
+    bfac = 1.0_dp
+    call read_boozer_file(trim(eqdsk_file))
+
+    write(*, '(a,1x,3(es24.16e3,1x))') 'NEORT_EQDSK_META', R0, a, bfac
+    do k = 1, nsample
+        x = [sample_s(k), sample_phi(k), sample_theta(k)]
+        xgeo = [x(1), x(3), x(2)]
+        call geoflux_to_cyl(xgeo, xcyl_cm, jac_cm)
+
+        call set_s(x(1))
+        call init_magfie_at_s()
+        call do_magfie(x, bmod, sqrtg, bder, hcov, hcon, hcurl)
+
+        call evaluate_field(xcyl_cm(1), xcyl_cm(2), xcyl_cm(3), b_native_g, derivs)
+
+        phi = xcyl_cm(2)
+        cphi = cos(phi)
+        sphi = sin(phi)
+        b_native_g = [b_native_g(1)*cphi - b_native_g(2)*sphi, &
+            b_native_g(1)*sphi + b_native_g(2)*cphi, b_native_g(3)]
+        b_from_hcon_g = bmod*( &
+            hcon(1)*[jac_cm(1, 1)*cphi, jac_cm(1, 1)*sphi, jac_cm(3, 1)] &
+            + hcon(2)*[-xcyl_cm(1)*sphi, xcyl_cm(1)*cphi, 0.0_dp] &
+            + hcon(3)*[jac_cm(1, 2)*cphi, jac_cm(1, 2)*sphi, jac_cm(3, 2)])
+
+        det_rz_cm2 = jac_cm(1, 1)*jac_cm(3, 2) - jac_cm(1, 2)*jac_cm(3, 1)
+        sqrtg_oriented_cm3 = xcyl_cm(1)*det_rz_cm2
+
+        write(*, '(a,1x,i0,1x,*(es24.16e3,1x))') 'NEORT_EQDSK_SAMPLE', k, &
+            x, xcyl_cm, b_native_g, b_from_hcon_g, bmod, sqrtg, &
+            sqrtg_oriented_cm3, q, iota, psi_pr, hcov, hcon
+    end do
+
+contains
+
+    subroutine evaluate_field(r, phi_in, z, b_cyl, field_derivs)
+        real(dp), intent(in) :: r, phi_in, z
+        real(dp), intent(out) :: b_cyl(3), field_derivs(12)
+
+        call field_eq(r, phi_in, z, b_cyl(1), b_cyl(2), b_cyl(3), &
+            field_derivs(1), field_derivs(2), field_derivs(3), &
+            field_derivs(4), field_derivs(5), field_derivs(6), &
+            field_derivs(7), field_derivs(8), field_derivs(9))
+        field_derivs(10:) = 0.0_dp
+    end subroutine evaluate_field
+
+end program probe_neort_eqdsk_coordinate

--- a/test/probe_neort_eqdsk_drift.f90
+++ b/test/probe_neort_eqdsk_drift.f90
@@ -1,0 +1,70 @@
+program probe_neort_eqdsk_drift
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use do_magfie_mod, only: inp_swi, bfac, read_boozer_file, set_s, &
+        init_magfie_at_s, do_magfie, q
+    use neort_orbit, only: timestep
+    use neort_profiles, only: Om_tE
+    use util, only: mi, qi
+
+    implicit none
+
+    integer, parameter :: nsample = 8
+    character(len=1024) :: eqdsk_file
+    real(dp), parameter :: sample_s(nsample) = &
+        [0.10_dp, 0.10_dp, 0.35_dp, 0.35_dp, 0.65_dp, 0.65_dp, 0.90_dp, 0.90_dp]
+    real(dp), parameter :: sample_phi(nsample) = &
+        [0.00_dp, 0.71_dp, 1.43_dp, 2.14_dp, 2.86_dp, 3.57_dp, 4.29_dp, 5.00_dp]
+    real(dp), parameter :: sample_theta(nsample) = &
+        [0.00_dp, 0.79_dp, 1.57_dp, 2.36_dp, 3.14_dp, 3.93_dp, 4.71_dp, 5.50_dp]
+    real(dp), parameter :: pitch_b = 0.30_dp
+    real(dp), parameter :: v_probe = 1.0_dp
+
+    real(dp) :: x(3), y(7), ydot_plus(7), ydot_minus(7), ydot_eplus(7), ydot_eminus(7)
+    real(dp) :: bmod, sqrtg, bder(3), hcov(3), hcon(3), hcurl(3)
+    real(dp) :: eta, mi_saved, qi_saved, omte_saved
+    integer :: k, status
+
+    call get_command_argument(1, eqdsk_file, status=status)
+    if (status /= 0 .or. len_trim(eqdsk_file) == 0) then
+        error stop 'usage: probe_neort_eqdsk_drift.x EQDSK_FILE'
+    end if
+
+    inp_swi = 11
+    bfac = 1.0_dp
+    call read_boozer_file(trim(eqdsk_file))
+
+    mi_saved = mi
+    qi_saved = qi
+    omte_saved = Om_tE
+    mi = 1.0_dp
+    do k = 1, nsample
+        x = [sample_s(k), sample_phi(k), sample_theta(k)]
+        call set_s(x(1))
+        call init_magfie_at_s()
+        call do_magfie(x, bmod, sqrtg, bder, hcov, hcon, hcurl)
+
+        eta = pitch_b/bmod
+        y = 0.0_dp
+        y(1) = x(3)
+        y(2) = v_probe*sqrt(1.0_dp - pitch_b)
+
+        qi = 1.0_dp
+        Om_tE = 0.0_dp
+        call timestep(v_probe, eta, size(y), 0.0_dp, y, ydot_plus)
+        qi = -1.0_dp
+        call timestep(v_probe, eta, size(y), 0.0_dp, y, ydot_minus)
+        qi = 1.0_dp
+        Om_tE = 1.0e9_dp
+        call timestep(v_probe, eta, size(y), 0.0_dp, y, ydot_eplus)
+        Om_tE = -1.0e9_dp
+        call timestep(v_probe, eta, size(y), 0.0_dp, y, ydot_eminus)
+
+        write(*, '(a,1x,i0,1x,*(es24.16e3,1x))') 'NEORT_DRIFT_SAMPLE', k, &
+            x, bmod, sqrtg, eta, q, bder, hcov, hcon, hcurl, &
+            ydot_plus(3), ydot_minus(3), ydot_eplus(3), ydot_eminus(3)
+    end do
+    mi = mi_saved
+    qi = qi_saved
+    Om_tE = omte_saved
+
+end program probe_neort_eqdsk_drift

--- a/test/probe_neort_perturbation_nfp.f90
+++ b/test/probe_neort_perturbation_nfp.f90
@@ -1,0 +1,89 @@
+program probe_neort_perturbation_nfp
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use do_magfie_mod, only: bfac, set_s
+    use do_magfie_pert_mod, only: do_magfie_pert, do_magfie_pert_amp, &
+        init_magfie_pert_at_s, inp_swi_pert, mph, read_boozer_pert_file
+
+    implicit none
+
+    character(len=*), parameter :: fixture = 'manufactured_perturbation_nfp.bc'
+    integer, parameter :: field_periods = 3, reduced_n = 2
+    real(dp), parameter :: theta = 0.6_dp, phi = -0.4_dp
+    real(dp), parameter :: cosine_amplitude_t = 2.0e-4_dp
+    real(dp), parameter :: sine_amplitude_t = 0.7e-4_dp
+    real(dp), parameter :: tolerance_g = 1.0e-12_dp
+    complex(dp) :: amplitude_g
+    real(dp) :: field_g, period_field_g, expected_g, wrong_reduced_g, x(3)
+
+    call write_fixture(fixture)
+    inp_swi_pert = 9
+    bfac = 1.0_dp
+    call set_s(0.5_dp)
+    call read_boozer_pert_file(fixture)
+    call init_magfie_pert_at_s()
+    x = [0.5_dp, phi, theta]
+    call do_magfie_pert_amp(x, amplitude_g)
+    call do_magfie_pert(x, field_g)
+    x(2) = phi + 2.0_dp*acos(-1.0_dp)/real(field_periods, dp)
+    call do_magfie_pert(x, period_field_g)
+    expected_g = expected_value(theta + field_periods*reduced_n*phi)
+    wrong_reduced_g = expected_value(theta + reduced_n*phi)
+    write (*, '(*(g0,1x))') 'NEORT_PERT_NFP', 'nfp', field_periods, &
+        'reduced_n', reduced_n, 'physical_n', mph, 'field_g', field_g, &
+        'period_field_g', period_field_g, 'expected_g', expected_g, &
+        'wrong_reduced_g', wrong_reduced_g, 'amplitude_real_g', real(amplitude_g), &
+        'amplitude_imag_g', aimag(amplitude_g)
+    if (abs(field_g - expected_g) > tolerance_g) error stop 'wrong physical n'
+    if (abs(period_field_g - field_g) > tolerance_g) error stop 'wrong NFP period'
+
+contains
+
+    real(dp) function expected_value(phase)
+        real(dp), intent(in) :: phase
+
+        expected_value = 1.0e4_dp*(cosine_amplitude_t*cos(phase) &
+            + sine_amplitude_t*sin(phase))
+    end function expected_value
+
+    subroutine write_fixture(path)
+        character(len=*), intent(in) :: path
+
+        integer :: unit, surface
+        real(dp), parameter :: surfaces(3) = [0.2_dp, 0.5_dp, 0.8_dp]
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(a)') 'CC manufactured NFP perturbation kernel'
+        write (unit, '(a)') 'CC physical n equals nper times stored n'
+        write (unit, '(a)') 'CC kernel m*theta+n*phi_CCW'
+        write (unit, '(a)') 'CC complex coefficient bmnc-i*bmns'
+        write (unit, '(a)') 'm0b n0b nsurf nper flux a R'
+        write (unit, '(*(g0,1x))') 2, 0, 3, field_periods, 1.0_dp, 1.0_dp, 1.0_dp
+        do surface = 1, size(surfaces)
+            call write_surface(unit, surfaces(surface))
+        end do
+        close (unit)
+    end subroutine write_fixture
+
+    subroutine write_surface(unit, radial_coordinate)
+        integer, intent(in) :: unit
+        real(dp), intent(in) :: radial_coordinate
+
+        write (unit, '(a)') 's iota Jpol Itor pprime sqrtg'
+        write (unit, '(a)') 'units A A Pa m3'
+        write (unit, '(*(es24.16e3,1x))') radial_coordinate, 1.0_dp, &
+            0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp
+        write (unit, '(a)') 'm n rmnc rmns zmnc zmns vmnc vmns bmnc bmns'
+        call write_mode(unit, -1, 0.0_dp, 0.0_dp)
+        call write_mode(unit, 0, 0.0_dp, 0.0_dp)
+        call write_mode(unit, 1, cosine_amplitude_t, sine_amplitude_t)
+    end subroutine write_surface
+
+    subroutine write_mode(unit, poloidal_mode, bmnc, bmns)
+        integer, intent(in) :: unit, poloidal_mode
+        real(dp), intent(in) :: bmnc, bmns
+
+        write (unit, '(*(g0,1x))') poloidal_mode, reduced_n, 0.0_dp, 0.0_dp, &
+            0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp, bmnc, bmns
+    end subroutine write_mode
+
+end program probe_neort_perturbation_nfp


### PR DESCRIPTION
## Summary

Adds behavioral probes for native EQDSK coordinates and drift, POTATO Cartesian field/drift/profile/perturbation serializers, the perturbation Hamiltonian, and packed NFP modes.

Production fixes formerly hidden in this branch were extracted to #106 and #107. This PR now contains only probes/oracles plus the required libneo flux-unit pin.

## Validation

- full cumulative `fo` pipeline passes
- probes use analytic or independently integrated physical/coordinate oracles

Stack: #99 -> this PR.