### PR TITLE
Replace system NetCDF/HDF5 with Fortio-backed libneo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ endif()
 
 include(Util)
 
+if(NOT DEFINED LIBNEO_REF)
+    set(LIBNEO_REF 8d58a5eb55a376d6b5d8ae1c160ab7e2c9190b2c)
+endif()
+
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND UNIX AND NOT APPLE AND NOT DEFINED BLA_VENDOR)
     find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND)
@@ -88,35 +92,6 @@ FetchContent_Declare(
     GIT_TAG main
 )
 FetchContent_MakeAvailable(fortplot)
-
-# NetCDF
-find_program(NF_CONFIG "nf-config")
-
-if(NF_CONFIG)
-    execute_process(COMMAND nf-config --includedir
-        OUTPUT_VARIABLE NETCDFINCLUDE_DIR)
-    execute_process(COMMAND nc-config --libdir
-        OUTPUT_VARIABLE NETCDFLIB_DIR)
-    execute_process(COMMAND nf-config --flibs
-        OUTPUT_VARIABLE NETCDF_FLIBS)
-else()
-    message(SEND_ERROR "nf-config not found. Please install libnetcdff-dev")
-endif()
-
-string(STRIP ${NETCDFINCLUDE_DIR} NETCDFINCLUDE_DIR)
-string(STRIP ${NETCDFLIB_DIR} NETCDFLIB_DIR)
-string(STRIP ${NETCDF_FLIBS} NETCDF_FLIBS)
-
-message(STATUS "NetCDF include path: " ${NETCDFINCLUDE_DIR})
-message(STATUS "NetCDF lib path: " ${NETCDFLIB_DIR})
-message(STATUS "NetCDF Fortran libs: " ${NETCDF_FLIBS})
-
-# Replace space by semicolon in the Fortran libs
-string(REPLACE " " ";" NETCDF_FLIBS ${NETCDF_FLIBS})
-
-include_directories(${NETCDFINCLUDE_DIR})
-link_directories(${NETCDFLIB_DIR})
-add_link_options(${NETCDF_FLIBS})
 
 add_executable(${PROJECT_EXE_NAME} src/program.f90)
 

--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -14,6 +14,9 @@ else ()
 endif ()
 
 include(Util)
+if(NOT DEFINED LIBNEO_REF)
+    set(LIBNEO_REF 8d58a5eb55a376d6b5d8ae1c160ab7e2c9190b2c)
+endif()
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND UNIX AND NOT APPLE AND NOT DEFINED BLA_VENDOR)
     find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND)
@@ -26,7 +29,6 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND UNIX AND NOT APPLE AND NOT DEFIN
 endif()
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
-find_package(HDF5 REQUIRED COMPONENTS Fortran)
 # OpenMP parallelizes the find_bounce-heavy resonance grid build
 # (SRC/sample_matrix.f90) and the per-mode resonance root search
 # (SRC/resonant_int.f90).  Linked to potato_base so -fopenmp reaches POTATO's own
@@ -139,6 +141,19 @@ target_link_libraries(potato_resonance_probe.x
 )
 
 find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+    set(_neo2_reader_fixture "${CMAKE_CURRENT_BINARY_DIR}/neo2-reader-oracle.h5")
