### PR TITLE
Add strict GPEC torque boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(NEO_RT_SOURCES
     src/driftorbit.f90
     src/electromagnetic_torque.f90
     src/freq.f90
+    src/gpec_torque_contract.f90
     src/lib.f90
     src/logging.f90
     src/magfie.f90

--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ For single-point runs such as ripple tests, populate a `config_t` instance, call
 
 When spline mode is active the `M_t`, `vth`, `qi`, and `mi` values come from the supplied plasma/profile data and overwrite any prior config settings, so reset them if you later switch back to the config-only workflow.
 
+### GPEC torque boundary
+
+`gpec_torque_contract` reads the integrated toroidal torque from a native
+`gpec_control_n*.out` file. The toroidal mode must be supplied separately
+because it is not serialized in that file. GPEC computes this value from the
+SI perturbed energy as `-2*n*Im(deltaW)`; its native torque output identifies
+the corresponding unit as Nm.
+
+An ideal GPEC response does not serialize a volume perturbed-current vector or
+a radial electromagnetic torque profile. It therefore cannot supply the
+required input to `electromagnetic_torque`, and the contract fails explicitly
+if volume current is requested. `pentrc_tgar_n*.out` contains kinetic
+nonambipolar transport torque, not electromagnetic JxB torque.
+
 ## Examples
 
 The `examples/` directory contains ready-to-run input decks. To run the base example:

--- a/src/gpec_torque_contract.f90
+++ b/src/gpec_torque_contract.f90
@@ -1,0 +1,66 @@
+module gpec_torque_contract
+    ! Strict access to the integrated torque reported by GPEC_CONTROL.
+    !
+    ! GPEC_CONTROL does not contain a volume perturbed-current vector or a
+    ! radial JxB profile. Its scalar torque can therefore check only an
+    ! independently integrated result, not the electromagnetic-torque kernel.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+    implicit none
+    private
+
+    type, public :: gpec_control_torque
+        integer :: toroidal_mode = 0
+        real(dp) :: torque_nm = 0.0_dp
+    end type gpec_control_torque
+
+    public :: read_gpec_control_torque
+    public :: require_gpec_volume_current
+
+contains
+
+    subroutine read_gpec_control_torque(filename, toroidal_mode, result)
+        character(*), intent(in) :: filename
+        integer, intent(in) :: toroidal_mode
+        type(gpec_control_torque), intent(out) :: result
+        character(512) :: line
+        integer :: unit, io_status, separator, torque_count
+        logical :: header_found
+
+        if (toroidal_mode == 0) error stop "GPEC toroidal mode must be nonzero"
+
+        open(newunit=unit, file=filename, status="old", action="read", iostat=io_status)
+        if (io_status /= 0) error stop "cannot open GPEC_CONTROL file"
+
+        header_found = .false.
+        torque_count = 0
+        do
+            read(unit, "(a)", iostat=io_status) line
+            if (io_status < 0) exit
+            if (io_status > 0) error stop "cannot read GPEC_CONTROL file"
+
+            if (index(adjustl(line), "GPEC_CONTROL:") == 1) header_found = .true.
+            if (index(adjustl(line), "toroidal torque") == 1) then
+                separator = index(line, "=")
+                if (separator == 0) error stop "malformed GPEC toroidal torque"
+                torque_count = torque_count + 1
+                read(line(separator + 1:), *, iostat=io_status) result%torque_nm
+                if (io_status /= 0) error stop "malformed GPEC toroidal torque"
+            end if
+        end do
+        close(unit)
+
+        if (.not. header_found) error stop "not a GPEC_CONTROL file"
+        if (torque_count /= 1) error stop "GPEC_CONTROL must contain one toroidal torque"
+        if (.not. ieee_is_finite(result%torque_nm)) then
+            error stop "GPEC toroidal torque must be finite"
+        end if
+        result%toroidal_mode = toroidal_mode
+    end subroutine read_gpec_control_torque
+
+    subroutine require_gpec_volume_current()
+        error stop "GPEC output has no volume perturbed-current vector for JxB"
+    end subroutine require_gpec_volume_current
+
+end module gpec_torque_contract

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,34 @@ add_test(NAME test_electromagnetic_torque_invalid_full
 set_tests_properties(test_electromagnetic_torque_invalid_full
     PROPERTIES WILL_FAIL TRUE)
 
+add_test(NAME test_gpec_torque_contract
+    COMMAND test_gpec_torque_contract.x
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/gpec_control_n3.txt
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_test(NAME test_gpec_torque_contract_rejects_missing_volume_current
+    COMMAND test_gpec_torque_contract_invalid.x volume
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(test_gpec_torque_contract_rejects_missing_volume_current
+    PROPERTIES WILL_FAIL TRUE)
+
+add_test(NAME test_gpec_torque_contract_rejects_zero_mode
+    COMMAND test_gpec_torque_contract_invalid.x zero_mode
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(test_gpec_torque_contract_rejects_zero_mode
+    PROPERTIES WILL_FAIL TRUE)
+
+add_test(NAME test_gpec_torque_contract_rejects_missing_torque
+    COMMAND test_gpec_torque_contract_invalid.x missing_torque
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/gpec_control_missing_torque.txt
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(test_gpec_torque_contract_rejects_missing_torque
+    PROPERTIES WILL_FAIL TRUE)
+
 add_test(NAME test_vmax_over_vth
     COMMAND test_vmax_over_vth.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/fixtures/gpec_control_missing_torque.txt
+++ b/test/fixtures/gpec_control_missing_torque.txt
@@ -1,0 +1,5 @@
+ GPEC_CONTROL: Plasma response for an external perturbation on the control surface
+ v1.5.4-12-ga430ad2
+
+      mpert =  51
+  plasma energy =  1.24886311E+004

--- a/test/fixtures/gpec_control_n3.txt
+++ b/test/fixtures/gpec_control_n3.txt
@@ -1,0 +1,8 @@
+ GPEC_CONTROL: Plasma response for an external perturbation on the control surface
+ v1.5.4-12-ga430ad2
+
+      mpert =  51
+  vacuum energy =  1.29218915E+004
+ surface energy =  1.69798256E+004
+  plasma energy =  1.24886311E+004
+  toroidal torque = -1.23093339E+000

--- a/test/test_gpec_torque_contract.f90
+++ b/test/test_gpec_torque_contract.f90
@@ -1,0 +1,18 @@
+program test_gpec_torque_contract
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use gpec_torque_contract, only: gpec_control_torque, read_gpec_control_torque
+
+    implicit none
+
+    type(gpec_control_torque) :: result
+    character(512) :: fixture
+
+    call get_command_argument(1, fixture)
+    if (len_trim(fixture) == 0) error stop "missing GPEC_CONTROL fixture"
+
+    call read_gpec_control_torque(trim(fixture), 3, result)
+    if (result%toroidal_mode /= 3) error stop "wrong GPEC toroidal mode"
+    if (abs(result%torque_nm - (-1.23093339_dp)) > 1.0e-12_dp) then
+        error stop "wrong native GPEC toroidal torque"
+    end if
+end program test_gpec_torque_contract

--- a/test/test_gpec_torque_contract_invalid.f90
+++ b/test/test_gpec_torque_contract_invalid.f90
@@ -1,0 +1,23 @@
+program test_gpec_torque_contract_invalid
+    use gpec_torque_contract, only: gpec_control_torque, &
+        read_gpec_control_torque, require_gpec_volume_current
+
+    implicit none
+
+    character(16) :: case_name
+    character(512) :: fixture
+    type(gpec_control_torque) :: result
+
+    call get_command_argument(1, case_name)
+    select case (trim(case_name))
+    case ("volume")
+        call require_gpec_volume_current
+    case ("zero_mode")
+        call read_gpec_control_torque("unused", 0, result)
+    case ("missing_torque")
+        call get_command_argument(2, fixture)
+        call read_gpec_control_torque(trim(fixture), 3, result)
+    case default
+        error stop "unknown invalid GPEC torque case"
+    end select
+end program test_gpec_torque_contract_invalid


### PR DESCRIPTION
## Scope

This PR is stacked on #110 and contains only the incremental GPEC boundary contract.

It adds `gpec_torque_contract`, which reads exactly one finite toroidal torque from a native `GPEC_CONTROL` file when the toroidal mode is supplied by the caller. It rejects zero mode, malformed or missing torque records, and requests for a volume perturbed-current vector.

The README documents the limitation explicitly: GPEC’s scalar control output is an independently integrated torque, not the vector/current data required by the coordinate-independent electromagnetic `JxB` kernel. No GPEC-to-MARS or full-volume reconstruction is claimed.

## Validation

- Valid `GPEC_CONTROL` fixture with `n=3`.
- Missing-torque fixture.
- Zero-mode rejection.
- Explicit rejection of unavailable volume-current data.

Merge order: #110 first, then this stacked contract.

