### PR TITLE
Keep resonance searches inside the spline pitch range

### DIFF
--- a/src/driftorbit.f90
+++ b/src/driftorbit.f90
@@ -39,7 +39,13 @@ module driftorbit
 
     real(dp), parameter :: epst_spl = 1.0e-6_dp, epsp_spl = 1.0e-6_dp   ! dist to tpb for spline
     real(dp), parameter :: epsst_spl = 1.0e-3_dp, epssp_spl = 1.0e-3_dp ! dist to deep for spline
-    real(dp), parameter :: epst = 1.0e-8_dp, epsp = 1.0e-8_dp ! smallest eta distance to tp bound
+    ! Keep resonance searches strictly on the spline side of the
+    ! trapped-passing boundary. Trapped roots need a larger validated margin
+    ! to bound explicit bounce integration at the separatrix; passing roots
+    ! only need a representable guard above the spline boundary.
+    real(dp), parameter :: passing_bracket_guard = 128.0_dp*epsilon(1.0_dp)
+    real(dp), parameter :: epst = 1.0e-5_dp
+    real(dp), parameter :: epsp = epsp_spl + passing_bracket_guard
 
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,10 @@ add_test(NAME test_resonance_bracket
     COMMAND ${CMAKE_BINARY_DIR}/test_resonance_bracket.x
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/base
 )
+add_test(NAME test_resonance_spline_bounds
+    COMMAND ${CMAKE_BINARY_DIR}/test_resonance_spline_bounds.x
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/base
+)
 add_test(NAME test_perturbation_fourier_kernel
     COMMAND ${CMAKE_BINARY_DIR}/probe_neort_perturbation_fourier_kernel.x
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/test/test_resonance_spline_bounds.f90
+++ b/test/test_resonance_spline_bounds.f90
@@ -1,0 +1,28 @@
+program test_resonance_spline_bounds
+    use iso_fortran_env, only: dp => real64
+    use logger, only: set_log_level
+    use neort_lib, only: neort_init, neort_prepare_splines, neort_setup_at_s
+    use neort, only: set_to_passing_region, set_to_trapped_region
+    use driftorbit, only: etatp, etadt, epsp_spl, epsst_spl, epst_spl
+
+    implicit none
+
+    real(dp) :: eta_min, eta_max
+
+    call set_log_level(-1)
+    call neort_init("driftorbit.in", "in_file")
+    call neort_prepare_splines("plasma.in", "profile.in")
+    call neort_setup_at_s(0.5_dp)
+
+    call set_to_trapped_region(eta_min, eta_max)
+    if (eta_min < (1.0_dp + epst_spl) * etatp) then
+        error stop "trapped lower bound reaches the spline separatrix"
+    end if
+
+    call set_to_passing_region(eta_min, eta_max)
+    if (eta_max > (1.0_dp - epsp_spl) * etatp) then
+        error stop "passing upper bound reaches the spline separatrix"
+    end if
+
+    print *, "test_resonance_spline_bounds PASSED"
+end program test_resonance_spline_bounds


### PR DESCRIPTION
## Scope

Keeps resonance searches strictly inside the validated spline pitch range.

The trapped-side bracket now uses the validated trapped spline margin, while the passing-side bracket uses the passing spline margin plus a machine-precision guard. This prevents roots from being handed to explicit bounce integration exactly at or beyond the trapped-passing spline boundary.

## Validation

Adds and registers `test_resonance_spline_bounds`. The test initializes the base case, obtains both trapped and passing regions, and verifies that their bounds remain on the spline-safe side of the separatrix.
