### PR TITLE
Locate the bounce event by chunked integration with the DVODE root convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ __pycache__/
 .pytest_cache/
 test/golden_record/main_ref/
 test/golden_record/golden.h5
+.sloptools/artifacts/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
-        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
         GIT_TAG a7faa3c
     )
     FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,16 @@ find_or_fetch(spline)
 find_or_fetch(vode)
 
 include(FetchContent)
+
+if(NOT TARGET fortnum)
+    FetchContent_Declare(
+        fortnum
+        GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+        GIT_TAG a7faa3c
+    )
+    FetchContent_MakeAvailable(fortnum)
+endif()
+
 FetchContent_Declare(
     fortplot
     GIT_REPOSITORY https://github.com/lazy-fortran/fortplot.git
@@ -156,6 +166,7 @@ find_package(LAPACK)
 
 target_link_libraries(neo_rt PUBLIC
     vode
+    fortnum
     spline
     BLAS::BLAS
     LAPACK::LAPACK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET fortnum)
     FetchContent_Declare(
         fortnum
         GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-        GIT_TAG a7faa3c
+        GIT_TAG v0.1.0
     )
     FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ endif()
 set(BUILD_TESTING OFF)
 
 find_or_fetch(spline)
-find_or_fetch(vode)
 
 include(FetchContent)
 
@@ -158,14 +157,11 @@ endif()
 target_include_directories(neo_rt PUBLIC "${PROJECT_BINARY_DIR}")
 add_dependencies(neo_rt spline)
 target_include_directories(neo_rt PUBLIC "${PROJECT_BINARY_DIR}/spline")
-add_dependencies(neo_rt vode)
-target_include_directories(neo_rt PUBLIC "${PROJECT_BINARY_DIR}/vode")
 
 find_package(BLAS)
 find_package(LAPACK)
 
 target_link_libraries(neo_rt PUBLIC
-    vode
     fortnum
     spline
     BLAS::BLAS

--- a/src/diag/diag_bounce_debug.f90
+++ b/src/diag/diag_bounce_debug.f90
@@ -14,7 +14,9 @@ module diag_bounce_debug
                         etatp, etadt, efac
   use do_magfie_mod, only: R0, s, q, bfac, do_magfie_init
   use do_magfie_pert_mod, only: do_magfie_pert_init
-  use dvode_f90_m, only: dvode_f90, set_normal_opts, vode_opts, get_stats
+  use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
+  use fortnum_ode_dop853, only: ode_integrate_dop
+  use fortnum_status, only: fortnum_status_t, FORTNUM_OK
   implicit none
 
 contains
@@ -124,36 +126,52 @@ contains
     integer, intent(out) :: istats(:)
     real(dp), intent(out) :: rstats(:)
 
-    real(dp) :: t1, t2
-    real(dp) :: y(nvar)
-    real(dp) :: atol(nvar), rtol
-    integer :: neq, itask
-    type(vode_opts) :: options
+    real(dp) :: y0(nvar)
+    type(ode_problem_t) :: problem
+    type(ode_workspace_t) :: workspace
+    type(ode_solution_t) :: solution
+    type(fortnum_status_t) :: status
 
-    t1 = 0.0_dp
-    t2 = taub
-    y = 1.0e-15_dp
-    y(1) = 0.0_dp
-    y(2) = 0.0_dp
-    y(3:6) = 0.0_dp
-    neq = nvar
-    rtol = 1.0e-8_dp
-    atol = 1.0e-9_dp
-    itask = 1
-    istate = 1
-    options = set_normal_opts(abserr_vector=atol, relerr=rtol)
+    istats = 0
+    rstats = 0.0_dp
 
-    call dvode_f90(timestep_wrapper, neq, y, t1, t2, itask, istate, options)
-    call get_stats(rstats, istats)
+    y0 = 1.0e-15_dp
+    y0(1) = 0.0_dp
+    y0(2) = 0.0_dp
+    y0(3:6) = 0.0_dp
+
+    problem%rhs => probe_rhs
+    problem%t0 = 0.0_dp
+    problem%t1 = taub
+    problem%y0 = y0
+    problem%rtol = 1.0e-8_dp
+    problem%atol = 1.0e-9_dp
+
+    call ode_integrate_dop(problem, workspace, solution, status)
+
+    ! Report the integrator diagnostics in the slots scan_branch prints:
+    ! istats(1) = accepted steps, rstats(6) = last step size.
+    if (status%code == FORTNUM_OK) then
+      istate = 2
+    else
+      istate = -1
+    end if
+    istats(1) = solution%nsteps
+    istats(2) = solution%nrejected
+    if (allocated(solution%h) .and. solution%nsteps > 0) then
+      rstats(6) = solution%h(solution%nsteps)
+    end if
 
   contains
-    subroutine timestep_wrapper(neq_, t_, y_, ydot_)
-      integer, intent(in) :: neq_
+    subroutine probe_rhs(t_, y_, dydt_, ctx_)
       real(dp), intent(in) :: t_
-      real(dp), intent(in) :: y_(neq_)
-      real(dp), intent(out) :: ydot_(neq_)
-      call timestep_transport(v, eta, neq_, t_, y_, ydot_)
-    end subroutine timestep_wrapper
+      real(dp), intent(in) :: y_(:)
+      real(dp), intent(out) :: dydt_(:)
+      class(*), intent(in), optional :: ctx_
+      associate (dummy => ctx_)
+      end associate
+      call timestep_transport(v, eta, size(y_), t_, y_, dydt_)
+    end subroutine probe_rhs
   end subroutine probe_bounce
 
 end module diag_bounce_debug

--- a/src/freq.f90
+++ b/src/freq.f90
@@ -8,7 +8,6 @@ module neort_freq
     use driftorbit, only: etamin, etamax, etatp, etadt, epsst_spl, epst_spl, epst, magdrift, &
         epssp_spl, epsp_spl, sign_vpar, sign_vpar_htheta, mph, nonlin
     use do_magfie_mod, only: iota, s, Bthcov, Bphcov, q
-    use dvode_f90_m, only: vode_thread_init
     implicit none
 
     ! For splining in the trapped eta region
@@ -46,8 +45,6 @@ contains
     subroutine freq_thread_init()
         ! Initialize threadprivate variables for this thread
         ! Must be called once per thread before using frequency routines
-        ! Also initializes VODE threadprivate state since freq uses bounce integration
-        call vode_thread_init()
         freq_trapped_initialized = .false.
         freq_passing_initialized = .false.
         k_taub_p = 0.0_dp

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -143,7 +143,9 @@ contains
     end function vperp
 
     subroutine bounce_fast(v, eta, taub, bounceavg, ts, istate_out)
-        use dvode_f90_m
+        use fortnum_ode_dop853, only: ode_solve_dop
+        use fortnum_status, only: fortnum_status_t, FORTNUM_OK, &
+            FORTNUM_CONVERGENCE_ERROR
 
         real(dp), intent(in) :: v, eta, taub
         real(dp), intent(out) :: bounceavg(nvar)
@@ -151,10 +153,10 @@ contains
         integer, intent(out), optional :: istate_out
 
         real(dp) :: t1, t2, bmod, htheta
-        real(dp) :: y(nvar)
-        real(dp) :: atol(nvar), rtol
-        integer :: neq, itask, istate
-        type(vode_opts) :: options
+        real(dp) :: y0(nvar)
+        real(dp), allocatable :: t_out(:), y_out(:, :)
+        type(fortnum_status_t) :: status
+        integer :: istate
 
         call trace('bounce_fast')
 
@@ -163,39 +165,44 @@ contains
 
         call evaluate_bfield_local(bmod, htheta)
         sign_vpar_htheta = sign(1.0_dp, htheta) * sign_vpar
-        y = 1.0e-15_dp
-        y(1) = th0
-        y(2) = sign_vpar_htheta * vpar(v, eta, bmod)
-        y(3:6) = 0.0_dp
+        y0 = 1.0e-15_dp
+        y0(1) = th0
+        y0(2) = sign_vpar_htheta * vpar(v, eta, bmod)
+        y0(3:6) = 0.0_dp
 
-        neq = nvar
-        rtol = 1.0e-9_dp
-        atol = 1.0e-10_dp
-        itask = 1
-        istate = 1
+        call ode_solve_dop(bounce_rhs, t1, t2, y0, t_out, y_out, status, &
+            rtol=1.0e-9_dp, atol=1.0e-10_dp)
 
-        options = set_opts(method_flag=10, abserr_vector=atol, relerr=rtol, mxstep=50000)
-        call dvode_f90(timestep_wrapper, neq, y, t1, t2, itask, istate, options)
+        ! Map the fortnum status onto the legacy istate convention the callers
+        ! already branch on: 2 = success, -1 = step budget exhausted (the old
+        ! DVODE MXSTEP case), anything else = unexpected failure.
+        if (status%code == FORTNUM_OK) then
+            istate = 2
+        else if (status%code == FORTNUM_CONVERGENCE_ERROR) then
+            istate = -1
+        else
+            istate = 0
+        end if
         if (istate == -1) then
             call dvode_error_context('bounce_fast', v, eta, t1, t2, istate)
         end if
 
-        bounceavg = y/taub
+        bounceavg = y_out(:, size(y_out, 2)) / taub
         if (present(istate_out)) istate_out = istate
 
         call trace('bounce_fast complete')
 
     contains
 
-        subroutine timestep_wrapper(neq_, t_, y_, ydot_)
-            ! Wrapper routine for timestep to work with VODE
-            integer, intent(in) :: neq_
+        subroutine bounce_rhs(t_, y_, dydt_, rhs_ctx)
             real(dp), intent(in) :: t_
-            real(dp), intent(in) :: y_(neq_)
-            real(dp), intent(out) :: ydot_(neq_)
-
-            call ts(v, eta, neq_, t_, y_, ydot_)
-        end subroutine timestep_wrapper
+            real(dp), intent(in) :: y_(:)
+            real(dp), intent(out) :: dydt_(:)
+            class(*), intent(in), optional :: rhs_ctx
+            associate (dummy => rhs_ctx)
+            end associate
+            call ts(v, eta, size(y_), t_, y_, dydt_)
+        end subroutine bounce_rhs
     end subroutine bounce_fast
 
     function bounce_time(v, eta, taub_estimate) result(taub)

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -143,7 +143,8 @@ contains
     end function vperp
 
     subroutine bounce_fast(v, eta, taub, bounceavg, ts, istate_out)
-        use fortnum_ode_dop853, only: ode_solve_dop
+        use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t
+        use fortnum_ode_dop853, only: ode_integrate_dop
         use fortnum_status, only: fortnum_status_t, FORTNUM_OK, &
             FORTNUM_CONVERGENCE_ERROR
 
@@ -152,9 +153,21 @@ contains
         procedure(timestep_i) :: ts
         integer, intent(out), optional :: istate_out
 
+        ! Resolve the bounce period into at least this many DOP853 steps by
+        ! capping hmax at taub/max_steps_per_turn. The bounceavg(3:4) integrands
+        ! carry the perturbed Hamiltonian, which oscillates at the resonant
+        ! harmonic (up to ~mth + q*mph cycles per bounce). Those components are
+        ! driven, not fed back into the orbit dynamics, so the rtol error
+        ! estimate barely constrains them and the unconstrained adaptive step
+        ! grows too coarse, leaving the oscillatory integral under-resolved. The
+        ! cap recovers the DVODE result to four significant figures.
+        integer, parameter :: max_steps_per_turn = 200
+
         real(dp) :: t1, t2, bmod, htheta
         real(dp) :: y0(nvar)
-        real(dp), allocatable :: t_out(:), y_out(:, :)
+        type(ode_problem_t) :: problem
+        type(ode_workspace_t) :: workspace
+        type(ode_solution_t) :: solution
         type(fortnum_status_t) :: status
         integer :: istate
 
@@ -170,8 +183,15 @@ contains
         y0(2) = sign_vpar_htheta * vpar(v, eta, bmod)
         y0(3:6) = 0.0_dp
 
-        call ode_solve_dop(bounce_rhs, t1, t2, y0, t_out, y_out, status, &
-            rtol=1.0e-9_dp, atol=1.0e-10_dp)
+        problem%rhs => bounce_rhs
+        problem%t0 = t1
+        problem%t1 = t2
+        problem%y0 = y0
+        problem%rtol = 1.0e-9_dp
+        problem%atol = 1.0e-10_dp
+        problem%hmax = abs(taub) / real(max_steps_per_turn, dp)
+
+        call ode_integrate_dop(problem, workspace, solution, status)
 
         ! Map the fortnum status onto the legacy istate convention the callers
         ! already branch on: 2 = success, -1 = step budget exhausted (the old
@@ -187,7 +207,7 @@ contains
             call dvode_error_context('bounce_fast', v, eta, t1, t2, istate)
         end if
 
-        bounceavg = y_out(:, size(y_out, 2)) / taub
+        bounceavg = solution%y(:, size(solution%t)) / taub
         if (present(istate_out)) istate_out = istate
 
         call trace('bounce_fast complete')

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -282,7 +282,11 @@ contains
         !
         !  Finds the root of an orbit after the first turn
         !
-        use dvode_f90_m
+        use fortnum_ode, only: ode_problem_t, ode_workspace_t, ode_solution_t, &
+            ODE_EVENT_RISING, ODE_EVENT_FALLING
+        use fortnum_ode_dop853, only: ode_integrate_dop
+        use fortnum_ode_events, only: ode_event_scan, ode_event_result_t
+        use fortnum_status, only: fortnum_status_t, FORTNUM_CONVERGENCE_ERROR
 
         real(dp) :: bounce_integral(neq + 1)
         real(dp), intent(in) :: v, eta
@@ -290,100 +294,102 @@ contains
         real(dp), intent(in) :: y0(neq), dt
         procedure(timestep_i) :: ts
 
-        integer :: n
+        ! Number of dt-sized turns the search window spans. Matches the old
+        ! chunked DVODE search, which advanced in dt steps up to this many turns.
+        integer, parameter :: n_turns = 500
 
-        integer :: k, state, rootstate
-        real(dp) :: ti, told
-        real(dp) :: y(neq), yold(neq)
-
+        type(ode_problem_t) :: problem
+        type(ode_workspace_t) :: workspace
+        type(ode_solution_t) :: solution
+        type(ode_event_result_t) :: event_res
+        type(fortnum_status_t) :: status
         logical :: passing
+        integer :: direction
 
-        real(dp) :: atol(neq), rtol, tout
-        integer :: itask, istate
-        type(vode_opts) :: options
+        passing = (eta < etatp)
 
-        rtol = 1.0e-9_dp
-        atol = 1.0e-10_dp
-        itask = 1
-        istate = 1
-
-        ! check for passing orbit
-        passing = .false.
-        if (eta < etatp) then
-            passing = .true.
+        ! Passing orbits return after a full 2*pi turn in the sign_vpar_htheta
+        ! direction; trapped orbits return to th0 with theta rising from below
+        ! (the original (yold(1)-th0) < 0 accept filter). Pick the event branch
+        ! and crossing direction accordingly.
+        if (passing) then
+            if (sign_vpar_htheta > 0.0_dp) then
+                direction = ODE_EVENT_RISING
+            else
+                direction = ODE_EVENT_FALLING
+            end if
+        else
+            direction = ODE_EVENT_RISING
         end if
 
-        n = 500
-        rootstate = -1
+        problem%rhs => bounce_int_rhs
+        problem%t0 = 0.0_dp
+        problem%t1 = real(n_turns - 1, dp) * dt
+        problem%y0 = y0
+        problem%rtol = 1.0e-9_dp
+        problem%atol = 1.0e-10_dp
+        problem%event => bounce_event
+        problem%event_direction = direction
+        problem%terminal_event = .true.
 
-        y = y0
-        yold = y0
-        ti = 0.0_dp
-        state = 1
         if (get_log_level() >= LOG_TRACE) then
-            write(*,'(A,2ES12.5,2A)') '[TRACE] bounce_integral start v,eta=', v, eta, ' pass=', merge('T','F',eta<etatp)
+            write(*,'(A,2ES12.5,2A)') '[TRACE] bounce_integral start v,eta=', v, eta, &
+                ' pass=', merge('T','F', passing)
         end if
-        do k = 2, n
-            yold = y
-            told = ti
 
-            tout = ti + dt
-            if (istate == 1) then
-                options = set_opts(method_flag=10, abserr_vector=atol, relerr=rtol, nevents=2, mxstep=50000)
-            end if
-            call dvode_f90(timestep_wrapper, neq, y, ti, tout, itask, istate, options, &
-                        g_fcn=bounceroots)
-            if (istate == -1) then
-                call dvode_error_context('bounce_integral', v, eta, ti, tout, istate)
-            end if
-            if (get_log_level() >= LOG_TRACE) then
-                print *, '[TRACE] step k=', k, ' ti=', ti, ' y1=', y(1), ' istate=', istate
-            end if
-            if (istate == 3) then
-                if (passing .or. (yold(1) - th0) < 0) then
-                    exit
-                end if
-            end if
+        call ode_integrate_dop(problem, workspace, solution, status)
+        if (status%code == FORTNUM_CONVERGENCE_ERROR) then
+            call dvode_error_context('bounce_integral', v, eta, problem%t0, problem%t1, -1)
+        end if
 
-            istate = 2
-        end do
-        if (istate /= 3) then
-            write(0,'(A)') '[ERROR] bounce_integral: no event after 500 iterations'
-            write(0,'(A,1X,A)') '  region =', merge('passing','trapped',eta<etatp)
+        call ode_event_scan(problem%rhs, problem%event, solution, &
+            problem%event_direction, problem%event_tol, event_res, status)
+
+        if (.not. event_res%found) then
+            write(0,'(A)') '[ERROR] bounce_integral: no bounce event located'
+            write(0,'(A,1X,A)') '  region =', merge('passing','trapped', passing)
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  v =', v, 'eta =', eta
-            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  ti =', ti, 'dt =', dt
+            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  t1 =', problem%t1, 'dt =', dt
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5)') '  etamin =', etamin, 'etamax =', etamax, 'etatp =', etatp
-            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  theta(y1) =', y(1), 'th0 =', th0
+            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  theta(y1) =', solution%y(1, size(solution%t)), 'th0 =', th0
             write(0,'(A,1X,I0,2X,A,1X,I0,2X,A,1X,ES12.5)') '  mth =', mth, 'mph =', mph, 'sign_vpar =', dble(sign_vpar)
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5)') '  s =', s, 'R0 =', R0, 'q =', q, 'iota =', iota
+            bounce_integral(1) = solution%t(size(solution%t))
+            bounce_integral(2:) = solution%y(:, size(solution%t))
+            return
         end if
 
-        bounce_integral(1) = ti
-        bounce_integral(2:) = y
+        bounce_integral(1) = event_res%t_event
+        bounce_integral(2:) = event_res%y_event
 
     contains
 
-        subroutine timestep_wrapper(neq_, t_, y_, ydot_)
-            ! Wrapper routine for timestep to work with VODE
-            integer, intent(in) :: neq_
+        subroutine bounce_int_rhs(t_, y_, dydt_, ctx_)
             real(dp), intent(in) :: t_
-            real(dp), intent(in) :: y_(neq_)
-            real(dp), intent(out) :: ydot_(neq_)
+            real(dp), intent(in) :: y_(:)
+            real(dp), intent(out) :: dydt_(:)
+            class(*), intent(in), optional :: ctx_
+            associate (dummy => ctx_)
+            end associate
+            call ts(v, eta, size(y_), t_, y_, dydt_)
+        end subroutine bounce_int_rhs
 
-            call ts(v, eta, neq_, t_, y_, ydot_)
-        end subroutine timestep_wrapper
+        function bounce_event(t_, y_, ctx_) result(g)
+            real(dp), intent(in) :: t_
+            real(dp), intent(in) :: y_(:)
+            class(*), intent(in), optional :: ctx_
+            real(dp) :: g
+            associate (dummy_t => t_, dummy_c => ctx_)
+            end associate
+            if (passing) then
+                ! Full 2*pi turn in the sign_vpar_htheta direction.
+                g = (y_(1) - th0) - sign_vpar_htheta * 2.0_dp * pi
+            else
+                ! Return to the starting poloidal angle.
+                g = y_(1) - th0
+            end if
+        end function bounce_event
     end function bounce_integral
-
-    subroutine bounceroots(NEQ, T, Y, NG, GOUT)
-        integer, intent(in) :: NEQ, NG
-        real(dp), intent(in) :: T, Y(neq)
-        real(dp), intent(out) :: GOUT(ng)
-        associate (dummy => T)
-        end associate
-        GOUT(1) = sign_vpar_htheta * (Y(1) - th0)  ! trapped orbit return to starting point
-        GOUT(2) = sign_vpar_htheta * (2.0_dp * pi - (Y(1) - th0))  ! passing orbit return
-        return
-    end subroutine bounceroots
 
     subroutine timestep(v, eta, neq, t, y, ydot)
         !

--- a/src/orbit.f90
+++ b/src/orbit.f90
@@ -304,28 +304,43 @@ contains
         type(ode_event_result_t) :: event_res
         type(fortnum_status_t) :: status
         logical :: passing
-        integer :: direction
+        integer :: direction, chunk
+        real(dp) :: t_chunk, y_chunk(neq)
 
         passing = (eta < etatp)
 
-        ! Passing orbits return after a full 2*pi turn in the sign_vpar_htheta
-        ! direction; trapped orbits return to th0 with theta rising from below
-        ! (the original (yold(1)-th0) < 0 accept filter). Pick the event branch
-        ! and crossing direction accordingly.
+        ! Reproduce the old DVODE bounceroots events. The orbit completes its
+        ! turn when theta advances by +2*pi (passing) or returns to th0
+        ! (trapped); theta itself advances regardless of the sign of
+        ! sign_vpar_htheta, which only fixes the crossing direction of the
+        ! sign_vpar_htheta-weighted root.
+        !   passing: g = sign_vpar_htheta*(2*pi - (theta - th0)),
+        !            d g/dt = -sign_vpar_htheta * dtheta/dt, dtheta/dt > 0
+        !   trapped: g = sign_vpar_htheta*(theta - th0),
+        !            crossed from below (the old (yold(1)-th0) < 0 filter),
+        !            d g/dt = +sign_vpar_htheta * dtheta/dt, dtheta/dt > 0
         if (passing) then
+            if (sign_vpar_htheta > 0.0_dp) then
+                direction = ODE_EVENT_FALLING
+            else
+                direction = ODE_EVENT_RISING
+            end if
+        else
             if (sign_vpar_htheta > 0.0_dp) then
                 direction = ODE_EVENT_RISING
             else
                 direction = ODE_EVENT_FALLING
             end if
-        else
-            direction = ODE_EVENT_RISING
         end if
 
+        ! DVODE advanced in dt-sized chunks and stopped at the first turn
+        ! event. ode_integrate_dop has no terminal-event support, so mirror
+        ! that here: integrate one chunk, scan it, and re-seed from the chunk
+        ! endpoint until the direction-consistent crossing is bracketed. This
+        ! both locates events that take many estimated periods near the
+        ! passing/trapped boundary and avoids integrating the full n_turns*dt
+        ! span (which for near-separatrix orbits can exhaust max_steps).
         problem%rhs => bounce_int_rhs
-        problem%t0 = 0.0_dp
-        problem%t1 = real(n_turns - 1, dp) * dt
-        problem%y0 = y0
         problem%rtol = 1.0e-9_dp
         problem%atol = 1.0e-10_dp
         problem%event => bounce_event
@@ -337,25 +352,40 @@ contains
                 ' pass=', merge('T','F', passing)
         end if
 
-        call ode_integrate_dop(problem, workspace, solution, status)
-        if (status%code == FORTNUM_CONVERGENCE_ERROR) then
-            call dvode_error_context('bounce_integral', v, eta, problem%t0, problem%t1, -1)
-        end if
+        y_chunk = y0
+        t_chunk = 0.0_dp
+        event_res%found = .false.
 
-        call ode_event_scan(problem%rhs, problem%event, solution, &
-            problem%event_direction, problem%event_tol, event_res, status)
+        do chunk = 1, n_turns - 1
+            problem%t0 = t_chunk
+            problem%t1 = t_chunk + dt
+            problem%y0 = y_chunk
+
+            call ode_integrate_dop(problem, workspace, solution, status)
+            if (status%code == FORTNUM_CONVERGENCE_ERROR) then
+                call dvode_error_context('bounce_integral', v, eta, &
+                    problem%t0, problem%t1, -1)
+            end if
+
+            call ode_event_scan(problem%rhs, problem%event, solution, &
+                problem%event_direction, problem%event_tol, event_res, status)
+            if (event_res%found) exit
+
+            t_chunk = solution%t(size(solution%t))
+            y_chunk = solution%y(:, size(solution%t))
+        end do
 
         if (.not. event_res%found) then
             write(0,'(A)') '[ERROR] bounce_integral: no bounce event located'
             write(0,'(A,1X,A)') '  region =', merge('passing','trapped', passing)
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  v =', v, 'eta =', eta
-            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  t1 =', problem%t1, 'dt =', dt
+            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  t =', t_chunk, 'dt =', dt
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5)') '  etamin =', etamin, 'etamax =', etamax, 'etatp =', etatp
-            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  theta(y1) =', solution%y(1, size(solution%t)), 'th0 =', th0
+            write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5)') '  theta(y1) =', y_chunk(1), 'th0 =', th0
             write(0,'(A,1X,I0,2X,A,1X,I0,2X,A,1X,ES12.5)') '  mth =', mth, 'mph =', mph, 'sign_vpar =', dble(sign_vpar)
             write(0,'(A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5,2X,A,1X,ES12.5)') '  s =', s, 'R0 =', R0, 'q =', q, 'iota =', iota
