### PR TITLE
POTATO: seed the Poincare cut at the equilibrium midplane

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -88,6 +88,19 @@ add_test(NAME test_find_all_roots_bracketed
    COMMAND test_find_all_roots_bracketed.x
 )
 
+add_executable(test_poicut_midplane.x
+   SRC/test_poicut_midplane.f90
+)
+target_link_libraries(test_poicut_midplane.x
+   potato_base
+   potato
+)
+add_test(NAME test_poicut_midplane
+   COMMAND test_poicut_midplane.x
+   ${CMAKE_CURRENT_BINARY_DIR}/shifted_convexwall.dat
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test/golden_record_resonance
+)
+
 add_executable(test_wall_loss.x
    SRC/test_wall_loss.f90
 )

--- a/POTATO/SRC/sub_potato.f90
+++ b/POTATO/SRC/sub_potato.f90
@@ -721,7 +721,7 @@
 ! used as a Poincare cut.
 !
   use field_sub, only : psif,dpsidr,dpsidz
-  use field_eq_mod, only : psi_axis,psi_sep,rtf
+  use field_eq_mod, only : psi_axis,psi_sep,rtf,nzet,zet
   use poicut_mod, only   : npc,rpc_beg,h_rpc,rpc_arr,zpc_arr
 !
   implicit none
@@ -731,15 +731,21 @@
   integer :: i,j,npline
   double precision :: rho_pol,psils,sigpsi
   double precision :: h_R,det,delR,delZ,stepfac,err_dist,stepmod
-  double precision :: R,Z,gpgb,dgpgb_dr,dgpgb_dz
+  double precision :: R,Z,gpgb,dgpgb_dr,dgpgb_dz,z_mid
   double precision :: Rb,Zb,Re,Ze
 !
   npc=npline
   allocate(rpc_arr(0:npc),zpc_arr(0:npc))
 !
 !
+  z_mid=0.d0
+  if(nzet.gt.0 .and. allocated(zet)) z_mid=0.5d0*(zet(1)+zet(nzet))
+
   R=1.d0
-  Z=0.d0
+! The EQDSK geometric midplane need not be Z=0.  Starting the cut search at
+! the actual grid midplane keeps the Newton seed inside the supplied
+! equilibrium for vertically shifted devices such as ITER.
+  Z=z_mid
 !
   call gpsigb_and_ders(R,Z,gpgb,dgpgb_dr,dgpgb_dz)
 !
@@ -748,6 +754,7 @@
   sigpsi=sign(1.d0,psi_sep-psi_axis)
   psils=psi_axis+rho_pol**2*(psi_sep-psi_axis)
   R=rtf
+  Z=z_mid
 !
   do i=2,nsplit
     R=R-h_R
@@ -775,6 +782,7 @@
   Zb=Z
 !
   R=rtf
+  Z=z_mid
 !
   do i=2,nsplit
     R=R+h_R

--- a/POTATO/SRC/test_poicut_midplane.f90
+++ b/POTATO/SRC/test_poicut_midplane.f90
@@ -1,0 +1,67 @@
+program test_poicut_midplane
+   use field_eq_mod, only : allow_sol, nzet, zet, zmagaxis, rtf
+   use field_sub, only : field_eq
+   use field_mod, only : ampl, icall, iequil, ipert
+   use input_files, only : convexfile
+   use potato_input_mod, only : read_potato_input, npoicut, rho_pol_max
+   use poicut_mod, only : npc, zpc_arr
+   implicit none
+
+   double precision, parameter :: cut_tolerance = 1.d-2
+   character(len=1024) :: shifted_wall_file
+   character(len=1024) :: argument
+   double precision :: z_mid, theta
+   double precision :: bmod, sqrtg
+   double precision :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+   double precision :: br, bphi, bz
+   double precision :: dbrdr, dbrdphi, dbrdz
+   double precision :: dbphidr, dbphidphi, dbphidz
+   double precision :: dbzdr, dbzdphi, dbzdz
+   double precision :: x(3)
+   integer :: output_unit, i
+   double precision, parameter :: pi = 3.14159265358979323846d0
+   integer, parameter :: nwall = 128
+   double precision :: z_shift, wall_radius
+   external :: find_poicut
+   external :: magfie
+
+   call get_command_argument(1, argument)
+   shifted_wall_file = trim(argument)
+   if (len_trim(shifted_wall_file) == 0) then
+      error stop 'test_poicut_midplane requires a shifted wall output path'
+   end if
+
+   call read_potato_input('potato.in')
+   call field_eq(200.d0, 0.d0, 0.d0, br, bphi, bz, dbrdr, dbrdphi, dbrdz, &
+        dbphidr, dbphidphi, dbphidz, dbzdr, dbzdphi, dbzdz)
+   z_shift = 0.75d0 * (zet(nzet) - zet(1))
+   wall_radius = 2.d0 * max(rtf, max(abs(zet(1)), abs(zet(nzet))))
+   open(newunit=output_unit, file=trim(shifted_wall_file), status='replace', &
+        action='write')
+   do i = 1, nwall
+      theta = 2.d0 * pi * dble(i - 1) / dble(nwall)
+      write(output_unit, *) rtf + wall_radius * cos(theta), &
+           z_shift + wall_radius * sin(theta)
+   end do
+   close(output_unit)
+   convexfile = trim(shifted_wall_file)
+   icall = 1
+   ipert = 0
+   iequil = 1
+   ampl = 1.d0
+
+   x = [rtf, 0.d0, 0.d0]
+   call magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+   allow_sol = .false.
+   zet = zet + z_shift
+   zmagaxis = zmagaxis + z_shift
+   z_mid = 0.5d0 * (zet(1) + zet(nzet))
+
+   call find_poicut(rho_pol_max, npoicut)
+   if (abs(zpc_arr(0) - z_mid) > cut_tolerance .or. &
+       abs(zpc_arr(npc) - z_mid) > cut_tolerance) then
+      error stop 'Poincare cut did not follow the shifted equilibrium midplane'
+   end if
+
+   print *, 'test_poicut_midplane PASSED'
+end program test_poicut_midplane


### PR DESCRIPTION
## Summary

Seed the POTATO Poincare-cut search at the actual EQDSK grid midplane, `0.5*(zet(1)+zet(nzet))`, instead of assuming `Z=0`. The seed is used for the initial, forward, and backward cut searches.

This matters for vertically shifted equilibria, including non-circular cases such as AUG 30835 and ITER equilibria whose supplied grid is not centered at zero.

## Validation

- Clean current-`main` POTATO configure/rebuild completed successfully.
- `potato.x` builds with the change.
- The change is limited to the Poincare-cut seed; it does not alter orbit equations, signs, normalization, or torque formulas.

## Scope

Small input/initialization fix. A production AUG 30835 validation run remains follow-up work.