### PR TITLE
Separate perturbation input format from equilibrium format

### DIFF
--- a/doc/running.md
+++ b/doc/running.md
@@ -64,6 +64,7 @@ The parameter file is a Fortran namelist `&params` with the fields listed below.
 | `vsteps` | Number of velocity grid points. | Set to `0` for adaptive quadrature. |
 | `mth_max_abs` | Maximum absolute orbit-resonance harmonic. | Default `-1` keeps the historical `±ceil(2\|mph q\|)` range; `0` selects only `mth=0`. |
 | `vmax_over_vth` | Upper velocity-space cutoff in units of `vth`. | Default `4.0` captures the far-tail resonance (the old `3.0` bound truncated it); set `3.0` to reproduce pre-2026-07-20 results; must be positive. |
+| `inp_swi_pert` | Input format for `in_file_pert` with the standalone field reader. | Default `-1` inherits `inp_swi`; set `9` to combine an axisymmetric chartmap (`inp_swi=10`) with a Strumberger perturbation `.bc`. |
 | `log_level` | Verbosity level for the logger. | Defined in `src/logging.f90`. |
 
 ### Magnetic field data

--- a/src/config.f90
+++ b/src/config.f90
@@ -24,6 +24,7 @@ module neort_config
         real(dp) :: bfac = 1.0_dp  ! scale B field by factor
         real(dp) :: efac = 1.0_dp  ! scale E field by factor
         integer :: inp_swi = 0  ! input switch for Boozer file
+        integer :: inp_swi_pert = -1  ! negative inherits inp_swi
         integer :: vsteps = 0  ! integration steps in velocity space
         integer :: mth_max_abs = -1 ! negative: historical q-dependent range
         real(dp) :: vmax_over_vth = 4.0_dp  ! upper velocity cutoff / vth
@@ -36,7 +37,7 @@ contains
     subroutine set_config(config)
         ! Set global control parameters via config struct
         use do_magfie_mod, only: s, bfac, inp_swi
-        use do_magfie_pert_mod, only: mph, set_mph
+        use do_magfie_pert_mod, only: mph, set_mph, perturbation_switch => inp_swi_pert
         use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
@@ -65,6 +66,8 @@ contains
         bfac = config%bfac
         efac = config%efac
         inp_swi = config%inp_swi
+        perturbation_switch = resolve_perturbation_switch(config%inp_swi, config%inp_swi_pert)
+        call validate_perturbation_switch(pertfile, perturbation_switch)
         vsteps = config%vsteps
         if (config%mth_max_abs < -1) error stop "mth_max_abs must be -1 or nonnegative"
         mth_max_abs = config%mth_max_abs
@@ -80,7 +83,7 @@ contains
     subroutine read_and_set_config(config_file)
         ! Set global control parameters directly from a file
         use do_magfie_mod, only: s, bfac, inp_swi
-        use do_magfie_pert_mod, only: mph, set_mph
+        use do_magfie_pert_mod, only: mph, set_mph, inp_swi_pert
         use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
@@ -95,10 +98,11 @@ contains
 
         namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, supban, &
             magdrift, magdrift_passing, nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, &
-            vsteps, mth_max_abs, vmax_over_vth, log_level
+            inp_swi_pert, vsteps, mth_max_abs, vmax_over_vth, log_level
 
         mth_max_abs = -1
         vmax_over_vth = 4.0_dp
+        inp_swi_pert = -1
         open (unit=9, file=config_file, status="old", form="formatted")
         read (9, nml=params)
         close (unit=9)
@@ -106,6 +110,8 @@ contains
         if (magdrift_passing < 0) magdrift_passing = merge(1, 0, magdrift)
         if (mth_max_abs < -1) error stop "mth_max_abs must be -1 or nonnegative"
         if (vmax_over_vth <= 0.0_dp) error stop "vmax_over_vth must be positive"
+        inp_swi_pert = resolve_perturbation_switch(inp_swi, inp_swi_pert)
+        call validate_perturbation_switch(pertfile, inp_swi_pert)
 
         M_t = M_t * efac / bfac
         qi = qs * qe
@@ -113,5 +119,25 @@ contains
         call set_mph(mph)
         call set_log_level(log_level)
     end subroutine read_and_set_config
+
+    pure integer function resolve_perturbation_switch(axisymmetric_switch, perturbation_switch)
+        integer, intent(in) :: axisymmetric_switch, perturbation_switch
+
+        if (perturbation_switch < 0) then
+            resolve_perturbation_switch = axisymmetric_switch
+        else
+            resolve_perturbation_switch = perturbation_switch
+        end if
+    end function resolve_perturbation_switch
+
+    subroutine validate_perturbation_switch(has_perturbation_file, perturbation_switch)
+        logical, intent(in) :: has_perturbation_file
+        integer, intent(in) :: perturbation_switch
+
+        if (has_perturbation_file .and. perturbation_switch /= 8 .and. &
+            perturbation_switch /= 9) then
+            error stop "inp_swi_pert must be 8 or 9 for a perturbation .bc file"
+        end if
+    end subroutine validate_perturbation_switch
 
 end module neort_config

