### PR TITLE
Add fixed-energy POTATO contour scan

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -147,6 +147,14 @@ if(Python3_Interpreter_FOUND)
             ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
     )
     set_tests_properties(potato_invariant_handoff PROPERTIES TIMEOUT 150)
+    add_test(NAME potato_fixed_energy_contour
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/fixed_energy_contour/test_fixed_energy_contour.py
+            $<TARGET_FILE:potato_resonance_contour.x>
+            $<TARGET_FILE:potato.x>
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
+    )
+    set_tests_properties(potato_fixed_energy_contour PROPERTIES TIMEOUT 150)
     add_test(NAME potato_golden_displacement
         COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_displacement/test_potato_golden.py

--- a/POTATO/README.md
+++ b/POTATO/README.md
@@ -83,3 +83,32 @@ For a scan, rows retain the requested increasing-`R` order (HFS to LFS when
 the input bounds are ordered that way), matching POTATO's `R_c` convention.
 No `rho_pol`/`rho_tor` identification or outer/inner orbit selection is
 implied by the handoff.
+
+## Fixed-energy invariant contour scan
+
+`potato_resonance_contour.x` scans a rectangular `(rho_pol, J_perp)` grid at
+fixed kinetic energy. For a 5 keV deuteron scan, set `E_alpha = 5d3` and
+`contour_enkin = 1d0`; `contour_enkin` is normalized to `E_alpha`.
+
+```text
+contour_rho_min = 0.05d0
+contour_rho_max = 0.95d0
+contour_nrho = 21
+contour_jperp_min = 1d-6
+contour_jperp_max = 8d-5
+contour_njperp = 21
+contour_enkin = 1d0
+contour_sigma = 1
+```
+
+Run it from a directory containing the normal POTATO equilibrium, wall, profile,
+and `potato.in` inputs:
+
+```bash
+fo exec --cwd /path/to/run potato_resonance_contour.x
+```
+
+The resulting `potato_resonance_contour.dat` retains every requested grid point
+and contains `H0`, `J_perp`, `psi_star`, the guiding-centre start, `taub`,
+`delphi`, physical angular frequencies, and `ierr`. Keep failed rows for the
+rectangular grid and mask them using `ierr`; do not interpolate across them.

--- a/POTATO/SRC/potato_input_mod.f90
+++ b/POTATO/SRC/potato_input_mod.f90
@@ -9,12 +9,12 @@ module potato_input_mod
     integer :: itest_type = 3
 
     ! Species parameters
-    double precision :: E_alpha = 5d3       ! Reference energy [eV]
-    double precision :: A_alpha = 2d0       ! Mass number
-    double precision :: Z_alpha = 1d0       ! Charge number
+    double precision :: E_alpha = 5d3 ! Reference energy [eV]
+    double precision :: A_alpha = 2d0 ! Mass number
+    double precision :: Z_alpha = 1d0 ! Charge number
 
     ! Flux surface
-    double precision :: rho_pol = 0.6d0     ! Poloidal radius
+    double precision :: rho_pol = 0.6d0 ! Poloidal radius
     double precision :: rho_pol_max = 0.9d0 ! Max rho_pol for Poincare cut
 
     ! Scaling factors
@@ -22,8 +22,8 @@ module potato_input_mod
     double precision :: scalfac_efield = 1d0
 
     ! Orbit integration
-    double precision :: Rmax_orbit = 200d0  ! Max R for orbit integration
-    integer :: ntimstep = 30                ! Number of time steps
+    double precision :: Rmax_orbit = 200d0 ! Max R for orbit integration
+    integer :: ntimstep = 30 ! Number of time steps
 
     ! Poincare cut
     integer :: npoicut = 10000
@@ -35,7 +35,7 @@ module potato_input_mod
 
     ! Energy grid
     integer :: nenerg = 60
-    double precision :: thermen_max = 6d0   ! Max kinetic energy [T units]
+    double precision :: thermen_max = 6d0 ! Max kinetic energy [T units]
     ! Lowest slice starts at this kinetic energy [T units] when set.
     double precision :: enkin_min_over_temp = 0d0
 
@@ -56,16 +56,26 @@ module potato_input_mod
 
     ! Single-orbit trace (itest_type=4): start point on the poloidal plane and
     ! pitch cosine of one guiding-center orbit, traced over one bounce period.
-    double precision :: orbit_Rstart = 210d0   ! start major radius [cm]
-    double precision :: orbit_Zstart = 0d0     ! start height [cm]
-    double precision :: orbit_lambda = 0.4d0   ! pitch cosine v_par/v at start
+    double precision :: orbit_Rstart = 210d0 ! start major radius [cm]
+    double precision :: orbit_Zstart = 0d0 ! start height [cm]
+    double precision :: orbit_lambda = 0.4d0 ! pitch cosine v_par/v at start
 
     ! Frequency radial scan (itest_type=5): trace one bounce at each of freq_n
     ! midplane start radii from freq_Rmin to freq_Rmax (pitch orbit_lambda),
     ! and write rho_pol, omega_b, omega_phi to freq_scan.dat.
-    double precision :: freq_Rmin = 178d0      ! inner start radius [cm]
-    double precision :: freq_Rmax = 221d0      ! outer start radius [cm], into SOL
-    integer          :: freq_n = 40            ! number of surfaces
+    double precision :: freq_Rmin = 178d0 ! inner start radius [cm]
+    double precision :: freq_Rmax = 221d0 ! outer start radius [cm], into SOL
+    integer          :: freq_n = 40 ! number of surfaces
+
+    ! Fixed-energy invariant contour scan (potato_resonance_contour.x).
+    double precision :: contour_rho_min = 0.05d0
+    double precision :: contour_rho_max = 0.95d0
+    integer :: contour_nrho = 21
+    double precision :: contour_jperp_min = 1d-6
+    double precision :: contour_jperp_max = 8d-5
+    integer :: contour_njperp = 21
+    double precision :: contour_enkin = 1d0
+    integer :: contour_sigma = 1
 
     ! Resonance probe diagnostic
     double precision :: probe_rho_pol = 0.9d0
@@ -103,6 +113,9 @@ module potato_input_mod
         profile_file, edge_extension, &
         orbit_Rstart, orbit_Zstart, orbit_lambda, &
         freq_Rmin, freq_Rmax, freq_n, &
+        contour_rho_min, contour_rho_max, contour_nrho, &
+        contour_jperp_min, contour_jperp_max, contour_njperp, &
+        contour_enkin, contour_sigma, &
         probe_rho_pol, probe_ux, probe_eta, probe_m, probe_n
 
 contains
@@ -183,6 +196,14 @@ contains
         write(iunit, '(A,ES12.5)') '  freq_Rmin        = ', freq_Rmin
         write(iunit, '(A,ES12.5)') '  freq_Rmax        = ', freq_Rmax
         write(iunit, '(A,I0)') '  freq_n           = ', freq_n
+        write(iunit, '(A,ES12.5)') '  contour_rho_min  = ', contour_rho_min
+        write(iunit, '(A,ES12.5)') '  contour_rho_max  = ', contour_rho_max
+        write(iunit, '(A,I0)') '  contour_nrho     = ', contour_nrho
+        write(iunit, '(A,ES12.5)') '  contour_jperp_min = ', contour_jperp_min
+        write(iunit, '(A,ES12.5)') '  contour_jperp_max = ', contour_jperp_max
+        write(iunit, '(A,I0)') '  contour_njperp   = ', contour_njperp
+        write(iunit, '(A,ES12.5)') '  contour_enkin    = ', contour_enkin
+        write(iunit, '(A,I0)') '  contour_sigma    = ', contour_sigma
         write(iunit, '(A,ES12.5)') '  probe_rho_pol    = ', probe_rho_pol
         write(iunit, '(A,ES12.5)') '  probe_ux         = ', probe_ux
         write(iunit, '(A,ES12.5)') '  probe_eta        = ', probe_eta

--- a/POTATO/SRC/potato_resonance_contour.f90
+++ b/POTATO/SRC/potato_resonance_contour.f90
@@ -7,7 +7,9 @@ program potato_resonance_contour
     use potato_input_mod, only : read_potato_input, E_alpha, A_alpha, Z_alpha, &
         rho_pol_max, scalfac_energy, scalfac_efield, &
         Rmax_orbit, ntimstep, npoicut, profile_file, &
-        edge_extension
+        edge_extension, contour_rho_min, contour_rho_max, contour_nrho, &
+        contour_jperp_min, contour_jperp_max, contour_njperp, &
+        contour_enkin, contour_sigma
     use field_eq_mod, only : allow_sol, psi_axis, psi_sep
     use field_sub, only : psif
     implicit none
@@ -16,61 +18,123 @@ program potato_resonance_contour
     double precision, parameter :: e_charge = 4.8032d-10
     double precision, parameter :: p_mass = 1.6726d-24
     double precision, parameter :: ev = 1.6022d-12
-    integer, parameter :: nrho = 70, neta = 90
-    double precision, parameter :: ux = 1.5d0
-
-    integer :: i, j, u, ierr
-    double precision :: rho, eta, psi, dens, temp, ddens, dtemp, phi_elec, dPhi_dpsi
-    double precision :: enkin, toten, perpinv, Rst, psiast, dpsiast_dRst
-    double precision :: taub, delphi, extraset(1), z(neqm), v0, bmod_ref
+    double precision :: v0
 
     external :: find_bounce, velo
 
     call read_potato_input("potato.in")
-    allow_sol = edge_extension
-    E_alpha = E_alpha/scalfac_energy
-    rmu = 1.d30
-    v0 = sqrt(2.d0*E_alpha*ev/(p_mass*A_alpha))
-    bmod_ref = 1.d0
-    ro0 = v0*p_mass*A_alpha*c/(e_charge*Z_alpha*bmod_ref)
-    cE_ref = E_alpha*ev
-    Phi_eff = c*E_alpha*ev/(e_charge*Z_alpha*v0)
-    dtau = Rmax_orbit/dble(ntimstep)
-    numbasef = 0
-    next = 0
-
-    call load_profiles
-    call find_poicut(rho_pol_max, npoicut)
-
-    open(newunit=u, file="potato_resonance_contour.dat", status="replace", action="write")
-    write(u, '(A)') &
-        "# rho_pol eta ux delphi taub ierr psiast Rst toten perpinv R_gc Z_gc"
-    do i = 1, nrho
-        rho = 0.05d0 + 0.93d0*dble(i - 1)/dble(nrho - 1)
-        psi = psi_axis + rho*rho*(psi_sep - psi_axis)
-        call denstemp_of_psi(psi, dens, temp, ddens, dtemp)
-        call phielec_of_psi(psi, phi_elec, dPhi_dpsi)
-        enkin = ux*ux*temp
-        toten = enkin + phi_elec
-        Rst = R_from_psi_lfs(psi)
-        do j = 1, neta
-            eta = 1.d-6 + (8.d-5 - 1.d-6)*dble(j - 1)/dble(neta - 1)
-            perpinv = eta*enkin
-            call starter_doublecount(toten, perpinv, 1.d0, Rst, psiast, dpsiast_dRst, z, ierr)
-            taub = 0.d0
-            delphi = 0.d0
-            if (ierr == 0) then
-                extraset = 0.d0
-                call find_bounce(next, velo, dtau, z, taub, delphi, extraset, ierr)
-            end if
-            write(u, '(12ES18.9)') rho, eta, ux, delphi, taub, dble(ierr), &
-                psiast, Rst, toten, perpinv, z(1), z(3)
-        end do
-        write(u, *)
-    end do
-    close(u)
+    call initialize_contour(v0)
+    call write_contour(v0)
 
 contains
+
+    subroutine initialize_contour(v0)
+        double precision, intent(out) :: v0
+        double precision :: bmod_ref
+
+        allow_sol = edge_extension
+        E_alpha = E_alpha/scalfac_energy
+        rmu = 1.d30
+        v0 = sqrt(2.d0*E_alpha*ev/(p_mass*A_alpha))
+        bmod_ref = 1.d0
+        ro0 = v0*p_mass*A_alpha*c/(e_charge*Z_alpha*bmod_ref)
+        cE_ref = E_alpha*ev
+        Phi_eff = c*E_alpha*ev/(e_charge*Z_alpha*v0)
+        dtau = Rmax_orbit/dble(ntimstep)
+        numbasef = 0
+        next = 0
+
+        call load_profiles
+        call find_poicut(rho_pol_max, npoicut)
+    end subroutine initialize_contour
+
+    subroutine write_contour(v0)
+        double precision, intent(in) :: v0
+        integer :: i, j, u
+        double precision :: rho, jperp
+
+        call validate_contour_input
+        open(newunit=u, file="potato_resonance_contour.dat", &
+            status="replace", action="write")
+        write(u, '(A)') "# id rho_pol R_gc Z_gc p xi sigma H0 J_perp " &
+            // "psi_star psi_axis psi_edge phi_elec v0_cm_s taub delphi " &
+            // "omega_b omega_phi ierr"
+        do i = 1, contour_nrho
+            rho = grid_value(contour_rho_min, contour_rho_max, contour_nrho, i)
+            do j = 1, contour_njperp
+                jperp = grid_value(contour_jperp_min, contour_jperp_max, &
+                    contour_njperp, j)
+                call write_contour_point(u, (i - 1)*contour_njperp + j, &
+                    rho, jperp, v0)
+            end do
+            write(u, *)
+        end do
+        close(u)
+    end subroutine write_contour
+
+    subroutine write_contour_point(u, id, rho, jperp, v0)
+        integer, intent(in) :: u, id
+        double precision, intent(in) :: rho, jperp, v0
+        integer :: ierr
+        double precision :: psi, phi_elec, dphi_dpsi, h0, rst, psi_star
+        double precision :: dpsi_star_dr, taub, delphi, omega_b, omega_phi
+        double precision :: z(neqm)
+
+        psi = psi_axis + rho*rho*(psi_sep - psi_axis)
+        call phielec_of_psi(psi, phi_elec, dphi_dpsi)
+        h0 = contour_enkin + phi_elec
+        rst = R_from_psi_lfs(psi)
+        z = 0d0
+        psi_star = 0d0
+        dpsi_star_dr = 0d0
+        call starter_doublecount(h0, jperp, dble(contour_sigma), rst, &
+            psi_star, dpsi_star_dr, z, ierr)
+        call trace_contour_point(z, taub, delphi, omega_b, omega_phi, v0, ierr)
+        write(u, '(I8,17ES18.9,I8)') id, rho, z(1), z(3), z(4), z(5), &
+            dble(contour_sigma), h0, jperp, psi_star, psi_axis, psi_sep, &
+            phi_elec, v0, taub, delphi, omega_b, omega_phi, ierr
+    end subroutine write_contour_point
+
+    subroutine trace_contour_point(z, taub, delphi, omega_b, omega_phi, v0, ierr)
+        double precision, intent(inout) :: z(neqm)
+        double precision, intent(out) :: taub, delphi, omega_b, omega_phi
+        double precision, intent(in) :: v0
+        integer, intent(inout) :: ierr
+        double precision :: extraset(1)
+
+        taub = 0d0
+        delphi = 0d0
+        omega_b = 0d0
+        omega_phi = 0d0
+        if (ierr /= 0) return
+        extraset = 0d0
+        call find_bounce(next, velo, dtau, z, taub, delphi, extraset, ierr)
+        if (ierr /= 0) return
+        if (taub <= 0d0) then
+            ierr = 1
+            return
+        endif
+        omega_b = 2d0*acos(-1d0)*v0/taub
+        omega_phi = delphi*v0/taub
+    end subroutine trace_contour_point
+
+    subroutine validate_contour_input
+        if (contour_nrho < 1) error stop "contour_nrho must be positive"
+        if (contour_njperp < 1) error stop "contour_njperp must be positive"
+        if (contour_enkin <= 0d0) error stop "contour_enkin must be positive"
+        if (abs(contour_sigma) /= 1) error stop "contour_sigma must be -1 or 1"
+    end subroutine validate_contour_input
+
+    double precision function grid_value(lower, upper, count, index)
+        double precision, intent(in) :: lower, upper
+        integer, intent(in) :: count, index
+
+        if (count == 1) then
+            grid_value = lower
+        else
+            grid_value = lower + (upper - lower)*dble(index - 1)/dble(count - 1)
+        endif
+    end function grid_value
 
     subroutine load_profiles
         integer :: iunit

--- a/POTATO/test/fixed_energy_contour/test_fixed_energy_contour.py
+++ b/POTATO/test/fixed_energy_contour/test_fixed_energy_contour.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import math
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+INPUT_NAMES = (
+    "circ.eqdsk",
+    "convexwall.dat",
+    "field_divB0.inp",
+    "profile_poly.in",
+)
+EXPECTED_COLUMNS = (
+    "id",
+    "rho_pol",
+    "R_gc",
+    "Z_gc",
+    "p",
+    "xi",
+    "sigma",
+    "H0",
+    "J_perp",
+    "psi_star",
+    "psi_axis",
+    "psi_edge",
+    "phi_elec",
+    "v0_cm_s",
+    "taub",
+    "delphi",
+    "omega_b",
+    "omega_phi",
+    "ierr",
+)
+
+
+def zero_electric_potential(path: Path) -> None:
+    lines = path.read_text().splitlines()
+    lines[-1] = " ".join(["0.0"] * 10)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def write_input(path: Path, extra: str) -> None:
+    path.write_text(
+        f"""&potato_nml
+  itest_type = 4
+  E_alpha = 5d3
+  A_alpha = 2d0
+  Z_alpha = 1d0
+  rho_pol_max = 0.65d0
+  Rmax_orbit = 250d0
+  ntimstep = 2000
+  npoicut = 1000
+  profile_file = 'profile_poly.in'
+{extra}
+/
+"""
+    )
+
+
+def read_contour(path: Path) -> tuple[list[str], list[dict[str, float]]]:
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    columns = lines[0].removeprefix("# ").split()
+    rows = [
+        dict(zip(columns, (float(value) for value in line.split())))
+        for line in lines[1:]
+    ]
+    return columns, rows
+
+
+def parse_single_orbit(text: str) -> tuple[float, float, int]:
+    match = re.search(
+        r"single orbit: taub=\s*(\S+)\s+delphi=\s*(\S+)\s+ierr=(\d+)",
+        text,
+    )
+    if match is None:
+        raise AssertionError("single-orbit summary is missing")
+    return float(match.group(1)), float(match.group(2)), int(match.group(3))
+
+
+def assert_close(actual: float, expected: float, tolerance: float, name: str) -> None:
+    if not math.isclose(actual, expected, rel_tol=tolerance, abs_tol=tolerance):
+        raise AssertionError(f"{name}: expected {expected}, got {actual}")
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "usage: test_fixed_energy_contour.py "
+            "<contour.x> <potato.x> <fixture-dir>"
+        )
+        return 2
+
+    contour_executable = Path(sys.argv[1]).resolve()
+    potato_executable = Path(sys.argv[2]).resolve()
+    fixture = Path(sys.argv[3]).resolve()
+    with tempfile.TemporaryDirectory(prefix="potato-fixed-contour-") as tmp:
+        work = Path(tmp)
+        for name in INPUT_NAMES:
+            shutil.copy(fixture / name, work / name)
+        zero_electric_potential(work / "profile_poly.in")
+        write_input(
+            work / "potato.in",
+            """  contour_rho_min = 0.45d0
+  contour_rho_max = 0.55d0
+  contour_nrho = 2
+  contour_jperp_min = 2d-5
+  contour_jperp_max = 3d-5
+  contour_njperp = 2
+  contour_enkin = 1d0
+  contour_sigma = 1
+""",
+        )
+        subprocess.run([contour_executable], cwd=work, check=True, timeout=120)
+        columns, rows = read_contour(work / "potato_resonance_contour.dat")
+
+        if tuple(columns) != EXPECTED_COLUMNS:
+            raise AssertionError(f"unexpected columns: {columns}")
+        if len(rows) != 4:
+            raise AssertionError(f"expected a rectangular 2x2 grid, got {len(rows)}")
+        if {row["rho_pol"] for row in rows} != {0.45, 0.55}:
+            raise AssertionError("configured rho_pol endpoints are missing")
+        if {row["J_perp"] for row in rows} != {2.0e-5, 3.0e-5}:
+            raise AssertionError("configured J_perp endpoints are missing")
+
+        successful = [row for row in rows if row["ierr"] == 0.0]
+        if not successful:
+            raise AssertionError("fixed-energy contour has no successful orbit")
+        row = successful[0]
+        assert_close(row["H0"], 1.0, 1.0e-12, "fixed normalized energy")
+        assert_close(row["p"], 1.0, 1.0e-12, "fixed normalized momentum")
+        if row["psi_axis"] == row["psi_edge"]:
+            raise AssertionError("contour flux gauge is degenerate")
+        if row["phi_elec"] != 0.0 or row["v0_cm_s"] <= 0.0:
+            raise AssertionError("contour normalization metadata is invalid")
+        assert_close(
+            row["omega_phi"] / row["omega_b"],
+            row["delphi"] / (2.0 * math.pi),
+            1.0e-8,
+            "frequency normalization",
+        )
+
+        write_input(
+            work / "potato.in",
+            f"""  orbit_Rstart = {row['R_gc']:.17e}
+  orbit_Zstart = {row['Z_gc']:.17e}
+  orbit_lambda = {row['xi']:.17e}
+""",
+        )
+        single = subprocess.run(
+            [potato_executable],
+            cwd=work,
+            check=True,
+            timeout=120,
+            capture_output=True,
+            text=True,
+        )
+        taub, delphi, ierr = parse_single_orbit(single.stdout)
+        if ierr != 0:
+            raise AssertionError(f"equivalent single orbit failed with ierr={ierr}")
+        assert_close(taub, row["taub"], 2.0e-6, "single-orbit taub")
+        assert_close(delphi, row["delphi"], 2.0e-6, "single-orbit delphi")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a configurable rectangular rho_pol/J_perp scan at fixed normalized kinetic energy, including complete SIMPLE handoff metadata and physical frequencies. Failed points remain in the rectangular output.\n\nValidation:\n- fo full pipeline\n- potato_fixed_energy_contour\n- potato_invariant_handoff\n- test_potato_invariants