+    add_test(NAME generate_neo2_reader_oracle
+        COMMAND ${Python3_EXECUTABLE}
+            "${CMAKE_CURRENT_SOURCE_DIR}/test/make_neo2_reader_oracle.py"
+            "${_neo2_reader_fixture}")
+    add_executable(test_neo2_reader.x test/test_neo2_reader.f90)
+    target_link_libraries(test_neo2_reader.x PRIVATE potato_base)
+    add_test(NAME test_neo2_reader
+        COMMAND test_neo2_reader.x "${_neo2_reader_fixture}")
+    set_tests_properties(test_neo2_reader PROPERTIES
+        DEPENDS generate_neo2_reader_oracle)
+endif()
 if(Python3_Interpreter_FOUND)
     add_test(NAME potato_invariant_handoff
         COMMAND ${Python3_EXECUTABLE}

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(potato_base
-  ${LIBNEO_SOURCE_DIR}/src/libneo_kinds.f90
+  ${LIBNEO_SOURCE_DIR}/src/util/libneo_kinds.f90
   logging_mod.f90
   wall_loss_mod.f90
   potato_input_mod.f90
@@ -39,7 +39,18 @@ add_library(potato_base
   box_counting.f90
   neo2_reader.f90
 )
+set(VODE_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+if(DEFINED BUILD_TESTING)
+  set(_POTATO_BUILD_TESTING_WAS_DEFINED TRUE)
+  set(_POTATO_BUILD_TESTING_SAVED ${BUILD_TESTING})
+endif()
+set(BUILD_TESTING OFF)
 find_or_fetch(vode)
+if(_POTATO_BUILD_TESTING_WAS_DEFINED)
+  set(BUILD_TESTING ${_POTATO_BUILD_TESTING_SAVED})
+else()
+  unset(BUILD_TESTING)
+endif()
 # vode (dvode_f90_m) uses labeled DO termination, deleted in f2018; build it with
 # the permissive legacy standard rather than POTATO's f2018.
 target_compile_options(vode PRIVATE -std=legacy)
@@ -47,7 +58,7 @@ target_link_libraries(potato_base PUBLIC
 vode
 BLAS::BLAS
 LAPACK::LAPACK
-HDF5::HDF5
+LIBNEO::hdf5_tools
 fortplot::fortplot
 OpenMP::OpenMP_Fortran
 )

--- a/POTATO/SRC/neo2_reader.f90
+++ b/POTATO/SRC/neo2_reader.f90
@@ -1,5 +1,6 @@
 module neo2_reader
-    use hdf5
+    use hdf5_tools, only: HID_T, h5_close, h5_deinit, h5_get, h5_get_bounds, &
+        h5_init, h5_open
     implicit none
 
     integer, parameter :: dp = kind(1.0d0)
@@ -30,11 +31,10 @@ module neo2_reader
         character(len=*), intent(in) :: neo2_file
         type(neo2_data_t), intent(out) :: neo2_data
 
-        integer(hid_t) :: file_id
-        integer :: hdferr
+        integer(HID_T) :: file_id
         
-        call h5open_f(hdferr)
-        call h5fopen_f(neo2_file, H5F_ACC_RDONLY_F, file_id, hdferr)
+        call h5_init()
+        call h5_open(neo2_file, file_id)
         
         call h5read(file_id, "boozer_s", neo2_data%stor)
         call h5read(file_id, "aiota", neo2_data%q)
@@ -48,8 +48,8 @@ module neo2_reader
         call h5read(file_id, "Er", neo2_data%Er)
         call h5read(file_id, "MtOvR", neo2_data%MtOvR)
         
-        call h5fclose_f(file_id, hdferr)
-        call h5close_f(hdferr)
+        call h5_close(file_id)
+        call h5_deinit()
         
     end subroutine read_neo2_data
     
@@ -171,39 +171,25 @@ module neo2_reader
     end subroutine polyint
     
     subroutine h5_read_1d(file_id, name, array)
-        integer(hid_t), intent(in) :: file_id
+        integer(HID_T), intent(in) :: file_id
         character(len=*), intent(in) :: name
         real(dp), allocatable, intent(out) :: array(:)
+        integer :: lower, upper
         
-        integer(hid_t) :: dset_id, space_id
-        integer(hsize_t) :: dims(1)
-        integer :: hdferr
-        
-        call h5dopen_f(file_id, name, dset_id, hdferr)
-        call h5dget_space_f(dset_id, space_id, hdferr)
-        call h5sget_simple_extent_dims_f(space_id, dims, dims, hdferr)
-        allocate(array(dims(1)))
-        call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array, dims, hdferr)
-        call h5dclose_f(dset_id, hdferr)
-        call h5sclose_f(space_id, hdferr)
+        call h5_get_bounds(file_id, name, lower, upper)
+        allocate(array(lower:upper))
+        call h5_get(file_id, name, array)
     end subroutine h5_read_1d
     
     subroutine h5_read_2d(file_id, name, array)
-        integer(hid_t), intent(in) :: file_id
+        integer(HID_T), intent(in) :: file_id
         character(len=*), intent(in) :: name
         real(dp), allocatable, intent(out) :: array(:,:)
+        integer :: lower_1, lower_2, upper_1, upper_2
         
-        integer(hid_t) :: dset_id, space_id
-        integer(hsize_t) :: dims(2)
-        integer :: hdferr
-        
-        call h5dopen_f(file_id, name, dset_id, hdferr)
-        call h5dget_space_f(dset_id, space_id, hdferr)
-        call h5sget_simple_extent_dims_f(space_id, dims, dims, hdferr)
-        allocate(array(dims(1), dims(2)))
-        call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, array, dims, hdferr)
-        call h5dclose_f(dset_id, hdferr)
-        call h5sclose_f(space_id, hdferr)
+        call h5_get_bounds(file_id, name, lower_1, lower_2, upper_1, upper_2)
+        allocate(array(lower_1:upper_1, lower_2:upper_2))
+        call h5_get(file_id, name, array)
     end subroutine h5_read_2d
 
 end module neo2_reader

--- a/POTATO/test/make_neo2_reader_oracle.py
+++ b/POTATO/test/make_neo2_reader_oracle.py
@@ -1,0 +1,26 @@
+import sys
+
+import h5py
+import numpy as np
+
+
+with h5py.File(sys.argv[1], "w", libver="latest") as handle:
+    vectors = {
+        "boozer_s": [0.0, 0.5, 1.0],
+        "aiota": [0.5, 0.5, 0.5],
+        "Er": [-2.0, 0.0, 2.0],
+    }
+    for name, values in vectors.items():
+        dataset = handle.create_dataset(name, data=np.array(values, dtype=np.float64))
+        dataset.attrs["lbounds"] = np.array([1], dtype=np.int32)
+        dataset.attrs["ubounds"] = np.array([3], dtype=np.int32)
+
+    matrices = {
+        "n_spec": np.arange(1.0, 7.0, dtype=np.float64),
+        "T_spec": np.arange(11.0, 17.0, dtype=np.float64),
+        "MtOvR": np.arange(21.0, 27.0, dtype=np.float64),
+    }
+    for name, values in matrices.items():
+        dataset = handle.create_dataset(name, data=values.reshape(2, 3))
+        dataset.attrs["lbounds"] = np.array([1, 1], dtype=np.int32)
+        dataset.attrs["ubounds"] = np.array([3, 2], dtype=np.int32)

--- a/POTATO/test/test_neo2_reader.f90
+++ b/POTATO/test/test_neo2_reader.f90
@@ -1,0 +1,22 @@
+program test_neo2_reader
+    use neo2_reader, only: dp, neo2_data_t, read_neo2_data
+    implicit none
+
+    type(neo2_data_t) :: data
+    character(len=1024) :: fixture
+    integer :: i
+
+    call get_command_argument(1, fixture)
+    call read_neo2_data(trim(fixture), data)
+
+    if (any(abs(data%stor - [0.0_dp, 0.5_dp, 1.0_dp]) > 1.0e-12_dp)) &
+        error stop "toroidal flux differs"
+    if (any(abs(data%q - 2.0_dp) > 1.0e-12_dp)) error stop "safety factor differs"
+    if (any(abs(data%spol - [0.0_dp, 0.5_dp, 1.0_dp]) > 1.0e-12_dp)) &
+        error stop "poloidal flux differs"
+    if (any(shape(data%n_spec) /= [3, 2])) error stop "rank-two shape differs"
+    if (any(abs(data%n_spec - reshape([(real(i, dp), i=1, 6)], [3, 2])) > &
+        1.0e-12_dp)) error stop "rank-two values differ"
+    if (any(abs(data%Er - [-2.0_dp, 0.0_dp, 2.0_dp]) > 1.0e-12_dp)) &
+        error stop "electric field differs"
+end program test_neo2_reader

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -21,15 +21,20 @@ function(find_or_fetch DEPENDENCY)
         set(_override "${${_DEP}_REF}")
     endif()
     if(NOT "${_override}" STREQUAL "")
-        execute_process(
-            COMMAND git ls-remote ${REPO_URL} ${_override}
-            OUTPUT_VARIABLE _found
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        if(NOT "${_found}" STREQUAL "")
+        string(LENGTH "${_override}" _override_length)
+        if(_override_length EQUAL 40 AND "${_override}" MATCHES "^[0-9a-fA-F]+$")
             set(_ref "${_override}")
         else()
-            message(WARNING "${_DEP}_REF='${_override}' not found in ${REPO_URL}; ignoring")
+            execute_process(
+                COMMAND git ls-remote ${REPO_URL} ${_override}
+                OUTPUT_VARIABLE _found
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            if(NOT "${_found}" STREQUAL "")
+                set(_ref "${_override}")
+            else()
+                message(WARNING "${_DEP}_REF='${_override}' not found in ${REPO_URL}; ignoring")
+            endif()
         endif()
     endif()
     if("${_ref}" STREQUAL "" AND DEFINED ${_DEP}_RELEASE AND NOT "${${_DEP}_RELEASE}" STREQUAL "")


### PR DESCRIPTION
Removes NEO-RT's obsolete global NetCDF discovery/link flags and POTATO's direct system-HDF5 dependency. POTATO's small NEO-2 profile reader now composes libneo's Fortio-backed `hdf5_tools` API, including bounds-based allocation for the rank-1/rank-2 datasets it actually reads.

Also fixes first-party dependency SHA resolution (the previous helper silently rejected immutable SHAs), pins the migration candidate, and prevents VODE tests from leaking into POTATO's suite.

Verification:
- bare `fo`: build/tests/lint pass (legacy reader file remains pre-existing fmt-dirty)
- clean standalone POTATO CMake build fetches exact Libneo SHA and Fortio, with no system NetCDF/HDF5 detection
- 7 runnable POTATO tests pass; two data-dependent golden tests skip as designed
- new independent h5py oracle covers the NEO-2 rank-1/rank-2 profile data and bounds semantics