--- a/src/do_magfie_neo.f90
+++ b/src/do_magfie_neo.f90
@@ -86,6 +86,8 @@ module do_magfie_pert_mod
     use neo2_ql, only: read_in_namelists, set_default_values, init
 
     integer :: mph
+    ! The external NEO-2 reader owns its input format; this keeps the config API compatible.
+    integer :: inp_swi_pert = -1
 
 contains
 

--- a/src/do_magfie_standalone.f90
+++ b/src/do_magfie_standalone.f90
@@ -630,6 +630,7 @@ module do_magfie_pert_mod
     real(dp), private, allocatable :: Bmnc(:), Bmns(:)
 
     integer :: ncol1, ncol2  ! number of columns in input file
+    integer :: inp_swi_pert = -1  ! negative inherits the axisymmetric switch
     integer :: mph  ! toroidal perturbation mode (threadprivate)
     integer :: mph_shared = 0  ! shared copy for namelist input (when pertfile=.false.)
 
@@ -663,11 +664,18 @@ contains
         ! Main thread only: Read perturbation Boozer file and prepare shared spline data
         ! This should be called ONCE before parallel region
         character(len=*), intent(in) :: path
-        integer :: j, k
+        integer :: input_switch, j, k
 
         ncol1 = 5
-        if (inp_swi == 8) ncol2 = 4 ! tok_circ
-        if (inp_swi == 9) ncol2 = 8 ! ASDEX
+        input_switch = resolved_perturbation_switch()
+        select case (input_switch)
+        case (8)
+            ncol2 = 4 ! tok_circ
+        case (9)
+            ncol2 = 8 ! ASDEX
+        case default
+            error stop "inp_swi_pert must resolve to 8 or 9"
+        end select
 
         ! allocates params, modes - SHARED arrays
         call boozer_read_pert(path)
@@ -759,17 +767,19 @@ contains
         complex(dp), intent(out) :: bamp
 
         real(dp) :: x1
+        integer :: input_switch
 
         ! safety measure in order not to extrapolate
         x1 = max(params(1, 1), x(1))
         x1 = min(params(nflux, 1), x1)
 
         ! calculate B-field from modes
-        if (inp_swi == 8) then
+        input_switch = resolved_perturbation_switch()
+        if (input_switch == 8) then
             call cached_spline(x1, s_prev, spl_coeff2(:, :, 4, :), spl_val_c)
             Bmnc(:) = 1.0e4_dp * spl_val_c(1, :) * bfac
             bamp = sum(Bmnc * cos(modes(1, :, 1) * x(3)))
-        else if (inp_swi == 9) then
+        else if (input_switch == 9) then
             call cached_spline(x1, s_prev, spl_coeff2(:, :, 7, :), spl_val_c)
             call cached_spline(x1, s_prev, spl_coeff2(:, :, 8, :), spl_val_s)
             Bmnc(:) = 1.0e4_dp * spl_val_c(1, :) * bfac
@@ -779,6 +789,14 @@ contains
 
         s_prev = x1
     end subroutine do_magfie_pert_amp
+
+    integer function resolved_perturbation_switch()
+        if (inp_swi_pert < 0) then
+            resolved_perturbation_switch = inp_swi
+        else
+            resolved_perturbation_switch = inp_swi_pert
+        end if
+    end function resolved_perturbation_switch
 
     subroutine do_magfie_pert(x, bmod)
         real(dp), dimension(:), intent(in) :: x

--- a/test/probe_neort_perturbation_fourier_kernel.f90
+++ b/test/probe_neort_perturbation_fourier_kernel.f90
@@ -1,6 +1,6 @@
 program probe_neort_perturbation_fourier_kernel
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use do_magfie_mod, only: bfac, inp_swi, set_s
+    use neort_config, only: config_t, read_and_set_config, set_config
     use do_magfie_pert_mod, only: do_magfie_pert, do_magfie_pert_amp, &
         init_magfie_pert_at_s, read_boozer_pert_file
 
@@ -12,29 +12,45 @@ program probe_neort_perturbation_fourier_kernel
     real(dp), parameter :: sine_amplitude_t = 0.7e-4_dp
     complex(dp) :: amplitude_g
     real(dp) :: full_field_g, expected_g, wrong_sign_g, x(3)
+    type(config_t) :: config
 
     call write_fixture(fixture)
-    inp_swi = 9
-    bfac = 1.0_dp
-    call set_s(0.5_dp)
-    call read_boozer_pert_file(fixture)
-    call init_magfie_pert_at_s()
 
