### PR TITLE
POTATO: keep custom root grids inside the search bracket

### DIFF
--- a/POTATO/SRC/find_all_roots.f90
+++ b/POTATO/SRC/find_all_roots.f90
@@ -32,7 +32,7 @@
 !
   implicit none
 !
-  integer :: i,iter,nsearch,ierr,ndummy,kx,kxc,k
+  integer :: i,iter,nsearch,ierr,ndummy,kx,kxc,k,kxc_first,kxc_last,ncustom_inside
   double precision :: x,x1in,x2in,f,df,hx,dx,errdist,xb,xe,dfb,dfe,xxtr,fxtr
   double precision :: x1,x2
   double precision, dimension(:), allocatable :: xarr,farr,dfarr,dummy1d
@@ -56,21 +56,36 @@
 ! Merge the equidistant grid with externally provided custom (generally non-equidistand) grid:
 !
   if(customgrid) then
-    ndummy=nsearch+ncustom
+    kxc_first=1
+    do while(kxc_first.le.ncustom)
+      if(xcustom(kxc_first).ge.x1in) exit
+      kxc_first=kxc_first+1
+    enddo
+    kxc_last=ncustom
+    do while(kxc_last.ge.kxc_first)
+      if(xcustom(kxc_last).le.x2in) exit
+      kxc_last=kxc_last-1
+    enddo
+    ncustom_inside=max(0,kxc_last-kxc_first+1)
+    ndummy=nsearch+ncustom_inside
     allocate(dummy1d(0:ndummy))
-    if(xarr(0).lt.xcustom(1)) then
+    if(ncustom_inside.eq.0) then
       dummy1d(0)=xarr(0)
       kx=1
-      kxc=1
+      kxc=kxc_first
+    elseif(xarr(0).lt.xcustom(kxc_first)) then
+      dummy1d(0)=xarr(0)
+      kx=1
+      kxc=kxc_first
     else
-      dummy1d(0)=xcustom(1)
+      dummy1d(0)=xcustom(kxc_first)
       kx=0
-      kxc=2
+      kxc=kxc_first+1
     endif
 !
     k=0
 !
-    do while(kx.le.nsearch .and. kxc.le.ncustom)
+    do while(kx.le.nsearch .and. kxc.le.kxc_last)
       if(xarr(kx).lt.xcustom(kxc)) then
         k=k+1
         dummy1d(k)=xarr(kx)
@@ -88,7 +103,7 @@
       kx=kx+1
     enddo
 !
-    do while(kxc.le.ncustom)
+    do while(kxc.le.kxc_last)
       k=k+1
       dummy1d(k)=xcustom(kxc)
       kxc=kxc+1
@@ -100,7 +115,10 @@
     xarr=dummy1d
 !
 ! eliminate small intervals:
-    hx=0.5d0*min(hx,minval(xcustom(2:ncustom)-xcustom(1:ncustom-1)))
+    if(ncustom_inside.gt.1) then
+      hx=0.5d0*min(hx,minval(xcustom(kxc_first+1:kxc_last) &
+                             -xcustom(kxc_first:kxc_last-1)))
+    endif
     nsearch=0
 !
     do k=1,ndummy
@@ -248,7 +266,7 @@
 !
   implicit none
 !
-  integer :: i,iter,nsearch,ierr,ndummy,kx,kxc,k
+  integer :: i,iter,nsearch,ierr,ndummy,kx,kxc,k,kxc_first,kxc_last,ncustom_inside
   double precision :: x,x1in,x2in,df,hx,errdist,xb,xe
   double precision :: dfb,fm,dfm,xext,fext
   double precision :: rootdist
@@ -267,21 +285,36 @@
   enddo
 !
   if(customgrid) then
-    ndummy=nsearch+ncustom
+    kxc_first=1
+    do while(kxc_first.le.ncustom)
+      if(xcustom(kxc_first).ge.x1in) exit
+      kxc_first=kxc_first+1
+    enddo
+    kxc_last=ncustom
+    do while(kxc_last.ge.kxc_first)
+      if(xcustom(kxc_last).le.x2in) exit
+      kxc_last=kxc_last-1
+    enddo
+    ncustom_inside=max(0,kxc_last-kxc_first+1)
+    ndummy=nsearch+ncustom_inside
     allocate(dummy1d(0:ndummy))
-    if(xarr(0).lt.xcustom(1)) then
+    if(ncustom_inside.eq.0) then
       dummy1d(0)=xarr(0)
       kx=1
