### PR TITLE
fix: restore POTATO radial-box construction

### DIFF
--- a/POTATO/CMakeLists.txt
+++ b/POTATO/CMakeLists.txt
@@ -88,6 +88,16 @@ add_test(NAME test_find_all_roots_bracketed
    COMMAND test_find_all_roots_bracketed.x
 )
 
+add_executable(test_radial_boxes.x
+   SRC/test_radial_boxes.f90
+)
+target_link_libraries(test_radial_boxes.x
+   "$<LINK_GROUP:RESCAN,potato,potato_base>"
+)
+add_test(NAME test_radial_boxes
+   COMMAND test_radial_boxes.x
+)
+
 add_executable(test_wall_loss.x
    SRC/test_wall_loss.f90
 )

--- a/POTATO/SRC/box_counting.f90
+++ b/POTATO/SRC/box_counting.f90
@@ -1,3 +1,22 @@
+subroutine set_radial_boxes(nbox, unif_rho_pol, sbox)
+  implicit none
+
+  integer, intent(in) :: nbox
+  logical, intent(in) :: unif_rho_pol
+  real(8), intent(out) :: sbox(nbox)
+  integer :: i
+  real(8) :: rho_pol
+
+  do i=1,nbox
+    rho_pol = real(i,8)/real(nbox,8)
+    if (unif_rho_pol) then
+      sbox(i) = rho_pol**2
+    else
+      sbox(i) = rho_pol
+    endif
+  enddo
+end subroutine set_radial_boxes
+
 subroutine timestep_vode(n, tau, z, vz)
   implicit none
   ! See velo for details

--- a/POTATO/SRC/test_radial_boxes.f90
+++ b/POTATO/SRC/test_radial_boxes.f90
@@ -1,0 +1,21 @@
+program test_radial_boxes
+  implicit none
+
+  integer, parameter :: nbox=4
+  real(8) :: sbox(nbox)
+  integer :: i
+
+  call set_radial_boxes(nbox, .false., sbox)
+  do i=1,nbox
+    if (abs(sbox(i)-real(i,8)/real(nbox,8)) > 1d-14) then
+      error stop 'non-uniform radial-box boundaries are wrong'
+    endif
+  enddo
+
+  call set_radial_boxes(nbox, .true., sbox)
+  do i=1,nbox
+    if (abs(sbox(i)-(real(i,8)/real(nbox,8))**2) > 1d-14) then
+      error stop 'uniform-rho_pol radial-box boundaries are wrong'
+    endif
+  enddo
+end program test_radial_boxes


### PR DESCRIPTION
This draft PR publishes the existing committed state of `fix/potato-radial-box-helper` so the local branch/worktree can be retired after review.

Checks were not run in this cleanup operation; the branch-specific CI should provide validation.