### PR TITLE
POTATO: handle failed orbit nodes without stale interpolation data

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -88,6 +88,19 @@ add_test(NAME test_find_all_roots_bracketed
    COMMAND test_find_all_roots_bracketed.x
 )
 
+add_executable(test_failed_orbit_nodes.x
+   SRC/test_failed_orbit_nodes.f90
+)
+# sample_matrix pulls sub_potato (module state), which calls into a
+# profile_input implementation.  potato_base is intentionally incomplete there,
+# so the two archives must be rescanned as a group rather than linked in order.
+target_link_libraries(test_failed_orbit_nodes.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+add_test(NAME test_failed_orbit_nodes
+   COMMAND test_failed_orbit_nodes.x
+)
+
 add_executable(test_wall_loss.x
    SRC/test_wall_loss.f90
 )

--- a/POTATO/SRC/sample_matrix.f90
+++ b/POTATO/SRC/sample_matrix.f90
@@ -22,6 +22,7 @@
   DOUBLE PRECISION, DIMENSION(:,:),   ALLOCATABLE :: coef,amat_maxmod
   COMPLEX(8),   DIMENSION(:,:),   ALLOCATABLE :: amat1,amat2
   COMPLEX(8),   DIMENSION(:,:,:), ALLOCATABLE :: amat_old
+  LOGICAL,      DIMENSION(:),     ALLOCATABLE :: valid_old,valid_arr
 !
   external :: get_matrix
 !
@@ -40,18 +41,20 @@
     DEALLOCATE(amat,xarr,amat_arr)
   endif
 !
-  ALLOCATE(amat(n1,n2),xarr(npoi),amat_arr(n1,n2,npoi))
+  ALLOCATE(amat(n1,n2),xarr(npoi),amat_arr(n1,n2,npoi),valid_arr(npoi))
 !
   x=xbeg
   CALL get_matrix
 !
   xarr(1)=x
   amat_arr(:,:,1)=amat
+  valid_arr(1)=ierr_get_matrix.EQ.0
 !
   x=xend
   CALL get_matrix
   xarr(npoi)=x
   amat_arr(:,:,npoi)=amat
+  valid_arr(npoi)=ierr_get_matrix.EQ.0
 !
   DO i=2,npoi-1
     x=xbeg+h*(i-1)+hh*(i-1)**2
@@ -67,6 +70,7 @@
     x=xarr(i)
     CALL get_matrix
     amat_arr(:,:,i)=amat
+    valid_arr(i)=ierr_get_matrix.EQ.0
   ENDDO
   !$omp end parallel do
 !
@@ -79,6 +83,7 @@
     x=0.5d0*(xarr(inew)+xarr(inew+1))
     ibeg=MAX(1,MIN(npoi-nlagr-1,inew-nshift-1))
     iend=ibeg+nlagr
+    IF(.NOT.ALL(valid_arr(ibeg:iend))) CYCLE
     CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
     DO i=1,n1
       amat1(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
@@ -88,6 +93,7 @@
     ENDDO
     ibeg=MAX(2,MIN(npoi-nlagr,inew-nshift+1))
     iend=ibeg+nlagr
+    IF(.NOT.ALL(valid_arr(ibeg:iend))) CYCLE
     CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
     DO i=1,n1
       amat2(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
@@ -103,9 +109,10 @@
   ENDDO
   IF(MAXVAL(isplit).GT.0) THEN
     npoi_old=npoi
-    ALLOCATE(xold(npoi),amat_old(n1,n2,npoi))
+    ALLOCATE(xold(npoi),amat_old(n1,n2,npoi),valid_old(npoi))
     xold=xarr
     amat_old=amat_arr
+    valid_old=valid_arr
   ELSE
     RETURN
   ENDIF
@@ -128,9 +135,9 @@
       IF(isplit(iold).EQ.1) npoi=npoi+1
     ENDDO
     IF(ALLOCATED(xarr)) THEN
-      DEALLOCATE(xarr,amat_arr)
+      DEALLOCATE(xarr,amat_arr,valid_arr)
     ENDIF
-    ALLOCATE(xarr(npoi),amat_arr(n1,n2,npoi))
+    ALLOCATE(xarr(npoi),amat_arr(n1,n2,npoi),valid_arr(npoi))
 !
 ! Serial layout pass: copy the retained old nodes into their new slots and, for
 ! each split interval, reserve the new node's slot inew with its midpoint xarr.
@@ -144,6 +151,7 @@
       inew=inew+1
       xarr(inew)=xold(iold)
       amat_arr(:,:,inew)=amat_old(:,:,iold)
+      valid_arr(inew)=valid_old(iold)
       IF(isplit(iold).EQ.1) THEN
         inew=inew+1
         xarr(inew)=0.5d0*(xold(iold)+xold(iold+1))
@@ -166,6 +174,7 @@
       x=xarr(newslots(k))
       CALL get_matrix
       amat_arr(:,:,newslots(k))=amat
+      valid_arr(newslots(k))=ierr_get_matrix.EQ.0
     ENDDO
     !$omp end parallel do
     DEALLOCATE(newslots)
@@ -177,6 +186,7 @@
       x=0.5d0*(xarr(inew)+xarr(inew+1))
       ibeg=MAX(1,MIN(npoi-nlagr-1,inew-nshift-1))
       iend=ibeg+nlagr
+      IF(.NOT.ALL(valid_arr(ibeg:iend))) CYCLE
       CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
       DO i=1,n1
         amat1(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
@@ -186,6 +196,7 @@
       ENDDO
       ibeg=MAX(2,MIN(npoi-nlagr,inew-nshift+1))
       iend=ibeg+nlagr
+      IF(.NOT.ALL(valid_arr(ibeg:iend))) CYCLE
       CALL plag_coeff(npoilag,nder,x,xarr(ibeg:iend),coef)
       DO i=1,n1
         amat2(i,:)=MATMUL(amat_arr(i,:,ibeg:iend),coef(0,:))
@@ -201,10 +212,11 @@
     ENDDO
     IF(MAXVAL(isplit).GT.0) THEN
       npoi_old=npoi
-      DEALLOCATE(xold,amat_old)
-      ALLOCATE(xold(npoi),amat_old(n1,n2,npoi))
+      DEALLOCATE(xold,amat_old,valid_old)
+      ALLOCATE(xold(npoi),amat_old(n1,n2,npoi),valid_old(npoi))
       xold=xarr
       amat_old=amat_arr
+      valid_old=valid_arr
     ELSE
       EXIT
     ENDIF

--- a/POTATO/SRC/sample_matrix_mod.f90
+++ b/POTATO/SRC/sample_matrix_mod.f90
@@ -5,13 +5,18 @@
     integer, parameter :: sample_matrix_nonconverged=2
 
     integer :: nlagr,n1,n2,npoi,itermax,nstiff,i_int
+! Status of the last get_matrix call: nonzero when the orbit could not be
+! evaluated (left the field domain, crossed the wall).  amat then carries no
+! usable value and the node must be kept out of the refinement decision.
+    integer :: ierr_get_matrix
     double precision :: x,xbeg,xend,eps
     double precision, dimension(:),     allocatable :: xarr
     double precision, dimension(:,:),   allocatable :: amat
     double precision, dimension(:,:,:), allocatable :: amat_arr
 ! The class-grid state is per energy slice. Inner node-fill loops copy the
 ! current grid config into their workers before filling disjoint slots.
-    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr)
+    !$omp threadprivate(nlagr,n1,n2,npoi,itermax,x,xbeg,xend,eps,xarr,amat,amat_arr, &
+    !$omp               ierr_get_matrix)
 
   contains
 
@@ -21,5 +26,4 @@
       sample_matrix_grid_usable = ierr.eq.sample_matrix_success .or. &
           ierr.eq.sample_matrix_nonconverged
     end function sample_matrix_grid_usable
-
   end module sample_matrix_mod

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -2475,7 +2475,7 @@
 ! toroidal displacement per bounce time and bounce integrals as functions
 ! of class parameter x for adaptive refinement of interpolation grid over x
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use orbit_dim_mod,     only : neqm,next
   use get_matrix_mod,    only : iclass
   use global_invariants, only : dtau,toten,perpinv
@@ -2492,6 +2492,8 @@
 !
   external :: velo,velo_pphint
 !
+  ierr_get_matrix=0
+!
   sigma=sigma_class(iclass)
   delta_R=R_class_end(iclass)-R_class_beg(iclass)
 !
@@ -2504,6 +2506,10 @@
 !
   if(ierr.ne.0) then
     print *,'get_matrix: error in starter'
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+    ierr_get_matrix=1
+    amat=0.d0
     return
   endif
 !
@@ -2514,7 +2520,13 @@
     if(fullbounce) then
 !
       call find_bounce(next,velo,dtau,z,taub,delphi,extraset,ierr)
-      if(ierr.ne.0) return
+      if(ierr.ne.0) then
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+        ierr_get_matrix=1
+        amat=0.d0
+        return
+      endif
 !
     else
 !
@@ -2528,7 +2540,13 @@
     extraset=0.d0
 !
     call find_bounce(next,velo_pphint,dtau,z,taub,delphi,extraset,ierr)
-    if(ierr.ne.0) return
+    if(ierr.ne.0) then
+! Orbit failed (left the field domain or crossed the wall): flag it and clear
+! amat, so callers read the status instead of the previous node's values.
+      ierr_get_matrix=1
+      amat=0.d0
+      return
+    endif
 !
   endif
 !
@@ -2619,7 +2637,7 @@
 ! the root search with non-physical dense roots.  The endpoint is located by
 ! bisection on |delphi_b(x)| using get_matrix_doublecount as the orbit evaluator.
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use get_matrix_mod,    only : delphi_max
 !
   implicit none
@@ -2675,12 +2693,15 @@
 !
   double precision function eval_delphi(xval)
   double precision :: xval
-! huge sentinel: get_matrix_doublecount leaves amat untouched on orbit failure,
-! so a failed evaluation reads as "beyond delphi_max" and pulls the search in.
-  amat(3,1)=huge(1.d0)
   x=xval
   call get_matrix_doublecount
-  eval_delphi=amat(3,1)
+! A failed orbit has no delphi_b; report it as beyond the bound so the search
+! trims towards the part of the class that does close.
+  if(ierr_get_matrix.ne.0) then
+    eval_delphi=huge(1.d0)
+  else
+    eval_delphi=amat(3,1)
+  endif
   end function eval_delphi
 !
   end subroutine bound_class_delphi
@@ -2690,13 +2711,13 @@
   subroutine bound_class_wall(xb,xe)
 !
 ! Trim the class interval to where the orbit closes inside the limiter wall.
-! A wall-crossing orbit fails in get_matrix_doublecount (amat(3,1) left at the
-! huge sentinel); without this trim a single lost sample makes sample_matrix
-! exceed itermax and the whole class is dropped (ierr=2) instead of only the
-! lost orbits.  Trims both endpoints by bisection on orbit validity, so the
-! inside-wall part of the class is still sampled and its resonances kept.
+! A wall-crossing orbit is reported by get_matrix_doublecount through
+! ierr_get_matrix; without this trim the lost samples drag the refinement into
+! itermax instead of costing only the lost orbits.  Trims both endpoints by
+! bisection on orbit validity, so the inside-wall part of the class is still
+! sampled and its resonances kept.
 !
-  use sample_matrix_mod, only : n1,n2,x,amat
+  use sample_matrix_mod, only : n1,n2,x,amat,ierr_get_matrix
   use wall_loss_mod,     only : wall_loaded
 !
   implicit none
@@ -2743,12 +2764,9 @@
 !
   logical function orbit_lost(xval)
   double precision :: xval
-! huge sentinel: get_matrix_doublecount leaves amat untouched when the orbit
-! fails (e.g. crosses the wall), so an untouched entry reads as a lost orbit.
-  amat(3,1)=huge(1.d0)
   x=xval
   call get_matrix_doublecount
-  orbit_lost = (amat(3,1).eq.huge(1.d0))
+  orbit_lost = (ierr_get_matrix.ne.0)
   end function orbit_lost
 !
   end subroutine bound_class_wall

--- a/POTATO/SRC/test_failed_orbit_nodes.f90
+++ b/POTATO/SRC/test_failed_orbit_nodes.f90
@@ -1,0 +1,76 @@
+program test_failed_orbit_nodes
+! A class may contain orbits that leave the field domain.  get_matrix reports
+! those through ierr_get_matrix and leaves no usable value behind, so the grid
+! refinement must not read them as structure and keep bisecting towards them.
+!
+! The stub below is linear (exactly reproduced by the Lagrange interpolation
+! used for the split test) outside a failed stretch, so every split the
+! refinement performs is driven by the failed nodes alone.
+  use sample_matrix_mod, only : nlagr,n1,n2,npoi,itermax,x,amat,xarr,xbeg,xend, &
+                                eps
+  implicit none
+
+! Refinement starts from nlagr+2 nodes.  Bisecting towards the failed stretch
+! adds nodes on every one of the itermax passes; staying under this bound means
+! the failed nodes were excluded rather than chased.
+  integer, parameter :: npoi_max_expected = 20
+  integer :: ierr,i,nodes_in_gap
+  character(len=64) :: msg
+
+  external :: stub_matrix
+
+  nlagr   = 7
+  n1      = 1
+  n2      = 1
+  itermax = 20
+  eps     = 1.d-3
+  xbeg    = 0.d0
+  xend    = 1.d0
+
+  call sample_matrix(stub_matrix,ierr)
+
+  call require(ierr.eq.0,'sample_matrix reported failure')
+
+  write(msg,'(A,I0)') 'grid grew chasing failed nodes, npoi = ',npoi
+  call require(npoi.le.npoi_max_expected,trim(msg))
+
+! No node may be inserted inside the failed stretch: nothing there is worth
+! resolving, and the values carry no physical weight.
+  nodes_in_gap = 0
+  do i = 1,npoi
+    if(xarr(i).gt.0.4d0 .and. xarr(i).lt.0.6d0) nodes_in_gap = nodes_in_gap+1
+  end do
+  write(msg,'(A,I0)') 'nodes inserted inside failed stretch = ',nodes_in_gap
+  call require(nodes_in_gap.le.2,trim(msg))
+
+  print *,'test_failed_orbit_nodes: OK  (npoi = ',npoi,')'
+
+contains
+
+  subroutine require(ok,text)
+    logical, intent(in) :: ok
+    character(len=*), intent(in) :: text
+
+    if(ok) return
+    print *,text
+    error stop 1
+  end subroutine require
+
+end program test_failed_orbit_nodes
+
+subroutine stub_matrix
+! Stands in for get_matrix_doublecount: linear where the orbit closes, and a
+! reported failure with no usable value where it leaves the domain.
+  use sample_matrix_mod, only : x,amat,ierr_get_matrix
+
+  implicit none
+
+  if(x.gt.0.4d0 .and. x.lt.0.6d0) then
+    amat = 0.d0
+    ierr_get_matrix = 1
+    return
+  endif
+
+  ierr_get_matrix = 0
+  amat(1,1) = 1.d0+x
+end subroutine stub_matrix


### PR DESCRIPTION
## Scope

Prevents failed POTATO orbit evaluations from being treated as valid interpolation data during adaptive sample-matrix refinement.

The production path records the status of each `get_matrix` call, marks failed orbit nodes invalid, skips interpolation windows containing invalid nodes, and keeps the last completed grid when the refinement iteration cap is reached. This avoids stale `amat` values driving further refinement toward an orbit that left the valid field domain.

The existing sample-matrix nonconvergence status from merged main is preserved; this PR adds the per-node failure handling needed by the refinement consumer.

## Validation

Adds and registers `test_failed_orbit_nodes`, an independent stub oracle with a deliberately failed interval. It verifies that refinement does not chase the failed interval or insert nodes into it.

