### PR TITLE
Split analytic and file perturbation scaling

### DIFF
--- a/doc/library.md
+++ b/doc/library.md
@@ -134,7 +134,7 @@ Computes transport using `s`, `M_t`, `vth`, etc. from the config file or `config
 type :: config_t
     ! Same fields as the params namelist in <base>.in
     real(8) :: s, qs, ms
-    real(8) :: epsmn, mph
+    real(8) :: epsmn, pertfile_scale, mph
     real(8) :: bfac, efac
     real(8) :: M_t, vth
     real(8) :: vmax_over_vth

--- a/doc/running.md
+++ b/doc/running.md
@@ -49,7 +49,8 @@ The parameter file is a Fortran namelist `&params` with the fields listed below.
 | `qs` | Ion charge in units of the elementary charge. | Used to compute `qi`. |
 | `ms` | Ion mass in atomic mass units. | Used to compute `mi`. |
 | `vth` | Thermal velocity `[cm/s]`. | Used when no `plasma.in` is provided. |
-| `epsmn` | Perturbation amplitude `B₁/B₀`. | Used when `pertfile=.false.`. |
+| `epsmn` | Perturbation amplitude `B₁/B₀`. | Used when `pertfile=.false.`; default `1`. |
+| `pertfile_scale` | Scale factor for the perturbation read from `in_file_pert`. | Used when `pertfile=.true.`; default `1`. |
 | `m0` | Poloidal perturbation harmonic. | Integer. |
 | `mph` | Toroidal perturbation harmonic. | Positive integer when using analytic perturbations. |
 | `magdrift` | Include magnetic drift (`.true.`/`.false.`). | Controls bounce-averaged drifts. |

--- a/examples/base/driftorbit.in
+++ b/examples/base/driftorbit.in
@@ -8,6 +8,7 @@
     ms = 2.014             ! Particle mass / 1u
     vth = 40000000.0       ! thermal velocity [cm/s]
     epsmn = 0.001          ! perturbation amplitude B1/B0 (if pertfile==F)
+    pertfile_scale = 1.0   ! scale perturbation read from in_file_pert
     m0 = 0                 ! poloidal perturbation mode (if pertfile==F)
     mph = 3                ! toroidal perturbation mode (if pertfile==F, n>0!)
     supban = .false.       ! Shaing superbanana plateau (trapped ell=0) only

--- a/examples/driftorbit.in
+++ b/examples/driftorbit.in
@@ -8,6 +8,7 @@
     ms = 2.014d0           ! Particle mass [atomic unit]
     vth = 40000000.0d0     ! Thermal velocity [cm/s]
     epsmn = 1.0d-3         ! Perturbation amplitude B1/B0 (if pertfile==.false.)
+    pertfile_scale = 1.0d0 ! Scale perturbation read from in_file_pert
     m0 = 0                 ! poloidal perturbation harmonic (if pertfile==.false.)
     mph = 3                ! Toroidal perturbation harmonic (if pertfile==.false., n>0!)
     supban = .false.       ! Shaing superbanana plateau (trapped ell=0) only

--- a/src/config.f90
+++ b/src/config.f90
@@ -9,7 +9,8 @@ module neort_config
         real(dp) :: qs = 0.0_dp  ! particle charge / elementary charge !*!
         real(dp) :: ms = 0.0_dp  ! particle mass / u !*!
         real(dp) :: vth = 0.0_dp  ! thermal velocity / cm/s !*!
-        real(dp) :: epsmn = 0.0_dp  ! perturbation amplitude B1/B0 (if pertfile==F)
+        real(dp) :: epsmn = 1.0_dp  ! perturbation amplitude B1/B0 (if pertfile==F)
+        real(dp) :: pertfile_scale = 1.0_dp  ! scale factor for perturbations read from file
         integer :: m0 = 0  ! poloidal perturbation mode (if pertfile==F)
         integer :: mph = 0  ! toroidal perturbation mode (if pertfile==F, n>0!)
         logical :: comptorque = .false.  ! compute torque
@@ -42,7 +43,8 @@ contains
         ! Set global control parameters via config struct
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph, perturbation_switch => inp_swi_pert
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
+        use driftorbit, only: epsmn, pertfile_scale, m0, comptorque, magdrift, &
+            magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
@@ -56,6 +58,7 @@ contains
         M_t = config%M_t * config%efac / config%bfac
         vth = config%vth
         epsmn = config%epsmn
+        pertfile_scale = config%pertfile_scale
         m0 = config%m0
         mph = config%mph
         comptorque = config%comptorque
@@ -90,7 +93,8 @@ contains
         ! Set global control parameters directly from a file
         use do_magfie_mod, only: s, bfac, inp_swi
         use do_magfie_pert_mod, only: mph, set_mph, inp_swi_pert
-        use driftorbit, only: epsmn, m0, comptorque, magdrift, magdrift_passing, nopassing, pertfile, &
+        use driftorbit, only: epsmn, pertfile_scale, m0, comptorque, magdrift, &
+            magdrift_passing, nopassing, pertfile, &
             nonlin, efac, supban
         use logger, only: set_log_level
         use neort, only: vsteps, mth_max_abs, vmax_over_vth
@@ -102,7 +106,8 @@ contains
         real(dp) :: qs, ms
         integer :: log_level = 0
 
-        namelist /params/ s, M_t, qs, ms, vth, epsmn, m0, mph, comptorque, supban, &
+        namelist /params/ s, M_t, qs, ms, vth, epsmn, pertfile_scale, m0, mph, comptorque, &
+            supban, &
             magdrift, magdrift_passing, nopassing, noshear, pertfile, nonlin, bfac, efac, inp_swi, &
             inp_swi_pert, vsteps, mth_max_abs, vmax_over_vth, log_level, output_format
 

--- a/src/driftorbit.f90
+++ b/src/driftorbit.f90
@@ -19,6 +19,7 @@ module driftorbit
     ! Harmonics TODO: make dynamic, multiple harmonics
     ! Default values are overridden by config file in driftorbit_test:read_control
     real(dp) :: epsmn = 1.0_dp            ! perturbation amplitude B1/B0
+    real(dp) :: pertfile_scale = 1.0_dp   ! scale factor for perturbations read from file
     integer :: m0 = 1                 ! Boozer poloidal perturbation mode
     integer :: mth = 1                ! canonical poloidal mode
     logical :: magdrift = .true.      ! consider magnetic drift
@@ -54,7 +55,8 @@ module driftorbit
     !$omp threadprivate (mth, dVds, etadt, etatp, etamin, etamax)
     !$omp threadprivate (B0, Bmin, Bmax, sign_vpar, sign_vpar_htheta)
 
-    ! Shared read-only configuration (NOT threadprivate): efac, epsmn, m0,
+    ! Shared read-only configuration (NOT threadprivate): efac, epsmn,
+    ! pertfile_scale, m0,
     ! magdrift, nopassing, pertfile, comptorque, nonlin, supban
 
 end module driftorbit

--- a/src/neort.f90
+++ b/src/neort.f90
@@ -76,7 +76,8 @@ contains
         use do_magfie_mod, only: do_magfie, sign_theta, R0, a, psi_pr, iota, q, Bthcov, Bphcov, &
             dBthcovds, dBphcovds, eps
         use do_magfie_pert_mod, only: do_magfie_pert_amp, mph
-        use driftorbit, only: B0, etatp, etadt, M_t, Om_tE, m0, pertfile, nonlin, epsmn, dVds
+        use driftorbit, only: B0, etatp, etadt, M_t, Om_tE, m0, pertfile, nonlin, &
+                              epsmn, pertfile_scale, dVds
 
         type(magfie_data_t), intent(out) :: data
 
@@ -139,7 +140,7 @@ contains
             call do_magfie(x, bmod, sqrtg, hder, hcovar, hctrvr, hcurl)
             if (pertfile) then
                 call do_magfie_pert_amp(x, bn)
-                bn = epsmn*bn/bmod
+                bn = pertfile_scale*bn/bmod
             else
                 bn = epsmn*exp(imun*m0*x(3))
             end if

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -12,6 +12,7 @@ module neort_transport
     use neort_orbit, only: bounce_fast, nvar, noshear, poloidal_velocity
     use neort_resonance, only: driftorbit_coarse, driftorbit_root
     use driftorbit, only: vth, mth, mph, mi, B0, Bmin, Bmax, comptorque, epsmn, &
+        pertfile_scale, &
         etamin, etamax, A1, A2, nlev, pertfile, nonlin, m0, etatp, etadt, &
         sign_vpar_htheta, sign_vpar
 
@@ -171,7 +172,7 @@ contains
         ! evaluate orbit averages of Hamiltonian perturbation
         if (pertfile) then
             call do_magfie_pert_amp(x, epsn)
-            epsn = epsmn * epsn / bmod
+            epsn = pertfile_scale * epsn / bmod
         else
             epsn = epsmn * exp(imun * m0 * y(1))
         end if

--- a/test/golden_record/input/template.in
+++ b/test/golden_record/input/template.in
@@ -4,6 +4,7 @@
     qs = 1.0
     ms = 2.014
     epsmn = 1.0
+    pertfile_scale = 1.0
     m0 = -1
     mph = 1
     magdrift = .true.

--- a/test/probe_neort_perturbation_fourier_kernel.f90
+++ b/test/probe_neort_perturbation_fourier_kernel.f90
@@ -1,20 +1,31 @@
 program probe_neort_perturbation_fourier_kernel
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use neort_config, only: config_t, read_and_set_config, set_config
+    use neort, only: check_magfie
+    use neort_datatypes, only: magfie_data_t
+    use do_magfie_mod, only: bfac, do_magfie, init_magfie_at_s, inp_swi, &
+        magfie_thread_init, read_boozer_file, set_s
     use do_magfie_pert_mod, only: do_magfie_pert, do_magfie_pert_amp, &
         init_magfie_pert_at_s, read_boozer_pert_file
+    use driftorbit, only: epsmn, m0, pertfile, pertfile_scale
+    use neort_magfie, only: B0
 
     implicit none
 
     character(len=*), parameter :: fixture = 'manufactured_perturbation.bc'
+    character(len=*), parameter :: equilibrium_fixture = 'manufactured_equilibrium.bc'
     real(dp), parameter :: theta = 0.6_dp, phi = -0.4_dp
     real(dp), parameter :: cosine_amplitude_t = 2.0e-4_dp
     real(dp), parameter :: sine_amplitude_t = 0.7e-4_dp
-    complex(dp) :: amplitude_g
-    real(dp) :: full_field_g, expected_g, wrong_sign_g, x(3)
+    complex(dp) :: amplitude_g, expected_consumer
+    real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+    real(dp) :: full_field_g, expected_g, wrong_sign_g, x(3), theta_sample
+    integer :: sample
     type(config_t) :: config
+    type(magfie_data_t) :: magfie_data
 
     call write_fixture(fixture)
+    call write_equilibrium_fixture(equilibrium_fixture)
 
     call write_config("mixed_readers.in")
     call read_and_set_config("mixed_readers.in")
@@ -26,7 +37,47 @@ program probe_neort_perturbation_fourier_kernel
     call set_config(config)
     call check_manufactured_field("legacy inherited reader")
 
+    config = config_t()
+    config%s = 0.5_dp
+    config%qs = 1.0_dp
+    config%ms = 1.0_dp
+    config%inp_swi = 9
+    config%inp_swi_pert = 9
+    config%pertfile = .true.
+    config%pertfile_scale = 2.0_dp
+    call set_config(config)
+    bfac = 1.0_dp
+    B0 = 1.0_dp
+    call magfie_thread_init()
+    call read_boozer_file(equilibrium_fixture)
+    call set_s(0.5_dp)
+    call init_magfie_at_s()
+    call read_boozer_pert_file(fixture)
+    call init_magfie_pert_at_s()
+    call check_magfie(magfie_data)
+
+    sample = 13
+    theta_sample = -acos(-1.0_dp) + (sample - 1) * 2.0_dp * acos(-1.0_dp) / 49.0_dp
+    x = [0.5_dp, 0.0_dp, theta_sample]
+    call do_magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+    call do_magfie_pert_amp(x, amplitude_g)
+    expected_consumer = pertfile_scale * amplitude_g / bmod
+    if (abs(magfie_data%tensors(sample)%bn - expected_consumer) > 1.0e-12_dp) then
+        error stop 'pertfile_scale does not scale file perturbations'
+    end if
+
+    config%pertfile = .false.
+    config%epsmn = 0.25_dp
+    config%m0 = 2
+    call set_config(config)
+    call check_magfie(magfie_data)
+    expected_consumer = epsmn * exp((0.0_dp, 1.0_dp) * real(m0, dp) * theta_sample)
+    if (abs(magfie_data%tensors(sample)%bn - expected_consumer) > 1.0e-12_dp) then
+        error stop 'epsmn does not control analytic perturbations independently'
+    end if
+
     call delete_file(fixture)
+    call delete_file(equilibrium_fixture)
     call delete_file("mixed_readers.in")
 
 contains
@@ -77,6 +128,33 @@ contains
         end do
         close (unit)
     end subroutine write_fixture
+
+    subroutine write_equilibrium_fixture(path)
+        character(len=*), intent(in) :: path
+
+        integer :: unit, surface
+        real(dp), parameter :: surfaces(3) = [0.2_dp, 0.5_dp, 0.8_dp]
+
+        open (newunit=unit, file=path, status='replace', action='write')
+        write (unit, '(a)') 'CC manufactured equilibrium field'
+        write (unit, '(a)') 'CC independent synthetic equilibrium oracle'
+        write (unit, '(a)') 'CC m0b n0b nsurf nper flux a R'
+        write (unit, '(a)') 'CC'
+        write (unit, '(a)') 'CC'
+        write (unit, '(*(g0,1x))') 1, 0, 3, 1, 1.0_dp, 0.5_dp, 5.0_dp
+        do surface = 1, size(surfaces)
+            write (unit, '(a)') 'CC s iota Jpol Itor pprime sqrtg00'
+            write (unit, '(a)') 'CC units A A Pa m3'
+            write (unit, '(*(g0,1x))') surfaces(surface), 0.2_dp, 100.0_dp, &
+                10.0_dp, 0.0_dp, 1.0_dp
+            write (unit, '(a)') 'CC m n rmnc rmns zmnc zmns vmnc vmns bmnc bmns'
+            write (unit, '(*(g0,1x))') 0, 0, 5.0_dp, 0.0_dp, 0.0_dp, 0.0_dp, &
+                0.0_dp, 0.0_dp, 2.0_dp, 0.0_dp
+            write (unit, '(*(g0,1x))') 1, 0, 0.5_dp, 0.0_dp, 0.0_dp, 0.5_dp, &
+                0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp
+        end do
+        close (unit)
+    end subroutine write_equilibrium_fixture
 
     subroutine write_config(path)
         character(len=*), intent(in) :: path

--- a/test/ripple_plateau/driftorbit_test.in
+++ b/test/ripple_plateau/driftorbit_test.in
@@ -8,6 +8,7 @@
     ms = 2.014d0           ! Particle mass [atomic unit]
     vth = 1.0d8            ! Thermal velocity [cm/s]
     epsmn = 1.0d-3         ! Perturbation amplitude B1/B0 (if pertfile==.false.)
+    pertfile_scale = 1.0d0 ! Scale perturbation read from in_file_pert
     m0 = 0                 ! poloidal perturbation harmonic (if pertfile==.false.)
     mph = 18               ! Toroidal perturbation harmonic (if pertfile==.false., n>0!)
     magdrift = .false.     ! Consider magnetic drift

--- a/test/superbanana_plateau/driftorbit_test.in
+++ b/test/superbanana_plateau/driftorbit_test.in
@@ -11,6 +11,7 @@
     ms = 2.014d0           ! Particle mass [atomic unit]
     vth = 1.0d8            ! Thermal velocity [cm/s]
     epsmn = 1.0d-3         ! Perturbation amplitude B1/B0 (if pertfile==.false.)
+    pertfile_scale = 1.0d0 ! Scale perturbation read from in_file_pert
     m0 = 0                 ! poloidal perturbation harmonic (if pertfile==.false.)
     mph = 18               ! Toroidal perturbation harmonic (if pertfile==.false., n>0!)
     supban = .true.        ! Shaing superbanana plateau (trapped ell=0) only


### PR DESCRIPTION
## Summary

- Keep `epsmn` for analytic perturbations (`pertfile=.false.`) and set its default to 1.
- Add `pertfile_scale` for perturbations read from `in_file_pert` (`pertfile=.true.`), defaulting to 1.
- Apply the separate scale in the existing magnetic-field and transport paths.
- Update the public configuration docs, examples, and the perturbation behavior probe.

## Validation

- `ctest --test-dir build --output-on-failure` — 14/14 passed.
- `test_perturbation_fourier_kernel` — passed.
- `git diff --check` — passed.