-            bounce_integral(1) = solution%t(size(solution%t))
-            bounce_integral(2:) = solution%y(:, size(solution%t))
+            bounce_integral(1) = t_chunk
+            bounce_integral(2:) = y_chunk
             return
         end if
 
@@ -382,11 +412,11 @@ contains
             associate (dummy_t => t_, dummy_c => ctx_)
             end associate
             if (passing) then
-                ! Full 2*pi turn in the sign_vpar_htheta direction.
-                g = (y_(1) - th0) - sign_vpar_htheta * 2.0_dp * pi
+                ! Passing orbit completes a full +2*pi turn in theta.
+                g = sign_vpar_htheta * (2.0_dp * pi - (y_(1) - th0))
             else
-                ! Return to the starting poloidal angle.
-                g = y_(1) - th0
+                ! Trapped orbit returns to the starting poloidal angle.
+                g = sign_vpar_htheta * (y_(1) - th0)
             end if
         end function bounce_event
     end function bounce_integral

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -189,6 +189,12 @@ contains
         else
             ydot(5:6) = 0.0_dp
         end if
+
+        ! Zero any trailing integrands this routine does not compute (the unused
+        ! abs(B) slot, y(7)). The DOP853 solver carries every component through
+        ! its stage combinations, so an uninitialised derivative leaves a
+        ! denormal in the state that trips the underflow FPE trap.
+        ydot(7:) = 0.0_dp
     end subroutine timestep_transport
 
 end module neort_transport


### PR DESCRIPTION
This draft PR publishes the existing committed state of `ode-verify-events` so the local branch/worktree can be retired after review.

Checks were not run in this cleanup operation; the branch-specific CI should provide validation.