### PR TITLE
Add coordinate-independent electromagnetic torque kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(NEO_RT_SOURCES
     src/config.f90
     src/datatypes.f90
     src/driftorbit.f90
+    src/electromagnetic_torque.f90
     src/freq.f90
     src/lib.f90
     src/logging.f90

--- a/src/electromagnetic_torque.f90
+++ b/src/electromagnetic_torque.f90
@@ -1,0 +1,56 @@
+module electromagnetic_torque
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+    private
+
+    public :: cross_contraction
+    public :: staggered_cross_contraction
+
+contains
+
+    pure elemental function cross_contraction(j1, b2, j2, b1) result(value)
+        complex(dp), intent(in) :: j1, b2, j2, b1
+        real(dp) :: value
+
+        value = 0.5_dp*real(conjg(j1)*b2 - conjg(j2)*b1, dp)
+    end function cross_contraction
+
+    function staggered_cross_contraction(j1_half, b2_half, j2_full, b1_full) &
+            result(density)
+        complex(dp), intent(in) :: j1_half(:, :), b2_half(:, :)
+        complex(dp), intent(in) :: j2_full(:, :), b1_full(:, :)
+        real(dp) :: density(size(j1_half, 1))
+        integer :: cell_count, mode
+
+        call require_same_shape(j1_half, b2_half, "half-mesh B2")
+        call require_same_shape(j2_full, b1_full, "full-mesh B1")
+        if (size(j2_full, 2) /= size(j1_half, 2)) then
+            error stop "full/half meshes have different mode counts"
+        end if
+        cell_count = size(j1_half, 1)
+        if (size(j2_full, 1) /= cell_count + 1) then
+            error stop "full mesh must have one more radial point than half mesh"
+        end if
+        density = 0.0_dp
+        do mode = 1, size(j1_half, 2)
+            density = density + 0.5_dp*real( &
+                conjg(j1_half(:, mode))*b2_half(:, mode) - 0.5_dp*( &
+                conjg(j2_full(:cell_count, mode))*b1_full(:cell_count, mode) + &
+                conjg(j2_full(2:, mode))*b1_full(2:, mode)), dp)
+        end do
+    end function staggered_cross_contraction
+
+    subroutine require_same_shape(first, second, label)
+        complex(dp), intent(in) :: first(:, :), second(:, :)
+        character(*), intent(in) :: label
+
+        if (size(first, 1) /= size(second, 1)) then
+            error stop label//" has a different radial size"
+        end if
+        if (size(first, 2) /= size(second, 2)) then
+            error stop label//" has a different mode count"
+        end if
+    end subroutine require_same_shape
+
+end module electromagnetic_torque

--- a/src/electromagnetic_torque.f90
+++ b/src/electromagnetic_torque.f90
@@ -1,4 +1,12 @@
 module electromagnetic_torque
+    ! Algebraic electromagnetic-torque contraction for native complex harmonics.
+    !
+    ! J and B are stored non-axisymmetric Fourier amplitudes. The factor 1/2
+    ! is the real-field average of one complex harmonic; callers must use one
+    ! consistent Fourier sign convention for both vectors. Results retain the
+    ! input J*B normalization and are not SI torque by themselves. Geometry,
+    ! B0**2/mu0 scaling, radial-coordinate conversion, filtering, and edge
+    ! policies belong to an adapter outside this coordinate-independent kernel.
     use, intrinsic :: iso_fortran_env, only: dp => real64
 
     implicit none
@@ -18,6 +26,9 @@ contains
 
     function staggered_cross_contraction(j1_half, b2_half, j2_full, b1_full) &
             result(density)
+        ! Return the unsmoothed native radial integration density on half cells.
+        ! Full-mesh J2*B1 products are averaged at adjacent cell endpoints;
+        ! half-mesh J1*B2 products are used at their native locations.
         complex(dp), intent(in) :: j1_half(:, :), b2_half(:, :)
         complex(dp), intent(in) :: j2_full(:, :), b1_full(:, :)
         real(dp) :: density(size(j1_half, 1))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,25 @@ add_test(NAME test_harmonic_bounds
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+add_test(NAME test_electromagnetic_torque
+    COMMAND test_electromagnetic_torque.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_test(NAME test_electromagnetic_torque_invalid_half
+    COMMAND test_electromagnetic_torque_invalid.x half
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(test_electromagnetic_torque_invalid_half
+    PROPERTIES WILL_FAIL TRUE)
+
+add_test(NAME test_electromagnetic_torque_invalid_full
+    COMMAND test_electromagnetic_torque_invalid.x full
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(test_electromagnetic_torque_invalid_full
+    PROPERTIES WILL_FAIL TRUE)
+
 add_test(NAME test_vmax_over_vth
     COMMAND test_vmax_over_vth.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/test_electromagnetic_torque.f90
+++ b/test/test_electromagnetic_torque.f90
@@ -1,0 +1,66 @@
+program test_electromagnetic_torque
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use electromagnetic_torque, only: cross_contraction, staggered_cross_contraction
+
+    implicit none
+
+    call test_hand_derived_mode_contraction
+    call test_explicit_full_half_stagger
+    call test_common_complex_phase
+
+contains
+
+    subroutine test_hand_derived_mode_contraction
+        complex(dp) :: j1(2), j2(2), b1(2), b2(2)
+        real(dp) :: actual
+
+        j1 = [cmplx(1.0_dp, 2.0_dp, dp), cmplx(-0.5_dp, 1.0_dp, dp)]
+        j2 = [cmplx(3.0_dp, -1.0_dp, dp), cmplx(2.0_dp, 0.25_dp, dp)]
+        b1 = [cmplx(-2.0_dp, 1.0_dp, dp), cmplx(1.5_dp, -3.0_dp, dp)]
+        b2 = [cmplx(0.5_dp, 4.0_dp, dp), cmplx(-1.0_dp, 2.0_dp, dp)]
+
+        actual = sum(cross_contraction(j1, b2, j2, b1))
+        call assert_close(actual, 7.875_dp, "hand-derived two-mode contraction")
+    end subroutine test_hand_derived_mode_contraction
+
+    subroutine test_explicit_full_half_stagger
+        complex(dp) :: j1_half(1, 1), b2_half(1, 1)
+        complex(dp) :: j2_full(2, 1), b1_full(2, 1)
+        real(dp), allocatable :: actual(:)
+
+        j1_half = cmplx(1.0_dp, 1.0_dp, dp)
+        b2_half = cmplx(3.0_dp, 3.0_dp, dp)
+        j2_full(:, 1) = [cmplx(1.0_dp, 0.0_dp, dp), cmplx(0.0_dp, 2.0_dp, dp)]
+        b1_full(:, 1) = [cmplx(4.0_dp, 0.0_dp, dp), cmplx(0.0_dp, 3.0_dp, dp)]
+
+        actual = staggered_cross_contraction(j1_half, b2_half, j2_full, b1_full)
+        call assert_close(actual(1), 0.5_dp, "explicit full/half-grid contraction")
+    end subroutine test_explicit_full_half_stagger
+
+    subroutine test_common_complex_phase
+        complex(dp), parameter :: phase = cmplx(0.6_dp, 0.8_dp, dp)
+        complex(dp) :: j1(1), j2(1), b1(1), b2(1)
+        real(dp) :: reference, rotated
+
+        j1 = cmplx(1.0_dp, -2.0_dp, dp)
+        j2 = cmplx(0.5_dp, 3.0_dp, dp)
+        b1 = cmplx(-4.0_dp, 0.25_dp, dp)
+        b2 = cmplx(2.0_dp, 1.5_dp, dp)
+        reference = sum(cross_contraction(j1, b2, j2, b1))
+        rotated = sum(cross_contraction(phase*j1, phase*b2, phase*j2, phase*b1))
+
+        call assert_close(rotated, reference, "common complex phase")
+    end subroutine test_common_complex_phase
+
+    subroutine assert_close(actual, expected, label)
+        real(dp), intent(in) :: actual, expected
+        character(*), intent(in) :: label
+        real(dp), parameter :: tolerance = 1.0e-13_dp
+
+        if (abs(actual - expected) > tolerance) then
+            print *, trim(label), ": expected", expected, "got", actual
+            error stop
+        end if
+    end subroutine assert_close
+
+end program test_electromagnetic_torque

--- a/test/test_electromagnetic_torque_invalid.f90
+++ b/test/test_electromagnetic_torque_invalid.f90
@@ -23,6 +23,5 @@ program test_electromagnetic_torque_invalid
         error stop "unknown invalid electromagnetic-torque case"
     end select
     print *, value
-    error stop "invalid electromagnetic-torque input was accepted"
 
 end program test_electromagnetic_torque_invalid

--- a/test/test_electromagnetic_torque_invalid.f90
+++ b/test/test_electromagnetic_torque_invalid.f90
@@ -1,0 +1,28 @@
+program test_electromagnetic_torque_invalid
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use electromagnetic_torque, only: staggered_cross_contraction
+
+    implicit none
+
+    character(8) :: case_name
+    complex(dp) :: half_one(1, 1), half_two(2, 1), full_two(2, 1), full_three(3, 1)
+    real(dp), allocatable :: value(:)
+
+    call get_command_argument(1, case_name)
+    half_one = cmplx(1.0_dp, 0.0_dp, dp)
+    half_two = cmplx(1.0_dp, 0.0_dp, dp)
+    full_two = cmplx(1.0_dp, 0.0_dp, dp)
+    full_three = cmplx(1.0_dp, 0.0_dp, dp)
+
+    select case (trim(case_name))
+    case ("half")
+        value = staggered_cross_contraction(half_one, half_two, full_two, full_two)
+    case ("full")
+        value = staggered_cross_contraction(half_one, half_one, full_three, full_two)
+    case default
+        error stop "unknown invalid electromagnetic-torque case"
+    end select
+    print *, value
+    error stop "invalid electromagnetic-torque input was accepted"
+
+end program test_electromagnetic_torque_invalid


### PR DESCRIPTION
## Scope

Adds a coordinate-independent electromagnetic torque contraction kernel for native complex Fourier amplitudes.

It provides:

- `cross_contraction` for the real-field average of `J1*B2 - J2*B1`;
- `staggered_cross_contraction` for half-mesh `J1/B2` and full-mesh `J2/B1` inputs;
- explicit shape checks that fail closed before invalid mesh contractions.

The kernel preserves the input normalization. It does not perform SI scaling, radial-coordinate conversion, filtering, field reconstruction, or MARS/GPEC file reading. No production reader or adapter is connected by this PR.

## Validation

- Hand-derived complex contraction.
- Explicit full/half-mesh contraction.
- Common complex-phase invariance.
- Invalid half-mesh and full-mesh shape cases are registered as expected-failure tests.

