### PR TITLE
Make POTATO perturbation torque representation-invariant

### DIFF
--- a/POTATO/SRC/resonant_int.f90
+++ b/POTATO/SRC/resonant_int.f90
@@ -319,7 +319,7 @@ subroutine integrate_class_resonances
             !
             ! multiply expression under summation over modes with toroidal mode number, with factor $-\pi^{3/2}/4$
             ! and with reference energy:
-            one_res=one_res*rm3*pi32_over4m*cE_ref
+            one_res=one_res*abs(rm3)*pi32_over4m*cE_ref
             !
             ! A near-tangent root (dresconddx -> 0) gives an infinite
             ! dpsiastdx/dresconddx; for a wall-crossing resonance absHn2=0, so the
@@ -491,6 +491,7 @@ subroutine resonant_torque
         ind_hist,xarr,amat_arr
     use potato_input_mod,  only : nbox, nenerg_input => nenerg, &
         thermen_max_input => thermen_max, &
+        enkin_min_over_temp, &
         adaptive_jperp, npoi_init, nlagr_sampling, &
         eps_sampling, itermax_sampling
     use logging_mod,       only : tee_message
@@ -549,8 +550,17 @@ subroutine resonant_torque
     !
     thermen_max=thermen_max*temp !maximum kinetic energy in units of reference energy
     !
-    ! Energy integration limits:
-    toten_min=phi_elec_min
+    ! Energy integration limits.  Preserve the legacy zero-cutoff grid, including
+    ! its skipped first midpoint.  An explicitly positive minimum instead starts
+    ! above the maximum potential so every sampled orbit has at least the
+    ! requested kinetic energy throughout the field domain.
+    if(enkin_min_over_temp.gt.0.d0) then
+        toten_min=phi_elec_max+enkin_min_over_temp*temp
+        ienerg_begin=1
+    else
+        toten_min=phi_elec_min
+        ienerg_begin=2
+    endif
     toten_max=thermen_max+phi_elec_max
     toten_range=toten_max-toten_min
     !
@@ -584,7 +594,6 @@ subroutine resonant_torque
     torquebox=0.d0
     !
     step_energ=toten_range/dble(nenerg) !integration step over total energy
-    ienerg_begin=2
     !step_energ=0.22521463755624047d0
     !
     omp_threads_env_len=0

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2627,7 +2627,11 @@
   double precision :: xsafe,xdiv,xlo,xhi,xm
   integer :: it
 !
-  if(abs(eval_delphi(xdiv)).le.delphi_max) return
+! xdiv is the boundary-type-declared divergent endpoint.  Do not evaluate it:
+! that defeats this guard by sending find_bounce into an unbounded separatrix
+! trace before the bisection has a chance to move inward.  If the endpoint is
+! actually regular, every interior midpoint stays below the bound and xlo
+! approaches xdiv to the existing interval tolerance.
   if(abs(eval_delphi(xsafe)).ge.delphi_max) return
 !
   xlo=xsafe


### PR DESCRIPTION
## Scope

Makes three existing POTATO torque paths representation- and input-consistent:

1. The torque prefactor uses the magnitude of the toroidal mode where the result is a mode-independent magnitude.
2. A positive `enkin_min_over_temp` starts the energy grid above the maximum electrostatic potential; the legacy zero-cutoff grid remains unchanged when the option is zero.
3. The resonance endpoint guard no longer evaluates the declared divergent endpoint before bisection, avoiding an unnecessary separatrix trace.

The signed mode itself is not removed from the resonance phase or mode selection.

## Validation

The diff contains no new standalone test file. It relies on the existing POTATO build, invariant, resonance, and golden-record tests. The three behavior changes should be reviewed as separate follow-up units if this PR is split further.

