### PR TITLE
Make zero-rotation resonance roots converge deterministically

### DIFF
--- a/src/resonance.f90
+++ b/src/resonance.f90
@@ -51,18 +51,24 @@ contains
         call driftorbit_coarse(v, eta_min, eta_max, roots, driftorbit_nroot)
     end function driftorbit_nroot
 
-    function driftorbit_root(v, tol, eta_min, eta_max)
+    function driftorbit_root(v, tol, eta_min, eta_max, converged)
         use logger, only: warning
 
+        ! Bisection can exhaust the representable eta values before a
+        ! zero-frequency lane reaches an absolute residual of exactly zero.
+        ! Keep the fallback well below the transport quadrature accuracy while
+        ! acknowledging the conditioning of the separatrix frequency splines.
+        real(dp), parameter :: relative_tolerance_floor = 1.0e-9_dp
         real(dp) :: driftorbit_root(2)
         real(dp), intent(in) :: v, tol, eta_min, eta_max
+        logical, intent(out), optional :: converged
         real(dp) :: res, res_old, eta_old
         real(dp) :: Omph, dOmphdv, dOmphdeta
         real(dp) :: Omth, dOmthdv, dOmthdeta
         integer :: maxit, k, state
         real(dp) :: etamin2, etamax2
         logical :: slope_pos
-        real(dp) :: resmin, resmax
+        real(dp) :: resmin, resmax, tol_eff
         real(dp) :: eta
 
         character(len=1024) :: msg
@@ -73,6 +79,7 @@ contains
         state = -2
         eta_old = 0.0_dp
         res = 0.0_dp
+        if (present(converged)) converged = .false.
 
         etamin2 = eta_min
         etamax2 = eta_max
@@ -87,6 +94,8 @@ contains
         call Om_ph(v, eta, Omph, dOmphdv, dOmphdeta)
         call Om_th(v, eta, Omth, dOmthdv, dOmthdeta)
         resmax = mph*Omph + mth*Omth
+        tol_eff = max(abs(tol), relative_tolerance_floor * &
+            max(1.0_dp, abs(resmin), abs(resmax)))
         if (resmax - resmin > 0) then
             slope_pos = .true.
         else
@@ -95,8 +104,8 @@ contains
 
         if (driftorbit_nroot(v, etamin2, etamax2) == 0) then
             write (msg, "(a,g0,a,g0,a,g0)") &
-                  "driftorbit_root couldn't bracket 0 for v/vth = ", v / vth, LF // &
-                  TAB // "etamin = ", etamin2, ", etamax = ", etamax2
+                "driftorbit_root couldn't bracket 0 for v/vth = ", v / vth, LF // &
+                TAB // "etamin = ", etamin2, ", etamax = ", etamax2
             call warning(msg)
             ! Defined sentinel: eta is a non-negative pitch parameter, so a
             ! negative root position flags "no resonance in this bracket".
@@ -115,9 +124,10 @@ contains
 
             driftorbit_root(1) = eta
 
-            if (abs(res) < tol) then
+            if (abs(res) <= tol_eff) then
                 state = 1
                 driftorbit_root(2) = mph * dOmphdeta + mth * dOmthdeta
+                if (present(converged)) converged = .true.
                 exit
             elseif ((slope_pos .and. res > 0) .or. &
                     ((.not. slope_pos) .and. res < 0)) then
@@ -131,14 +141,15 @@ contains
             end if
         end do
         if (state < 0) then