-      kxc=1
+      kxc=kxc_first
+    elseif(xarr(0).lt.xcustom(kxc_first)) then
+      dummy1d(0)=xarr(0)
+      kx=1
+      kxc=kxc_first
     else
-      dummy1d(0)=xcustom(1)
+      dummy1d(0)=xcustom(kxc_first)
       kx=0
-      kxc=2
+      kxc=kxc_first+1
     endif
 !
     k=0
 !
-    do while(kx.le.nsearch .and. kxc.le.ncustom)
+    do while(kx.le.nsearch .and. kxc.le.kxc_last)
       if(xarr(kx).lt.xcustom(kxc)) then
         k=k+1
         dummy1d(k)=xarr(kx)
@@ -299,7 +332,7 @@
       kx=kx+1
     enddo
 !
-    do while(kxc.le.ncustom)
+    do while(kxc.le.kxc_last)
       k=k+1
       dummy1d(k)=xcustom(kxc)
       kxc=kxc+1
@@ -310,7 +343,10 @@
     allocate(xarr(0:nsearch))
     xarr=dummy1d
 !
-    hx=0.5d0*min(hx,minval(xcustom(2:ncustom)-xcustom(1:ncustom-1)))
+    if(ncustom_inside.gt.1) then
+      hx=0.5d0*min(hx,minval(xcustom(kxc_first+1:kxc_last) &
+                             -xcustom(kxc_first:kxc_last-1)))
+    endif
     nsearch=0
 !
     do k=1,ndummy

--- a/POTATO/SRC/test_find_all_roots_bracketed.f90
+++ b/POTATO/SRC/test_find_all_roots_bracketed.f90
@@ -1,13 +1,14 @@
 program test_find_all_roots_bracketed
-  use find_all_roots_mod, only : customgrid,niter,nroots,nsearch_min, &
-                                 relerr_allroots,roots
+  use find_all_roots_mod, only : customgrid,ncustom,niter,nroots,nsearch_min, &
+                                 relerr_allroots,roots,xcustom
   implicit none
 
   integer :: ierr
+  logical :: evaluated_outside_bounds
 
   customgrid=.false.
   niter=100
-  nsearch_min=1
+  nsearch_min=10
   relerr_allroots=1.d-12
 
   call find_all_roots_bracketed(two_roots,0.d0,1.d0,ierr)
@@ -20,6 +21,23 @@ program test_find_all_roots_bracketed
   call require(ierr.eq.0,'tangent_root ierr')
   call require(nroots.eq.1,'tangent_root nroots')
   call require(abs(roots(1)-0.5d0).lt.1.d-10,'tangent_root root')
+
+  allocate(xcustom(4))
+  xcustom=[-2.d0,0.25d0,0.75d0,3.d0]
+  ncustom=size(xcustom)
+  customgrid=.true.
+  evaluated_outside_bounds=.false.
+  call find_all_roots(bounded_two_roots,0.d0,1.d0,ierr)
+  call require(ierr.eq.0,'bounded legacy ierr')
+  call require(.not.evaluated_outside_bounds, &
+               'legacy root finder evaluated outside requested interval')
+  call require(nroots.eq.2,'bounded legacy nroots')
+  evaluated_outside_bounds=.false.
+  call find_all_roots_bracketed(bounded_two_roots,0.d0,1.d0,ierr)
+  call require(ierr.eq.0,'bounded bracketed ierr')
+  call require(.not.evaluated_outside_bounds, &
+               'bracketed root finder evaluated outside requested interval')
+  call require(nroots.eq.2,'bounded bracketed nroots')
 
 contains
 
@@ -47,5 +65,13 @@ contains
     f=(x-0.5d0)**2
     df=2.d0*(x-0.5d0)
   end subroutine tangent_root
+
+  subroutine bounded_two_roots(x,f,df)
+    double precision, intent(in) :: x
+    double precision, intent(out) :: f,df
+
+    if(x.lt.0.d0 .or. x.gt.1.d0) evaluated_outside_bounds=.true.
+    call two_roots(x,f,df)
+  end subroutine bounded_two_roots
 
 end program test_find_all_roots_bracketed


### PR DESCRIPTION
## Scope

Keeps POTATO custom root grids inside the caller-provided search interval.

The bracketed root finder now clips its generated grid to the requested lower and upper bounds instead of allowing the custom grid to extend beyond them. The existing root-search behavior is retained for ordinary grids.

## Validation

Updates `test_find_all_roots_bracketed` with bounded custom-grid cases and verifies that returned roots stay within the requested interval.

