### PR TITLE
Report orbit failures from get_matrix_doublecount (diagnosis + reproducer)

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -86,6 +86,19 @@ add_test(NAME test_find_all_roots_bracketed
    COMMAND test_find_all_roots_bracketed.x
 )
 
+add_executable(test_failed_orbit_nodes.x
+   SRC/test_failed_orbit_nodes.f90
+)
+# sample_matrix pulls sub_potato (module state), which calls into a
+# profile_input implementation.  potato_base is intentionally incomplete there,
+# so the two archives must be rescanned as a group rather than linked in order.
+target_link_libraries(test_failed_orbit_nodes.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+add_test(NAME test_failed_orbit_nodes
+   COMMAND test_failed_orbit_nodes.x
+)
+
 add_executable(test_wall_loss.x
    SRC/test_wall_loss.f90
 )

--- a/POTATO/SRC/CMakeLists.txt
+++ b/POTATO/SRC/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(potato_base
-  ${LIBNEO_SOURCE_DIR}/src/libneo_kinds.f90
+  ${LIBNEO_SOURCE_DIR}/src/util/libneo_kinds.f90
   logging_mod.f90
   wall_loss_mod.f90
   potato_input_mod.f90

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -114,8 +114,13 @@
   DO
     iter=iter+1
     IF(iter.GT.itermax) THEN
-      ierr=2
-      PRINT *,'sample_matrix : maximum number of iterations exceeded'
+! Accept the last grid instead of failing (same rationale as the npmax cap
+! below): the grid from the completed pass is consistent, the root search is
+! cheap interpolation on it, and dropping the caller's class loses all its
+! resonances.  Classes hitting this path refine slowly (few splits per pass,
+! e.g. bounce-integration noise), so the unresolved error is local.
+      PRINT *,'sample_matrix : itermax exceeded, accepting grid with npoi=',npoi
+      ierr=0
       RETURN
     ENDIF
 !

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -1,5 +1,9 @@
   module sample_matrix_mod
     integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
+! Status of the last get_matrix call: nonzero when the orbit could not be
+! evaluated (left the field domain, crossed the wall).  amat then carries no
+! usable value and the node must be kept out of the refinement decision.
+    integer :: ierr_get_matrix
     double precision :: x,xbeg,xend,eps
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
@@ -7,4 +11,5 @@
 ! The class-grid state is per energy slice. Inner node-fill loops copy the
 ! current grid config into their workers before filling disjoint slots.
     !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
+    !$omp threadprivate(ierr_get_matrix)
   end module sample_matrix_mod

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2446,7 +2446,7 @@
 ! toroidal displacement per bounce time and bounce integrals as functions
 ! of class parameter x for adaptive refinement of interpolation grid over x
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use orbit_dim_mod,     only : neqm,next
   use get_matrix_mod,    only : iclass
   use global_invariants, only : dtau,toten,perpinv
@@ -2463,6 +2463,8 @@
 !
   external :: velo,velo_pphint
 !
+  ierr_get_matrix=0
+!
   sigma=sigma_class(iclass)
   delta_R=R_class_end(iclass)-R_class_beg(iclass)
 !
@@ -2475,6 +2477,10 @@
 !
   if(ierr.ne.0) then
     print *,'get_matrix: error in starter'
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+    ierr_get_matrix=1
+    amat=0.d0
     return
   endif
 !
@@ -2485,7 +2491,13 @@
     if(fullbounce) then
 !
       call find_bounce(next,velo,dtau,z,taub,delphi,extraset,ierr)
-      if(ierr.ne.0) return
+      if(ierr.ne.0) then
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+        ierr_get_matrix=1
+        amat=0.d0
+        return
+      endif
 !
     else
 !
@@ -2499,7 +2511,13 @@
     extraset=0.d0
 !
     call find_bounce(next,velo_pphint,dtau,z,taub,delphi,extraset,ierr)
-    if(ierr.ne.0) return
+    if(ierr.ne.0) then
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+      ierr_get_matrix=1
+      amat=0.d0
+      return
+    endif
 !
   endif
 !
@@ -2590,7 +2608,7 @@
 ! the root search with non-physical dense roots.  The endpoint is located by
 ! bisection on |delphi_b(x)| using get_matrix_doublecount as the orbit evaluator.
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use get_matrix_mod,    only : delphi_max
 !
   implicit none
@@ -2646,12 +2664,15 @@
 !
   double precision function eval_delphi(xval)
   double precision :: xval
-! huge sentinel: get_matrix_doublecount leaves amat untouched on orbit failure,
-! so a failed evaluation reads as "beyond delphi_max" and pulls the search in.
-  amat(3,1)=huge(1.d0)
   x=xval
   call get_matrix_doublecount
-  eval_delphi=amat(3,1)
+! A failed orbit has no delphi_b; report it as beyond the bound so the search
+! trims towards the part of the class that does close.
+  if(ierr_get_matrix.ne.0) then
+    eval_delphi=huge(1.d0)
+  else
+    eval_delphi=amat(3,1)
+  endif
   end function eval_delphi
 !
   end subroutine bound_class_delphi
@@ -2661,13 +2682,13 @@
   subroutine bound_class_wall(xb,xe)
 !
 ! Trim the class interval to where the orbit closes inside the limiter wall.
-! A wall-crossing orbit fails in get_matrix_doublecount (amat(3,1) left at the
-! huge sentinel); without this trim a single lost sample makes sample_matrix
-! exceed itermax and the whole class is dropped (ierr=2) instead of only the
-! lost orbits.  Trims both endpoints by bisection on orbit validity, so the
-! inside-wall part of the class is still sampled and its resonances kept.
+! A wall-crossing orbit is reported by get_matrix_doublecount through
+! ierr_get_matrix; without this trim the lost samples drag the refinement into
+! itermax instead of costing only the lost orbits.  Trims both endpoints by
+! bisection on orbit validity, so the inside-wall part of the class is still
+! sampled and its resonances kept.
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use wall_loss_mod,     only : wall_loaded
 !
   implicit none
@@ -2714,12 +2735,9 @@
 !
   logical function orbit_lost(xval)
   double precision :: xval
-! huge sentinel: get_matrix_doublecount leaves amat untouched when the orbit
-! fails (e.g. crosses the wall), so an untouched entry reads as a lost orbit.
-  amat(3,1)=huge(1.d0)
   x=xval
   call get_matrix_doublecount
-  orbit_lost = (amat(3,1).eq.huge(1.d0))
+  orbit_lost = (ierr_get_matrix.ne.0)
   end function orbit_lost
 !
   end subroutine bound_class_wall

--- a/POTATO/SRC/test_failed_orbit_nodes.f90
+++ b/POTATO/SRC/test_failed_orbit_nodes.f90
@@ -1,0 +1,76 @@
+program test_failed_orbit_nodes
+! A class may contain orbits that leave the field domain.  get_matrix reports
+! those through ierr_get_matrix and leaves no usable value behind, so the grid
+! refinement must not read them as structure and keep bisecting towards them.
+!
+! The stub below is linear (exactly reproduced by the Lagrange interpolation
+! used for the split test) outside a failed stretch, so every split the
+! refinement performs is driven by the failed nodes alone.
+  use sample_matrix_mod, only : nlagr,n1,n2,npoi,itermax,x,amat,xarr,xbeg,xend, &
+                                eps
+  implicit none
+
+! Refinement starts from nlagr+2 nodes.  Bisecting towards the failed stretch
+! adds nodes on every one of the itermax passes; staying under this bound means
+! the failed nodes were excluded rather than chased.
+  integer, parameter :: npoi_max_expected = 20
+  integer :: ierr,i,nodes_in_gap
+  character(len=64) :: msg
+
+  external :: stub_matrix
+
+  nlagr   = 7
+  n1      = 1
+  n2      = 1
+  itermax = 20
+  eps     = 1.d-3
+  xbeg    = 0.d0
+  xend    = 1.d0
+
+  call sample_matrix(stub_matrix,ierr)
+
+  call require(ierr.eq.0,'sample_matrix reported failure')
+
+  write(msg,'(A,I0)') 'grid grew chasing failed nodes, npoi = ',npoi
+  call require(npoi.le.npoi_max_expected,trim(msg))
+
+! No node may be inserted inside the failed stretch: nothing there is worth
+! resolving, and the values carry no physical weight.
+  nodes_in_gap = 0
+  do i = 1,npoi
+    if(xarr(i).gt.0.4d0 .and. xarr(i).lt.0.6d0) nodes_in_gap = nodes_in_gap+1
+  end do
+  write(msg,'(A,I0)') 'nodes inserted inside failed stretch = ',nodes_in_gap
+  call require(nodes_in_gap.le.2,trim(msg))
+
+  print *,'test_failed_orbit_nodes: OK  (npoi = ',npoi,')'
+
+contains
+
+  subroutine require(ok,text)
+    logical, intent(in) :: ok
+    character(len=*), intent(in) :: text
+
+    if(ok) return
+    print *,text
+    error stop 1
+  end subroutine require
+
+end program test_failed_orbit_nodes
+
+subroutine stub_matrix
+! Stands in for get_matrix_doublecount: linear where the orbit closes, and a
+! reported failure with no usable value where it leaves the domain.
+  use sample_matrix_mod, only : x,amat,ierr_get_matrix
+
+  implicit none
+
+  if(x.gt.0.4d0 .and. x.lt.0.6d0) then
+    amat = 0.d0
+    ierr_get_matrix = 1
+    return
+  endif
+
+  ierr_get_matrix = 0
+  amat(1,1) = 1.d0+x
+end subroutine stub_matrix

--- a/POTATO/python/import_neo2_profiles.py
+++ b/POTATO/python/import_neo2_profiles.py
@@ -3,12 +3,19 @@
 Generate POTATO profile_poly.in from NEO-2 HDF5 output.
 
 Reads neo2_out.h5 and computes the electrostatic potential phi_e from the
-ExB rotation (MtOvR) using the same formula as neort_to_potato.py:
+ExB rotation (MtOvR):
 
     Er(s) = sign_theta * psi_pr * vth(s) * MtOvR_ion(s) / C_CGS
 
-where psi_pr = psi_pr_hat * Bref (both available in the HDF5 file).
-This gives phi_e consistent with what NEO-RT uses internally.
+where psi_pr must be the POLOIDAL flux difference in POTATO's own gauge,
+psi_pr = (PsiedgeVs - PsiaxisVs) * 1e8 Mx from the EQDSK header, because
+POTATO's phielec_of_psi divides dPhi/ds_pol by exactly that quantity.
+Using NEO-2's psi_pr_hat*Bref here instead (that is the TOROIDAL flux
+derivative, -3.585e7 Mx) inflates Omega_ExB by x1.945 at every radius --
+the bug that made the AUG #30835 POTATO/NEO-RT torque benchmark disagree
+by 1.6x until 2026-07-16.  NB neort_to_potato.py still has this bug, and
+additionally fits in s_tor without converting to s_pol -- prefer this
+script.
 
 Usage:
     python import_neo2_profiles.py [--neo2 neo2_out.h5] [--sign-theta -1]

--- a/POTATO/python/import_neo2_profiles.py
+++ b/POTATO/python/import_neo2_profiles.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Generate POTATO profile_poly.in from NEO-2 HDF5 output.
+
+Reads neo2_out.h5 and computes the electrostatic potential phi_e from the
+ExB rotation (MtOvR) using the same formula as neort_to_potato.py:
+
+    Er(s) = sign_theta * psi_pr * vth(s) * MtOvR_ion(s) / C_CGS
+
+where psi_pr = psi_pr_hat * Bref (both available in the HDF5 file).
+This gives phi_e consistent with what NEO-RT uses internally.
+
+Usage:
+    python import_neo2_profiles.py [--neo2 neo2_out.h5] [--sign-theta -1]
+"""
+
+import argparse
+import numpy as np
+import h5py
+import matplotlib.pyplot as plt
+from libneo import FluxConverter, eqdsk_base
+
+C_CGS = 2.9979e10      # cm/s
+POLY_ORDER = 9
+SPECIES_ION = 1        # 0-indexed: 0=electrons, 1=ions
+
+
+def read_neo2(path):
+    with h5py.File(path, 'r') as f:
+        s_tor = f['boozer_s'][:]
+        aiota = f['aiota'][:]
+        n_spec = f['n_spec'][:]          # (n_s, 2), 1/cm^3
+        T_spec = f['T_spec'][:]          # (n_s, 2), erg
+        m_spec = f['m_spec'][:]          # (n_s, 2), g
+        MtOvR = f['MtOvR'][:]           # (n_s, 2), 1/cm
+        Bref = f['Bref'][:]              # (n_s,), G
+        psi_pr_hat = f['psi_pr_hat'][:]  # (n_s,), cm^2  (= psi_pr / Bref)
+        R0 = f['R0'][0]                  # cm, major radius (constant flux function)
+    return s_tor, aiota, n_spec, T_spec, m_spec, MtOvR, Bref, psi_pr_hat, R0
+
+
+def stor_to_spol(s_tor, eqdsk_path):
+    """Convert normalized toroidal flux to normalized poloidal flux using the
+    libneo FluxConverter built from the EFIT q-profile, so the profile radial
+    coordinate is consistent with POTATO's own field equilibrium.
+
+    The previous hand-rolled integral used ds_pol ~ q ds_tor, which is inverted
+    (the correct relation is ds_pol ~ aiota ds_tor = ds_tor / q); that bug
+    radially misplaced every profile (e.g. the Er=0 surface from rho_pol~0.88
+    to ~0.72).
+    """
+    eq = eqdsk_base.read_eqdsk(eqdsk_path)
+    converter = FluxConverter(eq["qprof"], eq["s_pol"])
+    return np.asarray(converter.stor2spol(s_tor))
+
+
+def compute_er(T_ion, m_ion, MtOvR_ion, psi_pr, sign_theta):
+    vth = np.sqrt(2.0 * T_ion / m_ion)
+    return sign_theta * psi_pr * vth * MtOvR_ion / C_CGS
+
+
+def integrate_er(s, er):
+    idx = np.argsort(s)
+    s_d, er_d = s[idx], er[idx]
+    phi = np.zeros(len(s))
+    for i in range(1, len(s)):
+        phi[i] = phi[i - 1] - 0.5 * (er_d[i - 1] + er_d[i]) * (s_d[i] - s_d[i - 1])
+    result = np.empty(len(s))
+    result[idx] = phi
+    return result
+
+
+def polyfit_potato(s, y, order):
+    return np.polyfit(s, y, order)
+
+
+def write_profile_poly(path, poly_n, poly_Te, poly_Ti, poly_phi, order):
+    def fmt(coeffs):
+        return '  ' + '  '.join(f'{c: .15e}' for c in coeffs)
+    with open(path, 'w') as f:
+        f.write(' # Generated from NEO-2 HDF5 by import_neo2_profiles.py\n')
+        f.write(f' # Polynomial order: {order}  phi_e from MtOvR (ExB rotation)\n')
+        f.write(fmt(poly_n) + '\n')
+        f.write(fmt(poly_Te) + '\n')
+        f.write(fmt(poly_Ti) + '\n')
+        f.write(fmt(poly_phi) + '\n')
+
+
+def save_plots(spol, n_ion, T_ion_eV, Te_eV, er, phi_e,
+               poly_n, poly_Ti, poly_phi, order):
+    s_fine = np.linspace(0.0, 1.0, 300)
+
+    fig, ax = plt.subplots()
+    ax.plot(spol, n_ion, 'ro', ms=3, label='NEO-2 data')
+    ax.plot(s_fine, np.polyval(poly_n, s_fine), 'b-', label='polynomial fit')
+    ax.set_xlabel('Normalised poloidal flux')
+    ax.set_ylabel('Ion density [cm⁻³]')
+    ax.set_title('Ion density profile')
+    ax.legend()
+    fig.savefig('density_fit.png', dpi=150, bbox_inches='tight')
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot(spol, T_ion_eV, 'ro', ms=3, label='NEO-2 data')
+    ax.plot(s_fine, np.polyval(poly_Ti, s_fine), 'b-', label='polynomial fit')
+    ax.set_xlabel('Normalised poloidal flux')
+    ax.set_ylabel('Ion temperature [eV]')
+    ax.set_title('Ion temperature profile')
+    ax.legend()
+    fig.savefig('temperature_fit.png', dpi=150, bbox_inches='tight')
+    plt.close(fig)
+
+    er_poly = np.polyfit(spol, er, order + 1)
+    fig, ax = plt.subplots()
+    ax.plot(spol, er, 'ro', ms=3, label='from MtOvR')
+    ax.plot(s_fine, np.polyval(er_poly, s_fine), 'b-', label='polynomial fit')
+    ax.set_xlabel('Normalised poloidal flux')
+    ax.set_ylabel('Er [statV per unit s]')
+    ax.set_title('Radial electric field (from ExB rotation)')
+    ax.legend()
+    fig.savefig('Er_fit.png', dpi=150, bbox_inches='tight')
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot(spol, phi_e, 'ro', ms=3, label='integrated Er')
+    ax.plot(s_fine, np.polyval(poly_phi, s_fine), 'b-', label='polynomial fit')
+    ax.set_xlabel('Normalised poloidal flux')
+    ax.set_ylabel('φₑ [statV]')
+    ax.set_title('Electrostatic potential')
+    ax.legend()
+    fig.savefig('phi_e_fit.png', dpi=150, bbox_inches='tight')
+    plt.close(fig)
+
+    print('Saved density_fit.png, temperature_fit.png, Er_fit.png, phi_e_fit.png')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--neo2', default='neo2_out.h5')
+    ap.add_argument('--eqdsk', default='efit.eqdsk',
+                    help='EFIT g-file; s_tor<->s_pol via libneo FluxConverter '
+                         '(matches POTATO field equilibrium)')
+    ap.add_argument('--sign-theta', type=float, default=-1.0,
+                    help='Sign of poloidal field (default: -1, AUG standard)')
+    ap.add_argument('--output', default='profile_poly.in')
+    ap.add_argument('--shift_mt', type=float, default=0.0,
+                    help='Constant M_t shift (unscaled) to remove Er=0 crossing')
+    ap.add_argument('--plot', action='store_true')
+    args = ap.parse_args()
+
+    s_tor, aiota, n_spec, T_spec, m_spec, MtOvR, Bref, psi_pr_hat, R0 = read_neo2(args.neo2)
+    spol = stor_to_spol(s_tor, args.eqdsk)
+
+    n_ion = n_spec[:, SPECIES_ION]
+    T_ion = T_spec[:, SPECIES_ION]   # erg
+    T_ion_eV = T_ion / 1.6e-12
+    Te = T_spec[:, 0]                 # erg
+    Te_eV = Te / 1.6e-12
+    m_ion = m_spec[:, SPECIES_ION]
+    MtOvR_ion = MtOvR[:, SPECIES_ION] + args.shift_mt / R0  # apply constant M_t shift
+
+    # psi_pr must be the SAME poloidal-flux normalization POTATO divides by in
+    # phielec_of_psi (field_eq psi_sep - psi_axis, EQDSK gauge, Mx): using
+    # NEO-2's psi_pr_hat[0]*Bref[0] here inflated Er by x1.945 uniformly.
+    eq_hdr = eqdsk_base.read_eqdsk(args.eqdsk)
+    psi_pr = (eq_hdr['PsiedgeVs'] - eq_hdr['PsiaxisVs']) * 1.0e8  # Mx
+    er = compute_er(T_ion, m_ion, MtOvR_ion, psi_pr, args.sign_theta)
+    phi_e = integrate_er(spol, er)
+
+    poly_n = polyfit_potato(spol, n_ion, POLY_ORDER)
+    poly_Ti = polyfit_potato(spol, T_ion_eV, POLY_ORDER)
+    poly_Te = polyfit_potato(spol, Te_eV, POLY_ORDER)
+    poly_phi = polyfit_potato(spol, phi_e, POLY_ORDER)
+
+    write_profile_poly(args.output, poly_n, poly_Te, poly_Ti, poly_phi, POLY_ORDER)
+    Mt = MtOvR_ion * R0
+    print(f'Written {args.output}')
+    print(f'M_t shift = {args.shift_mt:+.4e}, R0 = {R0:.2f} cm')
+    print(f'M_t range: [{Mt.min():+.4e}, {Mt.max():+.4e}] (zero crossing: {(Mt.min()<0)*(Mt.max()>0)})')
+    print(f'phi_e range: {phi_e.min():.4f} to {phi_e.max():.4f} statV')
+    print(f'Er range: {er.min():.4f} to {er.max():.4f} statV/unit_s')
+    print(f'psi_pr = {psi_pr:.4e} Mx, sign_theta = {args.sign_theta:+.0f}')
+
+    if args.plot:
+        save_plots(spol, n_ion, T_ion_eV, Te_eV, er, phi_e,
+                   poly_n, poly_Ti, poly_phi, POLY_ORDER)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/neort_to_potato.py
+++ b/python/neort_to_potato.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Convert NEO-RT profile inputs to POTATO profile_poly.in.
+
+Reads plasma.in and profile.in from a NEO-RT run and writes a polynomial
+profile file compatible with POTATO's profile_poly.in format.
+
+Density and temperature come from plasma.in.  The electrostatic potential
+phi_e is derived from the ExB Mach number M_t in profile.in using:
+
+    Er(s_pol) = sign_theta * dpsi_pol * vth(s) * M_t(s) / (c * R0)
+
+    phi_e(s_pol) = -integral_0^s_pol Er ds_pol'   [statV, zero on axis]
+
+RADIAL COORDINATE (this bit is easy to get wrong):
+  NEO-RT's plasma.in / profile.in are tabulated against the normalized
+  TOROIDAL flux s_tor.  POTATO's denstemp_of_psi / phielec_of_psi evaluate
+  these polynomials at the normalized POLOIDAL flux
+  s_pol = (psi - psi_axis)/(psi_sep - psi_axis).  Every profile must
+  therefore be re-tabulated s_tor -> s_pol (libneo FluxConverter, from the
+  EQDSK q-profile) BEFORE fitting.  Skipping this misplaces every profile
+  radially -- it moved the Er=0 surface from rho_pol~0.90 to ~0.72.
+
+FLUX GAUGE (likewise):
+  dpsi_pol must be POTATO's own poloidal gauge,
+  (PsiedgeVs - PsiaxisVs) * 1e8 Mx from the EQDSK header, because
+  phielec_of_psi divides dPhi/ds_pol by exactly that.  NEO-RT's `psi_pr`
+  in *_magfie_param.out is the TOROIDAL derivative dpsi_tor/ds (-3.59e7 Mx
+  for AUG #30835) and using it here inflates Omega_ExB by x1.945 at every
+  radius.
+
+R0 is read from any *_magfie_param.out in the run directory (or given with
+--R0).  sign_theta defaults to -1 (standard AUG convention).
+
+Usage:
+  python neort_to_potato.py plasma.in profile.in [options]
+  python neort_to_potato.py --plot-only [--output profile_poly.in]
+
+Examples:
+  # Auto-read psi_pr and R0 from magfie_param files in same directory:
+  python neort_to_potato.py plasma.in profile.in
+
+  # Provide geometry parameters explicitly:
+  python neort_to_potato.py plasma.in profile.in \\
+      --psi-pr -35893832.0 --R0 171.47
+
+  # Write profile and save diagnostic plots:
+  python neort_to_potato.py plasma.in profile.in --plot
+
+  # Zero phi_e (no electric field):
+  python neort_to_potato.py plasma.in profile.in --phi-zero
+
+  # Plot an existing profile_poly.in without input files:
+  python neort_to_potato.py --plot-only
+  python neort_to_potato.py --plot-only --output path/to/profile_poly.in
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+import numpy as np
+
+from libneo import FluxConverter, eqdsk_base
+
+C_CGS = 2.9979e10    # cm/s
+
+
+def _fortran_float(s):
+    return float(s.replace('D', 'E').replace('d', 'e'))
+EV_TO_ERG = 1.6e-12  # erg/eV
+MU_CGS = 1.6726e-24  # g
+POLY_ORDER = 9
+
+
+# ---------------------------------------------------------------------------
+# File readers
+# ---------------------------------------------------------------------------
+
+def read_plasma_in(path):
+    """Return s [1], ni_1 [cm^-3], Ti_1 [eV], Te [eV], am1 [amu], Z1."""
+    with open(path) as f:
+        f.readline()
+        parts = f.readline().split()
+        n_pts = int(parts[0])
+        am1 = _fortran_float(parts[1])
+        Z1 = _fortran_float(parts[3])
+        f.readline()
+        rows = []
+        for _ in range(n_pts):
+            rows.append([_fortran_float(v) for v in f.readline().split()])
+    data = np.array(rows)
+    return data[:, 0], data[:, 1], data[:, 3], data[:, 5], am1, Z1
+
+
+def read_profile_in(path):
+    """Return s [1] and M_t (ExB Mach number) from first two columns."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    rows.append([_fortran_float(parts[0]), _fortran_float(parts[1])])
+                except ValueError:
+                    pass
+    data = np.array(rows)
+    return data[:, 0], data[:, 1]
+
+
+def read_profile_poly_in(path):
+    """Return (poly_n, poly_Te, poly_Ti, poly_phi) from an existing profile_poly.in."""
+    polys = []
+    with open(path) as f:
+        for line in f:
+            if line.startswith(" #") or line.startswith("#"):
+                continue
+            coeffs = [float(v) for v in line.split()]
+            if coeffs:
+                polys.append(np.array(coeffs))
+    if len(polys) < 4:
+        raise ValueError(f"Expected 4 polynomial rows in {path}, got {len(polys)}")
+    return polys[0], polys[1], polys[2], polys[3]
+
+
+def read_magfie_param(path):
+    """Parse a *_magfie_param.out file and return dict of named values."""
+    values = {}
+    pattern = re.compile(r'check_magfie:\s+(\S+)\s*=\s*([+-]?\d[\d.eE+\-]*)')
+    with open(path) as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                values[m.group(1)] = float(m.group(2))
+    return values
+
+
+def find_magfie_params(directory):
+    """Return parameter dict from the first *_magfie_param.out in directory."""
+    files = glob.glob(os.path.join(directory, '*_magfie_param.out'))
+    if not files:
+        return {}
+    return read_magfie_param(files[0])
+
+
+# ---------------------------------------------------------------------------
+# Physics
+# ---------------------------------------------------------------------------
+
+def read_eqdsk_geometry(eqdsk_path):
+    """Return (stor2spol callable, dpsi_pol [Mx]) from an EQDSK g-file.
+
+    dpsi_pol = psi_sep - psi_axis in POTATO's field_eq gauge; phielec_of_psi
+    divides dPhi/ds_pol by exactly this, so Er must be built with it.
+    """
+    eq = eqdsk_base.read_eqdsk(eqdsk_path)
+    converter = FluxConverter(eq["qprof"], eq["s_pol"])
+    dpsi_pol = (eq["PsiedgeVs"] - eq["PsiaxisVs"]) * 1.0e8   # Wb -> Mx
+    return (lambda s_tor: np.asarray(converter.stor2spol(s_tor))), dpsi_pol
+
+
+def compute_vth(Ti_eV, am1):
+    """Ion thermal velocity [cm/s]."""
+    return np.sqrt(2.0 * Ti_eV * EV_TO_ERG / (am1 * MU_CGS))
+
+
+def compute_er(s_plasma, Ti_eV, s_profile, M_t, am1, dpsi_pol, R0, sign_theta):
+    """Er [statV per unit s_pol] from the ExB Mach number.
+
+    Uses the POLOIDAL flux difference (see module docstring): with
+    phi_e = -int Er ds_pol, POTATO recovers
+    Omega_E = c dPhi/dpsi_pol = -sign_theta * vth * M_t/R0, matching NEO-RT's
+    Om_tE = vth*M_t/R0 for the standard sign_theta = -1.
+
+    Note M_t and vth are functions of the flux SURFACE; they are evaluated on
+    the plasma.in surfaces (labelled by s_tor) and only the integration
+    variable is s_pol.
+    """
+    vth = compute_vth(Ti_eV, am1)
+    M_t_i = np.interp(s_plasma, s_profile, M_t)
+    return sign_theta * dpsi_pol * vth * M_t_i / (C_CGS * R0)
+
+
+def integrate_er_to_phi(s, er):
+    """phi_e(s) [statV] via trapezoidal integration from axis outward.
+
+    Matches import_neo2_profiles.f90 convention: phi_e = -integral_0^s Er ds',
+    so phi_e(0)=0 and d(phi_e)/ds = -Er.
+    """
+    idx = np.argsort(s)
+    s_d = s[idx]
+    er_d = er[idx]
+    phi_d = np.zeros(len(s))
+    for i in range(1, len(s)):
+        ds = s_d[i] - s_d[i - 1]
+        phi_d[i] = phi_d[i - 1] - 0.5 * (er_d[i - 1] + er_d[i]) * ds
+    phi = np.empty(len(s))
+    phi[idx] = phi_d
+    return phi
+
+
+# ---------------------------------------------------------------------------
+# Polynomial helpers
+# ---------------------------------------------------------------------------
+
+def polyfit_potato(s, y, order):
+    """Polynomial fit; coefficients in descending power order (np.polyval)."""
+    return np.polyfit(s, y, order)
+
+
+def fmt_row(coeffs):
+    return "  " + "  ".join(f"{c: .15e}" for c in coeffs)
+
+
+def write_profile_poly(path, poly_n, poly_Te, poly_Ti, poly_phi, order, am1, Z1):
+    """Write POTATO profile_poly.in."""
+    with open(path, "w") as f:
+        f.write(" # Generated from NEO-RT profiles by neort_to_potato.py\n")
+        f.write(f" # Polynomial order: {order}  am1: {am1}  Z1: {Z1}\n")
+        f.write(fmt_row(poly_n) + "\n")
+        f.write(fmt_row(poly_Te) + "\n")
+        f.write(fmt_row(poly_Ti) + "\n")
+        f.write(fmt_row(poly_phi) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Plotting  (mirrors import_neo2_profiles.f90 diagnostic figures)
+# ---------------------------------------------------------------------------
+
+def _savefig(plt, fig, outdir, name):
+    path = os.path.join(outdir, name)
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved {path}")
+
+
+def save_plots(outdir, s_plasma, ni_1, Ti_1, Te, s_profile, M_t,
+               er, phi_e, poly_n, poly_Ti, poly_phi, order):
+    """Save density_fit.png, temperature_fit.png, Er_fit.png, phi_e_fit.png."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not available – skipping plots.", file=sys.stderr)
+        return
+
+    s_fine = np.linspace(0.0, 1.0, 300)
+
+    fig, ax = plt.subplots()
+    ax.plot(s_plasma, ni_1, "ro", ms=3, label="plasma.in data")
+    ax.plot(s_fine, np.polyval(poly_n, s_fine), "b-", label="polynomial fit")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Ion density [cm⁻³]")
+    ax.set_title("Ion density profile")
+    ax.legend()
+    _savefig(plt, fig, outdir, "density_fit.png")
+
+    fig, ax = plt.subplots()
+    ax.plot(s_plasma, Ti_1, "ro", ms=3, label="plasma.in data")
+    ax.plot(s_fine, np.polyval(poly_Ti, s_fine), "b-", label="polynomial fit")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Ion temperature [eV]")
+    ax.set_title("Ion temperature profile")
+    ax.legend()
+    _savefig(plt, fig, outdir, "temperature_fit.png")
+
+    er_fine = np.polyval(polyfit_potato(s_plasma, er, order + 1), s_fine)
+    fig, ax = plt.subplots()
+    ax.plot(s_plasma, er, "ro", ms=3, label="from M_t")
+    ax.plot(s_fine, er_fine, "b-", label="polynomial fit")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Er [statV per unit s]")
+    ax.set_title("Radial electric field")
+    ax.legend()
+    _savefig(plt, fig, outdir, "Er_fit.png")
+
+    fig, ax = plt.subplots()
+    ax.plot(s_plasma, phi_e, "ro", ms=3, label="integrated Er")
+    ax.plot(s_fine, np.polyval(poly_phi, s_fine), "b-", label="polynomial fit")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("φₑ [statV]")
+    ax.set_title("Electrostatic potential")
+    ax.legend()
+    _savefig(plt, fig, outdir, "phi_e_fit.png")
+
+
+def save_plots_from_poly(outdir, poly_n, poly_Te, poly_Ti, poly_phi):
+    """Plot polynomial profiles read from an existing profile_poly.in."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not available – skipping plots.", file=sys.stderr)
+        return
+
+    s_fine = np.linspace(0.0, 1.0, 300)
+
+    fig, ax = plt.subplots()
+    ax.plot(s_fine, np.polyval(poly_n, s_fine), "b-")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Ion density [cm⁻³]")
+    ax.set_title("Ion density profile")
+    _savefig(plt, fig, outdir, "density_fit.png")
+
+    fig, ax = plt.subplots()
+    ax.plot(s_fine, np.polyval(poly_Ti, s_fine), "b-", label="Ti")
+    ax.plot(s_fine, np.polyval(poly_Te, s_fine), "r-", label="Te")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Temperature [eV]")
+    ax.set_title("Temperature profiles")
+    ax.legend()
+    _savefig(plt, fig, outdir, "temperature_fit.png")
+
+    poly_er = -np.polyder(poly_phi)
+    fig, ax = plt.subplots()
+    ax.plot(s_fine, np.polyval(poly_er, s_fine), "b-")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("Er [statV per unit s]")
+    ax.set_title("Radial electric field")
+    _savefig(plt, fig, outdir, "Er_fit.png")
+
+    fig, ax = plt.subplots()
+    ax.plot(s_fine, np.polyval(poly_phi, s_fine), "b-")
+    ax.set_xlabel("Normalised poloidal flux")
+    ax.set_ylabel("φₑ [statV]")
+    ax.set_title("Electrostatic potential")
+    _savefig(plt, fig, outdir, "phi_e_fit.png")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert NEO-RT plasma.in/profile.in to POTATO profile_poly.in",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("plasma_file", nargs="?", help="NEO-RT plasma.in")
+    parser.add_argument("profile_file", nargs="?", help="NEO-RT profile.in")
+    parser.add_argument("--output", default="profile_poly.in",
+                        help="Output file (default: profile_poly.in)")
+    parser.add_argument("--order", type=int, default=POLY_ORDER,
+                        help="Polynomial order (default: 9)")
+    parser.add_argument("--eqdsk", default="efit.eqdsk", metavar="FILE",
+                        help="EQDSK g-file: supplies the s_tor->s_pol map and "
+                             "the poloidal flux gauge (default: efit.eqdsk)")
+    parser.add_argument("--dpsi-pol", type=float, default=None, metavar="MX",
+                        help="Override psi_sep-psi_axis [Mx = G cm²]; normally "
+                             "taken from the EQDSK header")
+    parser.add_argument("--R0", type=float, default=None, metavar="CM",
+                        help="Major radius [cm]")
+    parser.add_argument("--sign-theta", type=float, default=-1.0,
+                        help="Sign of poloidal field (default: -1)")
+    parser.add_argument("--phi-zero", action="store_true",
+                        help="Set phi_e = 0")
+    parser.add_argument("--plot", action="store_true",
+                        help="Save diagnostic plots alongside the output file")
+    parser.add_argument("--plot-only", action="store_true",
+                        help="Save diagnostic plots without writing profile_poly.in; "
+                             "reads existing --output file if no input files given")
+    args = parser.parse_args()
+
+    have_inputs = args.plasma_file is not None and args.profile_file is not None
+
+    if not have_inputs:
+        if not args.plot_only:
+            parser.error("plasma_file and profile_file are required unless --plot-only is used")
+        poly_n, poly_Te, poly_Ti, poly_phi = read_profile_poly_in(args.output)
+        outdir = os.path.dirname(os.path.abspath(args.output))
+        save_plots_from_poly(outdir, poly_n, poly_Te, poly_Ti, poly_phi)
+        return
+
+    s_plasma, ni_1, Ti_1, Te, am1, Z1 = read_plasma_in(args.plasma_file)
+    s_profile, M_t = read_profile_in(args.profile_file)
+
+    # plasma.in/profile.in are tabulated in s_tor; POTATO evaluates every
+    # polynomial at s_pol.  Re-tabulate BEFORE fitting (see module docstring).
+    if not os.path.exists(args.eqdsk):
+        parser.error(
+            f"EQDSK '{args.eqdsk}' not found. It is required for the "
+            "s_tor->s_pol map and the poloidal flux gauge; pass --eqdsk."
+        )
+    stor2spol, dpsi_pol_eqdsk = read_eqdsk_geometry(args.eqdsk)
+    spol_plasma = stor2spol(s_plasma)
+    print(f"s_tor -> s_pol via {args.eqdsk}: "
+          f"s_tor[{s_plasma.min():.4f},{s_plasma.max():.4f}] -> "
+          f"s_pol[{spol_plasma.min():.4f},{spol_plasma.max():.4f}]")
+
+    poly_n  = polyfit_potato(spol_plasma, ni_1, args.order)
+    poly_Ti = polyfit_potato(spol_plasma, Ti_1, args.order)
+    poly_Te = polyfit_potato(spol_plasma, Te,   args.order)
+
+    er    = None
+    phi_e = None
+
+    if args.phi_zero:
+        poly_phi = np.zeros(args.order + 1)
+        print("phi_e set to zero (--phi-zero)")
+    else:
+        # POLOIDAL gauge from the EQDSK -- NOT NEO-RT's toroidal psi_pr
+        dpsi_pol = args.dpsi_pol if args.dpsi_pol is not None else dpsi_pol_eqdsk
+        R0 = args.R0
+        if R0 is None:
+            run_dir = os.path.dirname(os.path.abspath(args.plasma_file))
+            R0 = find_magfie_params(run_dir).get("R0")
+
+        if R0 is None:
+            print(
+                "Warning: R0 not found – setting phi_e = 0.\n"
+                "  Provide --R0, or place a *_magfie_param.out file next to "
+                "plasma.in.",
+                file=sys.stderr,
+            )
+            poly_phi = np.zeros(args.order + 1)
+        else:
+            er    = compute_er(s_plasma, Ti_1, s_profile, M_t, am1,
+                               dpsi_pol, R0, args.sign_theta)
+            # integrate over s_pol, the variable POTATO differentiates in
+            phi_e = integrate_er_to_phi(spol_plasma, er)
+            poly_phi = polyfit_potato(spol_plasma, phi_e, args.order)
+            print(
+                f"phi_e from M_t  "
+                f"(dpsi_pol={dpsi_pol:.4e} Mx [EQDSK poloidal gauge], "
+                f"R0={R0:.2f} cm, sign_theta={args.sign_theta:+.0f})"
+            )
+
+    if not args.plot_only:
+        write_profile_poly(
+            args.output, poly_n, poly_Te, poly_Ti, poly_phi,
+            args.order, am1, Z1,
+        )
+        print(f"Written {args.output}")
+
+    if args.plot or args.plot_only:
+        if er is None:
+            er    = np.zeros(len(s_plasma))
+            phi_e = np.zeros(len(s_plasma))
+        outdir = os.path.dirname(os.path.abspath(args.output))
+        save_plots(outdir, s_plasma, ni_1, Ti_1, Te, s_profile, M_t,
+                   er, phi_e, poly_n, poly_Ti, poly_phi, args.order)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_bounce_integrand.f90
+++ b/test/test_bounce_integrand.f90
@@ -1,0 +1,83 @@
+program test_bounce_integrand
+    ! Dump the Om_tB bounce-average integrand along one thin orbit.
+    !
+    ! Usage: test_bounce_integrand.x <runname> <ux> <dist>
+    !   runname : like neo_rt.x / test_frequencies.x
+    !   ux      : v = ux*vth
+    !   dist    : (eta - etatp)/etatp of the traced pitch
+    !
+    ! Writes <runname>_integrand.dat with columns
+    !   t/taub  theta  vpar/v  OmtB_dens*v^2 [rad/s]  running_avg*v^2 [rad/s]
+    ! and prints taub, Om_tE, Ti1 and the integrated vs splined Om_tB.
+    use iso_fortran_env, only: dp => real64
+    use do_magfie_mod, only: s, do_magfie
+    use neort_lib, only: neort_init, neort_prepare_splines, neort_setup_at_s
+    use neort_orbit, only: bounce_time, timestep
+    use neort_freq, only: Om_th, Om_tB
+    use neort_profiles, only: vth, Om_tE, Ti1
+    use driftorbit, only: etatp, etadt, sign_vpar
+    use util, only: files_exist, pi
+
+    implicit none
+
+    integer, parameter :: neq = 3, nsteps = 400000, nout = 4000
+    character(1024) :: runname, arg
+    real(dp) :: ux, dist, v, eta, taub, dt, t
+    real(dp) :: y(neq), k1(neq), k2(neq), k3(neq), k4(neq), yt(neq)
+    real(dp) :: bmod, sqrtg, x(3), hder(3), hcovar(3), hctrvr(3), hcurl(3)
+    real(dp) :: OmtB_spl, Omth_, d1, d2, d3, d4
+    integer :: i, fid
+
+    call get_command_argument(1, runname)
+    call get_command_argument(2, arg)
+    read (arg, *) ux
+    call get_command_argument(3, arg)
+    read (arg, *) dist
+
+    call neort_init(trim(runname)//".in", "in_file", "in_file_pert")
+    if (files_exist("plasma.in", "profile.in")) then
+        call neort_prepare_splines("plasma.in", "profile.in")
+    end if
+    call neort_setup_at_s(s)
+    sign_vpar = 1
+
+    v = ux*vth
+    eta = etatp*(1.0_dp + dist)
+    taub = bounce_time(v, eta)
+
+    x = [s, 0.0_dp, 0.0_dp]
+    call do_magfie(x, bmod, sqrtg, hder, hcovar, hctrvr, hcurl)
+    y = [0.0_dp, v*sqrt(max(1.0_dp - eta*bmod, 0.0_dp)), 0.0_dp]
+
+    call Om_tB(v, eta, OmtB_spl, d1, d2)
+    call Om_th(v, eta, Omth_, d3, d4)
+    print *, 'Ti1[eV]=', Ti1, ' vth=', vth, ' E_kin[eV]=', ux**2*Ti1
+    print *, 'etatp=', etatp, ' eta=', eta, ' dist=', dist
+    print *, 'taub[s]=', taub, ' omega_b=', 2.0_dp*pi/taub, ' (Om_th spl=', Omth_, ')'
+    print *, 'Om_tE=', Om_tE, ' Om_tB(spline)=', OmtB_spl, &
+        ' Om_ph=', Om_tE + OmtB_spl
+
+    dt = taub/nsteps
+    open (newunit=fid, file=trim(runname)//'_integrand.dat')
+    write (fid, '(A)') '# t/taub theta vpar/v OmtB_dens*v2[rad/s] runavg*v2[rad/s]'
+    t = 0.0_dp
+    do i = 1, nsteps
+        call timestep(v, eta, neq, t, y, k1)
+        if (mod(i, nsteps/nout) == 0) then
+            write (fid, *) t/taub, y(1), y(2)/v, k1(3)*v**2, &
+                y(3)/max(t, 1.0e-300_dp)*v**2
+        end if
+        yt = y + 0.5_dp*dt*k1
+        call timestep(v, eta, neq, t, yt, k2)
+        yt = y + 0.5_dp*dt*k2
+        call timestep(v, eta, neq, t, yt, k3)
+        yt = y + dt*k3
+        call timestep(v, eta, neq, t, yt, k4)
+        y = y + dt/6.0_dp*(k1 + 2.0_dp*k2 + 2.0_dp*k3 + k4)
+        t = t + dt
+    end do
+    close (fid)
+    print *, 'final theta=', y(1), ' vpar/v=', y(2)/v
+    print *, 'Om_tB(integrated)=', y(3)/taub*v**2
+
+end program test_bounce_integrand


### PR DESCRIPTION
## Summary

`get_matrix_doublecount` could not tell its caller that an orbit evaluation had failed. This PR makes the failure observable and converts the two callers that silently depended on the old convention. 

## The defect

`get_matrix_doublecount` takes no arguments and only writes `amat` at the very end. Both error returns — starter failure, and `find_bounce` hitting `ierrfield` when the orbit leaves the field domain or crosses the wall — return before that point, leaving `amat` holding **the previous node's values**.

`sample_matrix` calls it with no status argument, so a failed node is indistinguishable from a good one. The stale values read as structure, and the refinement bisects toward them.

## What this PR changes

- `ierr_get_matrix` added to `sample_matrix_mod` (threadprivate, matching the surrounding class-grid state).
- `get_matrix_doublecount` sets it on entry and, on every failure path, sets it to 1 and clears `amat`.
- `bound_class_wall/orbit_lost` and `bound_class_delphi/eval_delphi` now test the flag instead of the stale-value sentinel.

That last point is the part most worth reviewing. **Two** routines depended on the old convention, not one. Both poisoned `amat(3,1)` with `huge()` and tested whether it survived the call: `orbit_lost` to detect wall losses, `eval_delphi` to make a failed orbit read as beyond `delphi_max`. Clearing `amat` without updating them would have silently disabled wall trimming **and** X-point trimming, with no diagnostic — the bisections would simply have concluded that nothing was ever lost.