-            driftorbit_root(2) = mph * dOmphdeta + mth * dOmthdeta
-            write (msg, "(a,i0,a,g0,a,i0,a,g0,a,g0,a,g0,a,g0,a,g0,a,g0,a,g0,a,g0,a,g0,a,g0)") &
-                  "driftorbit_root: did not converge within ", maxit, " iterations" // LF // &
-                  TAB // "v/vth = ", v / vth, ", mth = ", mth, ", sign_vpar = ", sign_vpar, LF // &
-                  TAB // "etamin = ", eta_min, ", etamax = ", eta_max, ", eta = ", eta, LF // &
-                  TAB // "resmin = ", resmin, ", resmax = ", resmax, ", res = ", res, LF // &
-                  TAB // "resold = ", res_old, ", res = ", res, LF // &
-                  TAB // "tol = ", tol
+            driftorbit_root(1) = -2.0_dp
+            driftorbit_root(2) = 0.0_dp
+            write (msg, "(*(g0))") &
+                "driftorbit_root: did not converge within ", maxit, " iterations" // LF // &
+                TAB // "v/vth = ", v / vth, ", mth = ", mth, ", sign_vpar = ", sign_vpar, LF // &
+                TAB // "etamin = ", eta_min, ", etamax = ", eta_max, ", eta = ", eta, LF // &
+                TAB // "resmin = ", resmin, ", resmax = ", resmax, ", res = ", res, LF // &
+                TAB // "resold = ", res_old, ", res = ", res, LF // &
+                TAB // "requested tol = ", tol, ", effective tol = ", tol_eff
             call warning(msg)
         end if
     end function driftorbit_root

--- a/src/resonance.f90
+++ b/src/resonance.f90
@@ -51,7 +51,7 @@ contains
         call driftorbit_coarse(v, eta_min, eta_max, roots, driftorbit_nroot)
     end function driftorbit_nroot
 
-    function driftorbit_root(v, tol, eta_min, eta_max, converged)
+    function driftorbit_root(v, tol, eta_min, eta_max)
         use logger, only: warning
 
         ! Bisection can exhaust the representable eta values before a
@@ -61,7 +61,6 @@ contains
         real(dp), parameter :: relative_tolerance_floor = 1.0e-9_dp
         real(dp) :: driftorbit_root(2)
         real(dp), intent(in) :: v, tol, eta_min, eta_max
-        logical, intent(out), optional :: converged
         real(dp) :: res, res_old, eta_old
         real(dp) :: Omph, dOmphdv, dOmphdeta
         real(dp) :: Omth, dOmthdv, dOmthdeta
@@ -79,7 +78,6 @@ contains
         state = -2
         eta_old = 0.0_dp
         res = 0.0_dp
-        if (present(converged)) converged = .false.
 
         etamin2 = eta_min
         etamax2 = eta_max
@@ -127,7 +125,6 @@ contains
             if (abs(res) <= tol_eff) then
                 state = 1
                 driftorbit_root(2) = mph * dOmphdeta + mth * dOmthdeta
-                if (present(converged)) converged = .true.
                 exit
             elseif ((slope_pos .and. res > 0) .or. &
                     ((.not. slope_pos) .and. res < 0)) then

--- a/test/test_resonance_bracket.f90
+++ b/test/test_resonance_bracket.f90
@@ -11,12 +11,21 @@ program test_resonance_bracket
     use iso_fortran_env, only: dp => real64
     use logger, only: set_log_level
     use neort_lib, only: neort_init, neort_prepare_splines, neort_setup_at_s
-    use driftorbit, only: mth, vth, etatp, etadt
-    use neort_resonance, only: driftorbit_root
+    use driftorbit, only: mth, mph, nlev, sign_vpar, vth, etatp, etadt, &
+        epst
+    use neort_freq, only: Om_ph, Om_th
+    use neort_profiles, only: Om_tE
+    use neort_resonance, only: driftorbit_coarse, driftorbit_root
 
     implicit none
 
     real(dp) :: eta_res(2), eta_mid, v
+    real(dp) :: Omph, dOmphdv, dOmphdeta
+    real(dp) :: Omth, dOmthdv, dOmthdeta
+    real(dp) :: residual, residual_scale
+    real(dp) :: roots(nlev, 3)
+    integer :: nroots, trial_mth, trial_v
+    logical :: converged, found_root
 
     call set_log_level(-1)  ! silence the expected bracket-failure warning
 