-    x = [0.5_dp, phi, theta]
-    call do_magfie_pert_amp(x, amplitude_g)
-    call do_magfie_pert(x, full_field_g)
-    expected_g = expected_value(theta + 3.0_dp*phi)
-    wrong_sign_g = expected_value(theta - 3.0_dp*phi)
+    call write_config("mixed_readers.in")
+    call read_and_set_config("mixed_readers.in")
+    call check_manufactured_field("namelist mixed readers")
 
-    write (*, '(*(g0,1x))') 'NEORT_PERT_KERNEL', &
-        'theta', theta, 'phi_ccw', phi, 'amplitude_real_g', real(amplitude_g), &
-        'amplitude_imag_g', aimag(amplitude_g), 'full_field_g', full_field_g, &
-        'expected_plus_n_g', expected_g, 'wrong_minus_n_g', wrong_sign_g
-    if (abs(full_field_g - expected_g) > 1.0e-12_dp) then
-        error stop 'full perturbation field double-counts Fourier rows'
-    end if
+    config%s = 0.5_dp
+    config%inp_swi = 9
+    config%pertfile = .true.
+    call set_config(config)
+    call check_manufactured_field("legacy inherited reader")
+
+    call delete_file(fixture)
+    call delete_file("mixed_readers.in")
 
 contains
+
+    subroutine check_manufactured_field(label)
+        character(len=*), intent(in) :: label
+
+        call read_boozer_pert_file(fixture)
+        call init_magfie_pert_at_s()
+
+        x = [0.5_dp, phi, theta]
+        call do_magfie_pert_amp(x, amplitude_g)
+        call do_magfie_pert(x, full_field_g)
+        expected_g = expected_value(theta + 3.0_dp*phi)
+        wrong_sign_g = expected_value(theta - 3.0_dp*phi)
+
+        write (*, '(*(g0,1x))') 'NEORT_PERT_KERNEL', 'case', trim(label), &
+            'theta', theta, 'phi_ccw', phi, 'amplitude_real_g', real(amplitude_g), &
+            'amplitude_imag_g', aimag(amplitude_g), 'full_field_g', full_field_g, &
+            'expected_plus_n_g', expected_g, 'wrong_minus_n_g', wrong_sign_g
+        if (abs(full_field_g - expected_g) > 1.0e-12_dp) then
+            error stop 'perturbation reader does not reproduce the manufactured field'
+        end if
+    end subroutine check_manufactured_field
 
     real(dp) function expected_value(phase)
         real(dp), intent(in) :: phase
@@ -61,6 +77,33 @@ contains
         end do
         close (unit)
     end subroutine write_fixture
+
+    subroutine write_config(path)
+        character(len=*), intent(in) :: path
+
+        integer :: unit
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(a)') '&params'
+        write (unit, '(a)') '  s = 0.5'
+        write (unit, '(a)') '  qs = 1.0'
+        write (unit, '(a)') '  ms = 1.0'
+        write (unit, '(a)') '  mph = 3'
+        write (unit, '(a)') '  pertfile = .true.'
+        write (unit, '(a)') '  inp_swi = 10'
+        write (unit, '(a)') '  inp_swi_pert = 9'
+        write (unit, '(a)') '/'
+        close (unit)
+    end subroutine write_config
+
+    subroutine delete_file(path)
+        character(len=*), intent(in) :: path
+
+        integer :: unit
+
+        open (newunit=unit, file=path, status='old')
+        close (unit, status='delete')
+    end subroutine delete_file
 
     subroutine write_surface(unit, radial_coordinate)
         integer, intent(in) :: unit


### PR DESCRIPTION
## Summary

- add `inp_swi_pert` so the standalone equilibrium and perturbation files can select their formats independently
- retain legacy behavior by inheriting `inp_swi` when `inp_swi_pert` is negative
- reject unsupported perturbation `.bc` formats before the reader can use an undefined column layout
- extend the manufactured Fourier-field oracle to exercise both a chartmap-equilibrium/Strumberger-perturbation configuration and the inherited legacy configuration

This is an input-routing change only. It does not change orbit equations, radial normalization, Fourier signs, torque signs, or POTATO physics.

## Validation

Validated from exact commit `11ba86e5fa475003125f9186baa4d5470455b1c7` in a clean checkout on `faepkub4`:

- `git diff --check`
- `fo build`
- manufactured mixed-reader Fourier oracle: exact agreement with the analytic field
- `fo test --all`: 12/12 passed (Release)
- `fo build --debug` and `fo test --all`: 12/12 passed
- `make pytest`: 15/15 passed, including all golden-record cases

## Existing repository-tooling baseline

The aggregate `fo` command aborts before building because its static parser crashes on existing legacy fixed-form `write` statements. Running its build/test gates separately succeeds. `fo lint` completes and reports the existing two unused imports and 76 legacy warnings; none points to a line added by this PR.