### PR TITLE
CMake: apply preprocessing only to Fortran sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,10 @@ target_link_libraries(neo_rt PUBLIC
     LAPACK::LAPACK
 )
 
+target_compile_options(neo_rt PRIVATE
+    $<$<COMPILE_LANGUAGE:Fortran>:-cpp>
+)
+
 if(USE_STANDALONE)
     target_link_libraries(neo_rt PUBLIC
         LIBNEO::boozer


### PR DESCRIPTION
## Summary

Apply the Fortran preprocessor flag to the `neo_rt` target only when CMake is compiling Fortran. This keeps conditional Fortran sources buildable without passing `-cpp` to C/C++ sources or linked dependencies.

## Validation

- Clean configure with the repository build configuration.
- Release build of `neo_rt.x` completed successfully.
- No generated files or unrelated source changes are included.

## Scope

Build-system-only fix. It does not change orbit, torque, profile, or generated-kernel behavior.