@@ -37,6 +46,45 @@ program test_resonance_bracket
     end if
     if (eta_res(2) /= 0.0_dp) then
         error stop "bracket failure must return a defined eta_res(2)"
+    end if
+
+    ! A zero electric-rotation lane previously passed tol=0 to the bisection
+    ! solver. The strict abs(res)<tol predicate could then never succeed, and
+    ! the last iterate was returned as if it were a usable resonance. Locate
+    ! an actual magnetic-drift resonance, solve it with the production zero
+    ! tolerance, and verify the independently recomputed native residual.
+    Om_tE = 0.0_dp
+    sign_vpar = 1
+    found_root = .false.
+    do trial_v = 1, 24
+        v = (0.25_dp * trial_v) * vth
+        do trial_mth = -12, 12
+            if (trial_mth == 0) cycle
+            mth = trial_mth
+            call driftorbit_coarse(v, etatp * (1.0_dp + epst), &
+                etadt * (1.0_dp - epst), roots, nroots)
+            if (nroots > 0) then
+                found_root = .true.
+                exit
+            end if
+        end do
+        if (found_root) exit
+    end do
+    if (.not. found_root) error stop "test fixture has no zero-rotation resonance"
+
+    eta_res = driftorbit_root(v, 0.0_dp, roots(1, 1), roots(1, 2), converged)
+    if (.not. converged) error stop "zero-rotation resonance must converge"
+    if (eta_res(1) < roots(1, 1) .or. eta_res(1) > roots(1, 2)) then
+        error stop "zero-rotation resonance escaped its bracket"
+    end if
+
+    call Om_ph(v, eta_res(1), Omph, dOmphdv, dOmphdeta)
+    call Om_th(v, eta_res(1), Omth, dOmthdv, dOmthdeta)
+    residual = mph * Omph + mth * Omth
+    residual_scale = max(1.0_dp, abs(mph * Omph), abs(mth * Omth))
+    if (abs(residual) > 1.0e-9_dp * residual_scale) then
+        write(*,*) "zero-rotation residual and scale:", residual, residual_scale
+        error stop "zero-rotation resonance residual is not converged"
     end if
 
     print *, "test_resonance_bracket PASSED"

--- a/test/test_resonance_bracket.f90
+++ b/test/test_resonance_bracket.f90
@@ -25,7 +25,7 @@ program test_resonance_bracket
     real(dp) :: residual, residual_scale
     real(dp) :: roots(nlev, 3)
     integer :: nroots, trial_mth, trial_v
-    logical :: converged, found_root
+    logical :: found_root
 
     call set_log_level(-1)  ! silence the expected bracket-failure warning
 
@@ -72,8 +72,7 @@ program test_resonance_bracket
     end do
     if (.not. found_root) error stop "test fixture has no zero-rotation resonance"
 
-    eta_res = driftorbit_root(v, 0.0_dp, roots(1, 1), roots(1, 2), converged)
-    if (.not. converged) error stop "zero-rotation resonance must converge"
+    eta_res = driftorbit_root(v, 0.0_dp, roots(1, 1), roots(1, 2))
     if (eta_res(1) < roots(1, 1) .or. eta_res(1) > roots(1, 2)) then
         error stop "zero-rotation resonance escaped its bracket"
     end if


### PR DESCRIPTION
## Summary

Make zero-rotation resonance roots converge with a scale-aware numerical floor and return a defined failure sentinel when bisection cannot converge.

The public `driftorbit_root` signature remains unchanged. An optional convergence-status output was audited and removed because no production caller or other PR consumes it.

## Validation

- Rebased independently onto current `main`; #105 is no longer a parent.
- The compiled resonance regression locates a magnetic-drift root at zero electric rotation and independently checks its native residual.
- Focused Release validation passes.

No direct-EQDSK, converter, or full-orbit code is included.