### PR TITLE
port/rust: complete -- freq + resonance + transport + driver -> neo_rt_rust

### DIFF
--- a/port_rust/.gitignore
+++ b/port_rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/port_rust/Cargo.toml
+++ b/port_rust/Cargo.toml
@@ -18,3 +18,7 @@ path = "src/lib.rs"
 
 [profile.release]
 opt-level = 2
+
+[[bin]]
+name = "test_profiles"
+path = "src/bin/test_profiles.rs"

--- a/port_rust/Cargo.toml
+++ b/port_rust/Cargo.toml
@@ -8,6 +8,10 @@ description = "Rust port of NEO-RT (golden path). Uses SUNDIALS CVODE + LAPACK v
 name = "test_spline"
 path = "src/bin/test_spline.rs"
 
+[[bin]]
+name = "test_field"
+path = "src/bin/test_field.rs"
+
 [lib]
 name = "neo_rt_rust"
 path = "src/lib.rs"

--- a/port_rust/Cargo.toml
+++ b/port_rust/Cargo.toml
@@ -22,3 +22,7 @@ opt-level = 2
 [[bin]]
 name = "test_profiles"
 path = "src/bin/test_profiles.rs"
+
+[[bin]]
+name = "test_orbit"
+path = "src/bin/test_orbit.rs"

--- a/port_rust/Cargo.toml
+++ b/port_rust/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "neo_rt_rust"
+version = "0.1.0"
+edition = "2021"
+description = "Rust port of NEO-RT (golden path). Uses SUNDIALS CVODE + LAPACK via FFI."
+
+[[bin]]
+name = "test_spline"
+path = "src/bin/test_spline.rs"
+
+[lib]
+name = "neo_rt_rust"
+path = "src/lib.rs"
+
+[profile.release]
+opt-level = 2

--- a/port_rust/build.rs
+++ b/port_rust/build.rs
@@ -1,0 +1,11 @@
+// Link the same numerical packages as the C port: SUNDIALS CVODE (Adams + root
+// finding) and LAPACK/BLAS (dptsv for the spline solve). SUNDIALS here is
+// MPI-enabled, so libmpi is required for SUN_COMM_NULL.
+fn main() {
+    println!("cargo:rustc-link-lib=dylib=sundials_cvode");
+    println!("cargo:rustc-link-lib=dylib=sundials_core");
+    println!("cargo:rustc-link-lib=dylib=mpi");
+    println!("cargo:rustc-link-lib=dylib=lapack");
+    println!("cargo:rustc-link-lib=dylib=blas");
+    println!("cargo:rustc-link-lib=dylib=m");
+}

--- a/port_rust/src/bin/test_field.rs
+++ b/port_rust/src/bin/test_field.rs
@@ -1,0 +1,40 @@
+//! Cross-checks the Rust field port (do_magfie) against the Fortran do_magfie_mod
+//! reference (field_ref dump on stdin), to rtol 1e-12.
+use neo_rt_rust::field::{do_magfie, do_magfie_init, set_bfac, set_inp_swi};
+use std::io::{self, Read};
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-13 + 1e-12 * b.abs()
+}
+
+fn main() {
+    let in_file = std::env::args().nth(1).expect("usage: test_field <in_file>");
+    set_inp_swi(9);
+    set_bfac(1.0);
+    do_magfie_init(&in_file);
+
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf).unwrap();
+    let nums: Vec<f64> = buf.split_whitespace().map(|t| t.parse().unwrap()).collect();
+    let s = 0.5;
+    let names = ["bmod", "sqrtg", "bder1", "bder3", "hcov2", "hcov3", "hctr2", "hctr3"];
+    let mut checks = 0;
+    let mut fails = 0;
+    let nrow = nums.len() / 11;
+    for i in 0..nrow {
+        let r = &nums[i * 11..i * 11 + 11];
+        let theta = r[0];
+        let (bmod, sqrtg, bder, hcovar, hctrvr) = do_magfie(&[s, 0.0, theta]);
+        let got = [bmod, sqrtg, bder[0], bder[2], hcovar[1], hcovar[2], hctrvr[1], hctrvr[2]];
+        let refv = [r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]];
+        for k in 0..8 {
+            checks += 1;
+            if !close(got[k], refv[k]) {
+                eprintln!("theta={:.5} {} R={:.16e} ref={:.16e}", theta, names[k], got[k], refv[k]);
+                fails += 1;
+            }
+        }
+    }
+    println!("field: {} checks, {} failures", checks, fails);
+    std::process::exit(if fails == 0 { 0 } else { 1 });
+}

--- a/port_rust/src/bin/test_orbit.rs
+++ b/port_rust/src/bin/test_orbit.rs
@@ -1,0 +1,55 @@
+//! Cross-checks the Rust orbit port (CVODE) against the Fortran DVODE orbit
+//! reference (orbit_ref dump on stdin: 3 rows x 6). CVODE and DVODE share the
+//! VODE Adams lineage, so within the 1e-8 gate.
+use neo_rt_rust::driftorbit as dorb;
+use neo_rt_rust::field::{do_magfie, do_magfie_init, set_bfac, set_inp_swi, with_field};
+use neo_rt_rust::magfie::init_flux_surface_average;
+use neo_rt_rust::orbit::{bounce, bounce_time, set_s};
+use neo_rt_rust::profiles::{get, read_and_init_plasma_input, read_and_init_profile_input};
+use std::io::{self, Read};
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-12 + 1e-8 * b.abs()
+}
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let s = 0.5;
+    set_inp_swi(9);
+    set_bfac(1.0);
+    do_magfie_init(&a[1]);
+    let _ = do_magfie(&[s, 0.0, 0.0]);
+    let r0 = with_field(|f| f.r0);
+    init_flux_surface_average(s);
+    read_and_init_plasma_input(&a[2], s);
+    read_and_init_profile_input(&a[3], s, r0, 1.0, 1.0);
+    set_s(s);
+    dorb::update(|d| d.sign_vpar = 1.0);
+
+    let d = dorb::get();
+    let vth = get().vth;
+    let vv = [vth, vth, 1.5 * vth];
+    let ee = [0.5 * (d.etatp + d.etadt), 0.3 * d.etatp, 0.8 * d.etatp + 0.2 * d.etadt];
+
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf).unwrap();
+    let refv: Vec<f64> = buf.split_whitespace().map(|t| t.parse().unwrap()).collect();
+    let names = ["bounce_time", "taub", "bavg1", "bavg2", "bavg3", "bavg6"];
+    let mut fails = 0;
+    let mut checks = 0;
+    for i in 0..3 {
+        let tt = bounce_time(vv[i], ee[i], 0.0, false);
+        let (taub, bavg) = bounce(vv[i], ee[i], 0.0, false);
+        let got = [tt, taub, bavg[0], bavg[1], bavg[2], bavg[5]];
+        for k in 0..6 {
+            let r = refv[i * 6 + k];
+            checks += 1;
+            if !close(got[k], r) {
+                eprintln!("case {} {} R={:.16e} ref={:.16e} rel={:.2e}", i, names[k], got[k], r, ((got[k] - r) / r).abs());
+                fails += 1;
+            }
+        }
+    }
+    println!("orbit: {} checks, {} failures", checks, fails);
+    std::process::exit(if fails == 0 { 0 } else { 1 });
+}

--- a/port_rust/src/bin/test_profiles.rs
+++ b/port_rust/src/bin/test_profiles.rs
@@ -1,0 +1,48 @@
+//! Cross-checks the Rust profiles/collis port against the Fortran modules
+//! (profiles_ref dump on stdin: 21 scalars), to rtol 1e-12.
+use neo_rt_rust::collis::{efcolf, enrat, velrat};
+use neo_rt_rust::field::{do_magfie, do_magfie_init, set_bfac, set_inp_swi, with_field};
+use neo_rt_rust::profiles::{get, init_thermodynamic_forces, read_and_init_plasma_input, read_and_init_profile_input};
+use std::io::{self, Read};
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-13 + 1e-12 * b.abs()
+}
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let s = 0.5;
+    set_inp_swi(9);
+    set_bfac(1.0);
+    do_magfie_init(&a[1]);
+    let _ = do_magfie(&[s, 0.0, 0.0]);
+    let (r0, psi_pr, q) = with_field(|f| (f.r0, f.psi_pr, f.q));
+    read_and_init_plasma_input(&a[2], s);
+    read_and_init_profile_input(&a[3], s, r0, 1.0, 1.0);
+    init_thermodynamic_forces(psi_pr, q);
+
+    let p = get();
+    let ef = efcolf();
+    let vr = velrat();
+    let en = enrat();
+    let got = [
+        p.vth, p.m_t, p.om_te, p.a1, p.a2, p.ni1, p.ni2, p.ti1, p.ti2, p.te, p.qi, p.mi,
+        ef[0], ef[1], ef[2], vr[0], vr[1], vr[2], en[0], en[1], en[2],
+    ];
+    let names = [
+        "vth", "M_t", "Om_tE", "A1", "A2", "ni1", "ni2", "Ti1", "Ti2", "Te", "qi", "mi",
+        "efcolf1", "efcolf2", "efcolf3", "velrat1", "velrat2", "velrat3", "enrat1", "enrat2", "enrat3",
+    ];
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf).unwrap();
+    let refv: Vec<f64> = buf.split_whitespace().map(|t| t.parse().unwrap()).collect();
+    let mut fails = 0;
+    for k in 0..21 {
+        if !close(got[k], refv[k]) {
+            eprintln!("{} R={:.16e} ref={:.16e}", names[k], got[k], refv[k]);
+            fails += 1;
+        }
+    }
+    println!("profiles: 21 checks, {} failures", fails);
+    std::process::exit(if fails == 0 { 0 } else { 1 });
+}

--- a/port_rust/src/bin/test_spline.rs
+++ b/port_rust/src/bin/test_spline.rs
@@ -1,0 +1,57 @@
+//! Cross-checks the Rust spline against the Fortran itpplasma spline reference
+//! (spline_ref dump on stdin: COEFF and VAL lines), to rtol 1e-12.
+use neo_rt_rust::spline::{spline_coeff, spline_val_0};
+use std::io::{self, Read};
+
+const NP: usize = 9;
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-14 + 1e-12 * b.abs()
+}
+
+fn main() {
+    let x: Vec<f64> = (0..NP).map(|i| i as f64 * 0.37).collect();
+    let y: Vec<f64> = x.iter().map(|&xi| (1.3 * xi).sin() + 0.5 * xi).collect();
+    let coeff = spline_coeff(&x, &y);
+
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap();
+    let mut tok = input.split_whitespace();
+
+    let mut checks = 0;
+    let mut fails = 0;
+    // coefficients
+    for _ in 0..(NP - 1) {
+        assert_eq!(tok.next().unwrap(), "COEFF");
+        let idx: usize = tok.next().unwrap().parse().unwrap();
+        for k in 0..5 {
+            let refv: f64 = tok.next().unwrap().parse().unwrap();
+            checks += 1;
+            if !close(coeff[idx * 5 + k], refv) {
+                eprintln!("COEFF[{}][{}] R={:.16e} ref={:.16e}", idx, k, coeff[idx * 5 + k], refv);
+                fails += 1;
+            }
+        }
+    }
+    // evaluations
+    let mut jstart = 1i32;
+    while let Some(tag) = tok.next() {
+        assert_eq!(tag, "VAL");
+        let xe: f64 = tok.next().unwrap().parse().unwrap();
+        let refv: [f64; 3] = [
+            tok.next().unwrap().parse().unwrap(),
+            tok.next().unwrap().parse().unwrap(),
+            tok.next().unwrap().parse().unwrap(),
+        ];
+        let out = spline_val_0(&coeff, NP - 1, xe, &mut jstart);
+        for k in 0..3 {
+            checks += 1;
+            if !close(out[k], refv[k]) {
+                eprintln!("VAL(x={:.6})[{}] R={:.16e} ref={:.16e}", xe, k, out[k], refv[k]);
+                fails += 1;
+            }
+        }
+    }
+    println!("spline: {} checks, {} failures", checks, fails);
+    std::process::exit(if fails == 0 { 0 } else { 1 });
+}

--- a/port_rust/src/collis.rs
+++ b/port_rust/src/collis.rs
@@ -1,0 +1,95 @@
+//! Collision coefficients, literal port of collis_alp (collis_nbi.f90). Module
+//! state efcolf/velrat/enrat in a thread_local (single-threaded gate). collis
+//! keeps its local ev=1.6022e-12 distinct from util ev, faithful to Fortran.
+
+use std::cell::RefCell;
+
+pub const NSORTS: usize = 3;
+
+thread_local! {
+    static ST: RefCell<[[f64; NSORTS]; 3]> = RefCell::new([[0.0; NSORTS]; 3]);
+    // [0]=efcolf, [1]=velrat, [2]=enrat
+}
+
+pub fn efcolf() -> [f64; NSORTS] {
+    ST.with(|s| s.borrow()[0])
+}
+pub fn velrat() -> [f64; NSORTS] {
+    ST.with(|s| s.borrow()[1])
+}
+pub fn enrat() -> [f64; NSORTS] {
+    ST.with(|s| s.borrow()[2])
+}
+
+fn onseff(v: f64) -> (f64, f64, f64) {
+    let sqp = 1.7724538;
+    let cons = 0.75225278;
+    let v2 = v * v;
+    let v3 = v2 * v;
+    if v < 0.01 {
+        (cons * (1.0 - 0.6 * v2), cons * (1.0 - 0.2 * v2), 2.0 * cons * (1.0 - 1.2 * v2))
+    } else if v > 6.0 {
+        (1.0 / v3, (1.0 - 0.5 / v2) / v, -1.0 / v3)
+    } else {
+        let ex = (-v2).exp() / sqp;
+        let er = erf(v);
+        let d_p = er / v3 - 2.0 * ex / v2;
+        (d_p, er * (1.0 - 0.5 / v2) / v + ex / v2, 4.0 * ex - d_p)
+    }
+}
+
+/// dpp, dhh, fpeff (coleff).
+pub fn coleff(p: f64) -> (f64, f64, f64) {
+    let plim = if p > 1.0e-8 { p } else { 1.0e-8 };
+    let (ef, vr, en) = (efcolf(), velrat(), enrat());
+    let (mut dpp, mut dhh, mut fpeff) = (0.0, 0.0, 0.0);
+    for i in 0..NSORTS {
+        let (d_p, dh, dpd) = onseff(p * vr[i]);
+        dpp += d_p * ef[i];
+        dhh += dh * ef[i];
+        fpeff += (dpd / plim - 2.0 * d_p * p * en[i]) * ef[i];
+    }
+    dhh /= plim * plim;
+    (dpp, dhh, fpeff)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn loacol_nbi(amb: f64, am1: f64, am2: f64, zb: f64, z1: f64, z2: f64, densi1: f64, densi2: f64, tempi1: f64, tempi2: f64, tempe: f64, ebeam: f64) -> f64 {
+    let pi = 3.14159265358979;
+    let (pmass, emass, e, ev): (f64, f64, f64, f64) = (1.6726e-24, 9.1094e-28, 4.8032e-10, 1.6022e-12);
+    let eps = f64::EPSILON;
+    let v0 = (2.0 * ebeam * ev / (amb * pmass)).sqrt();
+    let vti1 = (2.0 * tempi1 * ev / (pmass * am1)).sqrt();
+    let vti2 = (2.0 * tempi2 * ev / (pmass * am2)).sqrt();
+    let vte = (2.0 * tempe * ev / emass).sqrt();
+    let dense = densi1 * z1 + densi2 * z2;
+    let a1 = (densi1 * z1 * z1 / tempi1).sqrt() * zb * z1 * (amb + am1) / (amb * tempi1 + am1 * ebeam);
+    let a2 = (densi2 * z2 * z2 / tempi2).sqrt() * zb * z2 * (amb + am2) / (amb * tempi2 + am2 * ebeam);
+    let alami1 = 23.0 - (if a1 > eps { a1 } else { eps }).ln();
+    let alami2 = 23.0 - (if a2 > eps { a2 } else { eps }).ln();
+    let alame = 24.0 - (dense.sqrt() / tempe).ln();
+    let mut frecol = 2.0 * pi * dense * e.powi(4) * zb * zb / ((amb * pmass).powi(2) * v0.powi(3));
+    frecol /= v0;
+    ST.with(|s| {
+        let mut st = s.borrow_mut();
+        st[2] = [ebeam / tempi1, ebeam / tempi2, ebeam / tempe];
+        st[1] = [v0 / vti1, v0 / vti2, v0 / vte];
+        st[0] = [
+            frecol * z1 * z1 * alami1 * densi1 / dense,
+            frecol * z2 * z2 * alami2 * densi2 / dense,
+            frecol * alame,
+        ];
+        for i in 0..NSORTS {
+            st[0][i] *= st[1][i];
+        }
+    });
+    v0
+}
+
+/// erf via libm (matches Fortran intrinsic erf).
+fn erf(x: f64) -> f64 {
+    extern "C" {
+        fn erf(x: f64) -> f64;
+    }
+    unsafe { erf(x) }
+}

--- a/port_rust/src/cvode.rs
+++ b/port_rust/src/cvode.rs
@@ -1,0 +1,51 @@
+//! Minimal FFI to SUNDIALS CVODE (Adams) + fixed-point nonlinear solver +
+//! root finding -- the same library the C port uses, so the Rust orbit
+//! integration is bit-identical to C. Single-threaded use only.
+//!
+//! sunrealtype is f64 in the default SUNDIALS build. Opaque handles are raw
+//! pointers. SUN_COMM_NULL is a null comm (SUNDIALS here is MPI-enabled, hence
+//! libmpi is linked in build.rs); passing null works for the serial context.
+
+use std::os::raw::{c_int, c_long, c_void};
+
+pub const CV_ADAMS: c_int = 1;
+pub const CV_NORMAL: c_int = 1;
+pub const CV_ROOT_RETURN: c_int = 2;
+
+pub type SunContext = *mut c_void;
+pub type NVector = *mut c_void;
+pub type CvodeMem = *mut c_void;
+pub type SunNonlinSol = *mut c_void;
+
+pub type CvRhsFn = extern "C" fn(t: f64, y: NVector, ydot: NVector, user_data: *mut c_void) -> c_int;
+pub type CvRootFn = extern "C" fn(t: f64, y: NVector, gout: *mut f64, user_data: *mut c_void) -> c_int;
+
+extern "C" {
+    // OpenMPI's MPI_COMM_NULL is &ompi_mpi_comm_null; SUN_COMM_NULL maps to it.
+    // Passing a plain null pointer makes SUNDIALS call MPI_Comm_dup -> abort.
+    pub static ompi_mpi_comm_null: u8;
+}
+
+/// The SUNComm value equal to C's SUN_COMM_NULL (MPI_COMM_NULL) on this build.
+pub fn sun_comm_null() -> *mut c_void {
+    unsafe { &ompi_mpi_comm_null as *const u8 as *mut c_void }
+}
+
+extern "C" {
+    pub fn SUNContext_Create(comm: *mut c_void, ctx: *mut SunContext) -> c_int;
+    pub fn SUNContext_Free(ctx: *mut SunContext) -> c_int;
+    pub fn N_VNew_Serial(len: c_long, ctx: SunContext) -> NVector;
+    pub fn N_VGetArrayPointer(v: NVector) -> *mut f64;
+    pub fn N_VDestroy(v: NVector);
+    pub fn CVodeCreate(lmm: c_int, ctx: SunContext) -> CvodeMem;
+    pub fn CVodeInit(mem: CvodeMem, f: CvRhsFn, t0: f64, y0: NVector) -> c_int;
+    pub fn CVodeSStolerances(mem: CvodeMem, reltol: f64, abstol: f64) -> c_int;
+    pub fn CVodeSetMaxNumSteps(mem: CvodeMem, mxsteps: c_long) -> c_int;
+    pub fn CVodeSetUserData(mem: CvodeMem, user_data: *mut c_void) -> c_int;
+    pub fn SUNNonlinSol_FixedPoint(y: NVector, m: c_int, ctx: SunContext) -> SunNonlinSol;
+    pub fn CVodeSetNonlinearSolver(mem: CvodeMem, nls: SunNonlinSol) -> c_int;
+    pub fn SUNNonlinSolFree(nls: SunNonlinSol) -> c_int;
+    pub fn CVodeRootInit(mem: CvodeMem, nrtfn: c_int, g: CvRootFn) -> c_int;
+    pub fn CVode(mem: CvodeMem, tout: f64, yout: NVector, tret: *mut f64, itask: c_int) -> c_int;
+    pub fn CVodeFree(mem: *mut CvodeMem);
+}

--- a/port_rust/src/driftorbit.rs
+++ b/port_rust/src/driftorbit.rs
@@ -1,0 +1,61 @@
+//! Shared driftorbit state (driftorbit.f90) + orbit th0/noshear, as a
+//! thread_local struct (single-threaded gate). Mirrors the C globals.
+
+use std::cell::RefCell;
+
+pub const EPST_SPL: f64 = 1.0e-6;
+pub const EPSP_SPL: f64 = 1.0e-6;
+pub const EPSST_SPL: f64 = 1.0e-3;
+pub const EPSSP_SPL: f64 = 1.0e-3;
+pub const EPST: f64 = 1.0e-8;
+pub const EPSP: f64 = 1.0e-8;
+pub const NLEV: usize = 100;
+
+#[derive(Clone, Copy)]
+pub struct DriftOrbit {
+    pub efac: f64,
+    pub epsmn: f64,
+    pub m0: i32,
+    pub mth: i32,
+    pub mph: i32,
+    pub magdrift: bool,
+    pub nopassing: bool,
+    pub pertfile: bool,
+    pub comptorque: bool,
+    pub nonlin: bool,
+    pub dvds: f64,
+    pub etadt: f64,
+    pub etatp: f64,
+    pub etamin: f64,
+    pub etamax: f64,
+    pub b0: f64,
+    pub bmin: f64,
+    pub bmax: f64,
+    pub sign_vpar: f64,
+    pub sign_vpar_htheta: f64,
+    pub noshear: bool,
+    pub th0: f64,
+}
+
+impl Default for DriftOrbit {
+    fn default() -> Self {
+        DriftOrbit {
+            efac: 1.0, epsmn: 1.0, m0: 1, mth: 1, mph: 1,
+            magdrift: true, nopassing: false, pertfile: false, comptorque: true,
+            nonlin: false, dvds: 0.0, etadt: 0.0, etatp: 0.0, etamin: 0.0, etamax: 0.0,
+            b0: 0.0, bmin: 0.0, bmax: 0.0, sign_vpar: 1.0, sign_vpar_htheta: 1.0,
+            noshear: false, th0: 0.0,
+        }
+    }
+}
+
+thread_local! {
+    static D: RefCell<DriftOrbit> = RefCell::new(DriftOrbit::default());
+}
+
+pub fn get() -> DriftOrbit {
+    D.with(|c| *c.borrow())
+}
+pub fn update(f: impl FnOnce(&mut DriftOrbit)) {
+    D.with(|c| f(&mut c.borrow_mut()))
+}

--- a/port_rust/src/field.rs
+++ b/port_rust/src/field.rs
@@ -64,6 +64,9 @@ pub fn set_bfac(v: f64) {
 pub fn set_inp_swi(v: i32) {
     F.with(|c| c.borrow_mut().inp_swi = v);
 }
+pub fn set_eps(v: f64) {
+    F.with(|c| c.borrow_mut().eps = v);
+}
 
 /// Read a Boozer file, mirroring boozer_read (header skip 5, per-surface skip 2
 /// before params and 1 before modes). Returns (nflux, nmode, nfp, flux, a, R0,

--- a/port_rust/src/field.rs
+++ b/port_rust/src/field.rs
@@ -1,0 +1,325 @@
+//! Axisymmetric + perturbation magnetic field, literal port of do_magfie_mod /
+//! do_magfie_pert_mod (do_magfie_standalone.f90), mirroring the C port. Module
+//! state lives in a thread_local (single-threaded gate), with accessors for the
+//! orbit/transport layers that read the shared field quantities.
+
+use crate::spline::{spline_coeff, spline_val_0};
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+pub const SIGN_THETA: f64 = -1.0;
+const ITOB: f64 = 2.0e-1 * SIGN_THETA;
+const PI: f64 = std::f64::consts::PI;
+
+#[derive(Default)]
+pub struct Field {
+    pub bfac: f64,
+    pub inp_swi: i32,
+    pub psi_pr: f64,
+    pub r0: f64,
+    pub a: f64,
+    pub b00: f64,
+    pub bthcov: f64,
+    pub bphcov: f64,
+    pub dbthcovds: f64,
+    pub dbphcovds: f64,
+    pub q: f64,
+    pub dqds: f64,
+    pub iota: f64,
+    pub eps: f64,
+    pub b0h: f64,
+    pub nflux: usize,
+    pub nmode: usize,
+    ncol1: usize,
+    ncol2: usize,
+    params0: Vec<f64>, // nflux x (ncol1+1)
+    modes0: Vec<f64>,  // nflux x nmode x (ncol2+2)
+    spl1: Vec<f64>,    // ncol1 splines of nseg*5
+    spl2: Vec<f64>,    // ncol2*nmode splines of nseg*5
+    nseg: usize,
+    jstart: i32,
+    // perturbation
+    pub pert_mph: i32,
+    p_ncol2: usize,
+    p_nflux: usize,
+    p_nmode: usize,
+    p_nfp: i32,
+    p_nseg: usize,
+    p_params: Vec<f64>,
+    p_modes: Vec<f64>,
+    p_spl2: Vec<f64>,
+}
+
+thread_local! {
+    static F: RefCell<Field> = RefCell::new(Field { bfac: 1.0, jstart: 1, ..Default::default() });
+}
+
+pub fn with_field<R>(f: impl FnOnce(&Field) -> R) -> R {
+    F.with(|c| f(&c.borrow()))
+}
+pub fn set_bfac(v: f64) {
+    F.with(|c| c.borrow_mut().bfac = v);
+}
+pub fn set_inp_swi(v: i32) {
+    F.with(|c| c.borrow_mut().inp_swi = v);
+}
+
+/// Read a Boozer file, mirroring boozer_read (header skip 5, per-surface skip 2
+/// before params and 1 before modes). Returns (nflux, nmode, nfp, flux, a, R0,
+/// params, modes) with params nflux x (ncol1+1), modes nflux x nmode x (nc2+2).
+fn boozer_read(path: &str, ncol1: usize, nc2: usize) -> (usize, usize, i32, f64, f64, f64, Vec<f64>, Vec<f64>) {
+    let file = File::open(path).unwrap_or_else(|_| panic!("cannot open {}", path));
+    let mut lines = BufReader::new(file).lines().map(|l| l.unwrap());
+    for _ in 0..5 {
+        lines.next();
+    }
+    let hdr: Vec<f64> = lines
+        .next()
+        .unwrap()
+        .split_whitespace()
+        .map(|t| t.parse().unwrap())
+        .collect();
+    let (m0b, n0b, nflux, nfp) = (hdr[0] as i32, hdr[1] as i32, hdr[2] as usize, hdr[3] as i32);
+    let (flux, a, r0) = (hdr[4], hdr[5], hdr[6]);
+    let nmode = ((m0b + 1) * (n0b + 1)) as usize;
+    let pcols = ncol1 + 1;
+    let mcols = nc2 + 2;
+    let mut params = vec![0.0f64; nflux * pcols];
+    let mut modes = vec![0.0f64; nflux * nmode * mcols];
+    for ks in 0..nflux {
+        lines.next();
+        lines.next(); // two label lines
+        let pv: Vec<f64> = lines
+            .next()
+            .unwrap()
+            .split_whitespace()
+            .map(|t| t.parse().unwrap())
+            .collect();
+        for k in 0..pcols {
+            params[ks * pcols + k] = pv[k];
+        }
+        lines.next(); // mode-label line
+        for j in 0..nmode {
+            let mv: Vec<f64> = lines
+                .next()
+                .unwrap()
+                .split_whitespace()
+                .map(|t| t.parse().unwrap())
+                .collect();
+            for k in 0..mcols {
+                modes[(ks * nmode + j) * mcols + k] = mv[k];
+            }
+        }
+    }
+    (nflux, nmode, nfp, flux, a, r0, params, modes)
+}
+
+fn build_splines(params: &[f64], modes: &[f64], nflux: usize, nmode: usize, nc2: usize, pcols: usize, mcols: usize) -> (Vec<f64>, Vec<f64>) {
+    let ncol1 = pcols - 1;
+    let seg = nflux - 1;
+    let x: Vec<f64> = (0..nflux).map(|i| params[i * pcols]).collect();
+    let mut s1 = vec![0.0f64; ncol1 * seg * 5];
+    for k in 0..ncol1 {
+        let y: Vec<f64> = (0..nflux).map(|i| params[i * pcols + k + 1]).collect();
+        let c = spline_coeff(&x, &y);
+        s1[k * seg * 5..(k + 1) * seg * 5].copy_from_slice(&c);
+    }
+    let mut s2 = vec![0.0f64; nc2 * nmode * seg * 5];
+    for j in 0..nmode {
+        for k in 0..nc2 {
+            let y: Vec<f64> = (0..nflux).map(|i| modes[(i * nmode + j) * mcols + k + 2]).collect();
+            let c = spline_coeff(&x, &y);
+            let off = (k * nmode + j) * seg * 5;
+            s2[off..off + seg * 5].copy_from_slice(&c);
+        }
+    }
+    (s1, s2)
+}
+
+pub fn do_magfie_init(path: &str) {
+    F.with(|c| {
+        let mut f = c.borrow_mut();
+        f.ncol1 = 5;
+        f.ncol2 = if f.inp_swi == 8 { 4 } else { 8 };
+        let (nflux, nmode, _nfp, flux, a, r0, params, modes) = boozer_read(path, f.ncol1, f.ncol2);
+        f.nflux = nflux;
+        f.nmode = nmode;
+        f.a = 100.0 * a;
+        f.r0 = 100.0 * r0;
+        f.psi_pr = 1.0e8 * flux / (2.0 * PI) * f.bfac;
+        f.nseg = nflux - 1;
+        let (s1, s2) = build_splines(&params, &modes, nflux, nmode, f.ncol2, f.ncol1 + 1, f.ncol2 + 2);
+        f.params0 = params;
+        f.modes0 = modes;
+        f.spl1 = s1;
+        f.spl2 = s2;
+        let mcols = f.ncol2 + 2;
+        f.r0 = f.modes0[0 * nmode * mcols + 0 * mcols + 2] * 100.0;
+        f.b00 = 1.0e4 * f.modes0[0 * nmode * mcols + 0 * mcols + 5] * f.bfac;
+    });
+}
+
+/// do_magfie at x=(s,ph,th): returns (bmod, sqrtg, bder[3], hcovar[3], hctrvr[3]).
+/// Updates the shared bthcov/bphcov/iota/q/dqds etc.
+pub fn do_magfie(x: &[f64; 3]) -> (f64, f64, [f64; 3], [f64; 3], [f64; 3]) {
+    F.with(|c| {
+        let mut f = c.borrow_mut();
+        let pcols = f.ncol1 + 1;
+        let mcols = f.ncol2 + 2;
+        let nseg = f.nseg;
+        let nm = f.nmode;
+        let bf = f.bfac;
+        let mut x1 = if f.params0[0] > x[0] { f.params0[0] } else { x[0] };
+        let last = f.params0[(f.nflux - 1) * pcols];
+        if last < x1 {
+            x1 = last;
+        }
+        let mut js = f.jstart;
+        let sv = spline_val_0(&f.spl1[2 * nseg * 5..3 * nseg * 5], nseg, x1, &mut js);
+        f.bthcov = ITOB * sv[0] * bf;
+        f.dbthcovds = ITOB * sv[1] * bf;
+        let sv = spline_val_0(&f.spl1[1 * nseg * 5..2 * nseg * 5], nseg, x1, &mut js);
+        f.bphcov = ITOB * sv[0] * bf;
+        f.dbphcovds = ITOB * sv[1] * bf;
+        let sv = spline_val_0(&f.spl1[0..nseg * 5], nseg, x1, &mut js);
+        f.iota = sv[0];
+        f.q = 1.0 / f.iota;
+        f.dqds = -sv[1] / (f.iota * f.iota);
+
+        let m0 = f.modes0[(0 * nm + 0) * mcols + 0];
+        let m1 = f.modes0[(0 * nm + 1) * mcols + 0];
+        let dm = m1 - m0;
+        let mut cost = vec![0.0f64; nm];
+        let mut sint = vec![0.0f64; nm];
+        // fast_sin_cos
+        let (mut ffr, mut ffi) = ((m0 * x[2]).cos(), (m0 * x[2]).sin());
+        let (rotr, roti) = ((dm * x[2]).cos(), (dm * x[2]).sin());
+        for j in 0..nm {
+            cost[j] = ffr;
+            sint[j] = ffi;
+            let nr = ffr * rotr - ffi * roti;
+            let ni = ffr * roti + ffi * rotr;
+            ffr = nr;
+            ffi = ni;
+        }
+
+        let (mut bm, mut db, mut bth) = (0.0, 0.0, 0.0);
+        if f.inp_swi == 8 {
+            for j in 0..nm {
+                let s2 = &f.spl2[(3 * nm + j) * nseg * 5..(3 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2, nseg, x1, &mut js);
+                let bmnc = 1.0e4 * sv[0] * bf;
+                let dbmnc = 1.0e4 * sv[1] * bf;
+                if j == 0 {
+                    f.b0h = bmnc;
+                }
+                bm += bmnc * cost[j];
+                db += dbmnc * cost[j];
+                bth += -f.modes0[(0 * nm + j) * mcols] * bmnc * sint[j];
+            }
+        } else {
+            for j in 0..nm {
+                let s2c = &f.spl2[(6 * nm + j) * nseg * 5..(6 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2c, nseg, x1, &mut js);
+                let bmnc = 1.0e4 * sv[0] * bf;
+                let dbmnc = 1.0e4 * sv[1] * bf;
+                let s2s = &f.spl2[(7 * nm + j) * nseg * 5..(7 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2s, nseg, x1, &mut js);
+                let bmns = 1.0e4 * sv[0] * bf;
+                let dbmns = 1.0e4 * sv[1] * bf;
+                if j == 0 {
+                    f.b0h = bmnc;
+                }
+                let mj = f.modes0[(0 * nm + j) * mcols];
+                bm += bmnc * cost[j] + bmns * sint[j];
+                db += dbmnc * cost[j] + dbmns * sint[j];
+                bth += -mj * bmnc * sint[j] + mj * bmns * cost[j];
+            }
+        }
+        f.jstart = js;
+        let bder = [db / bm, 0.0, bth / bm];
+        let sqgbmod2 = SIGN_THETA * f.psi_pr * (f.bphcov + f.iota * f.bthcov);
+        let sqgbmod = sqgbmod2 / bm;
+        let sqrtg = sqgbmod / bm;
+        let hcovar = [0.0, f.bphcov / bm, f.bthcov / bm];
+        let hctrvr = [
+            0.0,
+            SIGN_THETA * f.psi_pr / sqgbmod,
+            SIGN_THETA * f.iota * f.psi_pr / sqgbmod,
+        ];
+        (bm, sqrtg, bder, hcovar, hctrvr)
+    })
+}
+
+pub fn do_magfie_pert_init(path: &str) {
+    F.with(|c| {
+        let mut f = c.borrow_mut();
+        let ncol1 = 5usize;
+        let nc2 = if f.inp_swi == 8 { 4 } else { 8 };
+        let (nflux, nmode, nfp, _flux, _a, _r0, params, modes) = boozer_read(path, ncol1, nc2);
+        f.p_ncol2 = nc2;
+        f.p_nflux = nflux;
+        f.p_nmode = nmode;
+        f.p_nfp = nfp;
+        f.p_nseg = nflux - 1;
+        let mcols = nc2 + 2;
+        let nv = modes[(0 * nmode + 0) * mcols + 1];
+        f.pert_mph = (nfp as f64 * nv).round() as i32;
+        let (_s1, s2) = build_splines(&params, &modes, nflux, nmode, nc2, ncol1 + 1, mcols);
+        f.p_params = params;
+        f.p_modes = modes;
+        f.p_spl2 = s2;
+    });
+}
+
+/// Perturbation amplitude bamp at x=(s,ph,th) as (re, im).
+pub fn do_magfie_pert_amp(x: &[f64; 3]) -> (f64, f64) {
+    F.with(|c| {
+        let mut f = c.borrow_mut();
+        let pcols = 6usize;
+        let mcols = f.p_ncol2 + 2;
+        let nseg = f.p_nseg;
+        let nm = f.p_nmode;
+        let bf = f.bfac;
+        let mut x1 = if f.p_params[0] > x[0] { f.p_params[0] } else { x[0] };
+        let last = f.p_params[(f.p_nflux - 1) * pcols];
+        if last < x1 {
+            x1 = last;
+        }
+        let mut js = f.jstart;
+        let (mut sr, mut si) = (0.0, 0.0);
+        if f.inp_swi == 8 {
+            for j in 0..nm {
+                let s2 = &f.p_spl2[(3 * nm + j) * nseg * 5..(3 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2, nseg, x1, &mut js);
+                let bmnc = 1.0e4 * sv[0] * bf;
+                let m = f.p_modes[(0 * nm + j) * mcols];
+                sr += bmnc * (m * x[2]).cos();
+            }
+        } else {
+            let m0 = f.p_modes[(0 * nm + 0) * mcols];
+            let m1 = f.p_modes[(0 * nm + 1) * mcols];
+            let dm = m1 - m0;
+            let (mut ffr, mut ffi) = ((m0 * x[2]).cos(), (m0 * x[2]).sin());
+            let (rotr, roti) = ((dm * x[2]).cos(), (dm * x[2]).sin());
+            for j in 0..nm {
+                let s2c = &f.p_spl2[(6 * nm + j) * nseg * 5..(6 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2c, nseg, x1, &mut js);
+                let bmnc = 1.0e4 * sv[0] * bf;
+                let s2s = &f.p_spl2[(7 * nm + j) * nseg * 5..(7 * nm + j + 1) * nseg * 5];
+                let sv = spline_val_0(s2s, nseg, x1, &mut js);
+                let bmns = 1.0e4 * sv[0] * bf;
+                // (bmnc - i bmns) * (ffr + i ffi)
+                sr += bmnc * ffr + bmns * ffi;
+                si += bmnc * ffi - bmns * ffr;
+                let nr = ffr * rotr - ffi * roti;
+                let ni = ffr * roti + ffi * rotr;
+                ffr = nr;
+                ffi = ni;
+            }
+        }
+        f.jstart = js;
+        (sr, si)
+    })
+}

--- a/port_rust/src/freq.rs
+++ b/port_rust/src/freq.rs
@@ -1,0 +1,284 @@
+//! Canonical-frequency splines + evaluation, literal port of neort_freq
+//! (freq.f90), built on the verified orbit + spline layers. thread_local state.
+
+use crate::driftorbit as dorb;
+use crate::field::with_field;
+use crate::orbit::{bounce_fast, bounce_time, set_s, NVAR};
+use crate::profiles;
+use crate::spline::{spline_coeff, spline_val_0};
+use std::cell::RefCell;
+
+pub const NETASPL: usize = 100;
+const PI: f64 = std::f64::consts::PI;
+
+#[derive(Default)]
+struct FreqState {
+    omth_spl: Vec<f64>,
+    omtb_spl: Vec<f64>,
+    omth_pass_spl: Vec<f64>,
+    omtb_pass_spl: Vec<f64>,
+    k_taub_p: f64,
+    d_taub_p: f64,
+    k_taub_t: f64,
+    d_taub_t: f64,
+    k_omtb_p: f64,
+    d_omtb_p: f64,
+    k_omtb_t: f64,
+    d_omtb_t: f64,
+    js: [i32; 4],
+}
+
+thread_local! {
+    static FS: RefCell<FreqState> = RefCell::new(FreqState { js: [1; 4], ..Default::default() });
+}
+
+pub fn init_canon_freq_trapped_spline() {
+    let n = NETASPL;
+    let v = profiles::get().vth;
+    let d = dorb::get();
+    let etatp = d.etatp;
+    let etamin = (1.0 + dorb::EPST) * etatp;
+    let etamax = etatp + (d.etadt - etatp) * (1.0 - dorb::EPSST_SPL);
+    dorb::update(|x| {
+        x.etamin = etamin;
+        x.etamax = etamax;
+    });
+    let magdrift = d.magdrift;
+
+    let b = (dorb::EPST_SPL).ln();
+    let aa = 1.0 / (n as f64 - 1.0) * ((etamax / etamin - 1.0).ln() - b);
+    let mut etarange = vec![0.0f64; n];
+    let mut omtb_v = vec![0.0f64; n];
+    let mut omth_v = vec![0.0f64; n];
+    let (mut taub0, mut taub1, mut leta0, mut leta1, mut otb0, mut otb1) = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let mut est = 0.0f64;
+    for k in (0..n).rev() {
+        let eta = etamin * (1.0 + (aa * k as f64 + b).exp());
+        etarange[k] = eta;
+        est = if k == n - 1 { bounce_time(v, eta, 0.0, false) } else { bounce_time(v, eta, est, true) };
+        let taub = est;
+        let bavg = bounce_fast(v, eta, taub);
+        if magdrift {
+            omtb_v[k] = bavg[2];
+        }
+        omth_v[k] = 2.0 * PI / (v * taub);
+        if k == 0 {
+            leta0 = (eta - etatp).ln();
+            taub0 = v * taub;
+            if magdrift {
+                otb0 = omtb_v[k] / omth_v[k];
+            }
+        }
+        if k == 1 {
+            leta1 = (eta - etatp).ln();
+            taub1 = v * taub;
+            if magdrift {
+                otb1 = omtb_v[k] / omth_v[k];
+            }
+        }
+    }
+    let omth_spl = spline_coeff(&etarange, &omth_v);
+    let omtb_spl = if magdrift { spline_coeff(&etarange, &omtb_v) } else { Vec::new() };
+    FS.with(|c| {
+        let mut f = c.borrow_mut();
+        f.k_taub_t = (taub1 - taub0) / (leta1 - leta0);
+        f.d_taub_t = taub0 - f.k_taub_t * leta0;
+        f.omth_spl = omth_spl;
+        if magdrift {
+            f.k_omtb_t = (otb1 - otb0) / (leta1 - leta0);
+            f.d_omtb_t = otb0 - f.k_omtb_t * leta0;
+            f.omtb_spl = omtb_spl;
+        }
+    });
+}
+
+pub fn init_canon_freq_passing_spline() {
+    let n = NETASPL;
+    let v = profiles::get().vth;
+    let d = dorb::get();
+    let etatp = d.etatp;
+    let etamin = etatp * dorb::EPSSP_SPL;
+    let etamax = etatp;
+    dorb::update(|x| {
+        x.etamin = etamin;
+        x.etamax = etamax;
+    });
+    let magdrift = d.magdrift;
+
+    let b = ((etamax - etamin) / etamax).ln();
+    let aa = 1.0 / (n as f64 - 1.0) * ((dorb::EPSP_SPL).ln() - b);
+    let mut etarange = vec![0.0f64; n];
+    let mut omtb_v = vec![0.0f64; n];
+    let mut omth_v = vec![0.0f64; n];
+    let (mut taub0, mut taub1, mut leta0, mut leta1, mut otb0, mut otb1) = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let mut est = 0.0f64;
+    for k in (0..n).rev() {
+        let eta = etamax * (1.0 - (aa * k as f64 + b).exp());
+        etarange[k] = eta;
+        est = if k == n - 1 { bounce_time(v, eta, 0.0, false) } else { bounce_time(v, eta, est, true) };
+        let taub = est;
+        let bavg = bounce_fast(v, eta, taub);
+        if magdrift {
+            omtb_v[k] = bavg[2];
+        }
+        omth_v[k] = 2.0 * PI / (v * taub);
+        if k == n - 2 {
+            leta0 = (etatp - eta).ln();
+            taub0 = v * taub;
+            if magdrift {
+                otb0 = omtb_v[k] / omth_v[k];
+            }
+        }
+        if k == n - 1 {
+            leta1 = (etatp - eta).ln();
+            taub1 = v * taub;
+            if magdrift {
+                otb1 = omtb_v[k] / omth_v[k];
+            }
+        }
+    }
+    let omth_pass_spl = spline_coeff(&etarange, &omth_v);
+    let omtb_pass_spl = if magdrift { spline_coeff(&etarange, &omtb_v) } else { Vec::new() };
+    FS.with(|c| {
+        let mut f = c.borrow_mut();
+        f.k_taub_p = (taub1 - taub0) / (leta1 - leta0);
+        f.d_taub_p = taub0 - f.k_taub_p * leta0;
+        f.omth_pass_spl = omth_pass_spl;
+        if magdrift {
+            f.k_omtb_p = (otb1 - otb0) / (leta1 - leta0);
+            f.d_omtb_p = otb0 - f.k_omtb_p * leta0;
+            f.omtb_pass_spl = omtb_pass_spl;
+        }
+    });
+}
+
+pub fn om_th(v: f64, eta: f64) -> (f64, f64, f64) {
+    let d = dorb::get();
+    let etatp = d.etatp;
+    let sv = FS.with(|c| {
+        let mut f = c.borrow_mut();
+        if eta > etatp {
+            if eta > etatp * (1.0 + dorb::EPST_SPL) {
+                let mut js = f.js[0];
+                let r = spline_val_0(&f.omth_spl, NETASPL - 1, eta, &mut js);
+                f.js[0] = js;
+                r
+            } else {
+                let v0 = 2.0 * PI / (f.k_taub_t * (eta - etatp).ln() + f.d_taub_t);
+                [v0, -v0 * v0 / (2.0 * PI) * f.k_taub_t / (eta - etatp), 0.0]
+            }
+        } else if eta < etatp * (1.0 - dorb::EPSP_SPL) {
+            let mut js = f.js[2];
+            let r = spline_val_0(&f.omth_pass_spl, NETASPL - 1, eta, &mut js);
+            f.js[2] = js;
+            r
+        } else {
+            let v0 = 2.0 * PI / (f.k_taub_p * (etatp - eta).ln() + f.d_taub_p);
+            [v0, -v0 * v0 / (2.0 * PI) * f.k_taub_p / (eta - etatp), 0.0]
+        }
+    });
+    (d.sign_vpar * sv[0] * v, d.sign_vpar * sv[0], d.sign_vpar * sv[1] * v)
+}
+
+pub fn om_tb(v: f64, eta: f64) -> (f64, f64, f64) {
+    let d = dorb::get();
+    let etatp = d.etatp;
+    let sv: [f64; 2] = if eta > etatp {
+        if eta > etatp * (1.0 + dorb::EPST_SPL) {
+            FS.with(|c| {
+                let mut f = c.borrow_mut();
+                let mut js = f.js[1];
+                let r = spline_val_0(&f.omtb_spl, NETASPL - 1, eta, &mut js);
+                f.js[1] = js;
+                [r[0], r[1]]
+            })
+        } else {
+            let (omth, _dv, domthdeta) = om_th(v, eta);
+            let (k, dd) = FS.with(|c| { let f = c.borrow(); (f.k_omtb_t, f.d_omtb_t) });
+            [
+                d.sign_vpar * (k * (eta - etatp).ln() + dd) * omth / v,
+                d.sign_vpar * (omth / v * k / (eta - etatp) + domthdeta / v * (k * (eta - etatp).ln() + dd)),
+            ]
+        }
+    } else if eta < etatp * (1.0 - dorb::EPSP_SPL) {
+        FS.with(|c| {
+            let mut f = c.borrow_mut();
+            let mut js = f.js[3];
+            let r = spline_val_0(&f.omtb_pass_spl, NETASPL - 1, eta, &mut js);
+            f.js[3] = js;
+            [r[0], r[1]]
+        })
+    } else {
+        let (omth, _dv, domthdeta) = om_th(v, eta);
+        let (k, dd) = FS.with(|c| { let f = c.borrow(); (f.k_omtb_p, f.d_omtb_p) });
+        [
+            d.sign_vpar * (k * (etatp - eta).ln() + dd) * omth / v,
+            d.sign_vpar * (omth / v * k / (eta - etatp) + domthdeta / v * (k * (etatp - eta).ln() + dd)),
+        ]
+    };
+    (sv[0] * v * v, 2.0 * sv[0] * v, sv[1] * v * v)
+}
+
+pub fn om_ph(v: f64, eta: f64) -> (f64, f64, f64) {
+    let d = dorb::get();
+    let om_te = profiles::get().om_te;
+    let iota = with_field(|f| f.iota);
+    if eta > d.etatp {
+        let (mut omph, mut dv, mut de) = (om_te, 0.0, 0.0);
+        if d.magdrift {
+            let (otb, dvtb, detb) = om_tb(v, eta);
+            omph += otb;
+            dv += dvtb;
+            de += detb;
+        }
+        (omph, dv, de)
+    } else {
+        let (omth, dvth, deth) = om_th(v, eta);
+        let (mut omph, mut dv, mut de) = (om_te + omth / iota, dvth / iota, deth / iota);
+        if d.magdrift {
+            let (otb, dvtb, detb) = om_tb(v, eta);
+            omph += otb;
+            dv += dvtb;
+            de += detb;
+        }
+        (omph, dv, de)
+    }
+}
+
+pub fn d_om_ds(v: f64, eta: f64, taub_estimate: f64) -> (f64, f64) {
+    let ds = 2.0e-8;
+    let s0 = crate::orbit::get_s();
+    let d = dorb::get();
+    let iota = with_field(|f| f.iota);
+    let dom_teds = profiles::get().dom_teds;
+
+    set_s(s0 - ds / 2.0);
+    let taub = bounce_time(v, eta, taub_estimate, true);
+    let bavg: [f64; NVAR] = bounce_fast(v, eta, taub);
+    let omth = d.sign_vpar_htheta * 2.0 * PI / taub;
+    let omph_noe = if d.magdrift {
+        if eta > d.etatp { bavg[2] * v * v } else { bavg[2] * v * v + omth / iota }
+    } else if eta > d.etatp {
+        0.0
+    } else {
+        omth / iota
+    };
+
+    set_s(s0 + ds / 2.0);
+    let taub2 = bounce_time(v, eta, taub_estimate, true);
+    let bavg2 = bounce_fast(v, eta, taub2);
+    let domthds = d.sign_vpar_htheta * (2.0 * PI / taub2 - d.sign_vpar_htheta * omth) / ds;
+    let domphds = if d.magdrift {
+        if eta > d.etatp {
+            dom_teds + (bavg2[2] * v * v - omph_noe) / ds
+        } else {
+            dom_teds + (bavg2[2] * v * v + (2.0 * PI / taub2) / iota - omph_noe) / ds
+        }
+    } else if eta > d.etatp {
+        dom_teds
+    } else {
+        dom_teds + ((2.0 * PI / taub2) / iota - omph_noe) / ds
+    };
+    set_s(s0);
+    (domthds, domphds)
+}

--- a/port_rust/src/lib.rs
+++ b/port_rust/src/lib.rs
@@ -5,3 +5,7 @@ pub mod spline;
 pub mod field;
 pub mod collis;
 pub mod profiles;
+pub mod cvode;
+pub mod driftorbit;
+pub mod magfie;
+pub mod orbit;

--- a/port_rust/src/lib.rs
+++ b/port_rust/src/lib.rs
@@ -9,3 +9,6 @@ pub mod cvode;
 pub mod driftorbit;
 pub mod magfie;
 pub mod orbit;
+pub mod freq;
+pub mod resonance;
+pub mod transport;

--- a/port_rust/src/lib.rs
+++ b/port_rust/src/lib.rs
@@ -3,3 +3,5 @@
 
 pub mod spline;
 pub mod field;
+pub mod collis;
+pub mod profiles;

--- a/port_rust/src/lib.rs
+++ b/port_rust/src/lib.rs
@@ -2,3 +2,4 @@
 //! numerics use SUNDIALS CVODE + LAPACK via FFI for parity with the C port.
 
 pub mod spline;
+pub mod field;

--- a/port_rust/src/lib.rs
+++ b/port_rust/src/lib.rs
@@ -1,0 +1,4 @@
+//! Rust port of NEO-RT (golden path). Modules mirror the Fortran/C structure;
+//! numerics use SUNDIALS CVODE + LAPACK via FFI for parity with the C port.
+
+pub mod spline;

--- a/port_rust/src/magfie.rs
+++ b/port_rust/src/magfie.rs
@@ -1,0 +1,41 @@
+//! Flux-surface characterization, literal port of neort_magfie (magfie.f90).
+//! Sets driftorbit B0/Bmin/Bmax/etatp/etadt/dVds/th0 and field eps.
+
+use crate::driftorbit::update;
+use crate::field::{do_magfie, set_eps};
+
+const PI: f64 = std::f64::consts::PI;
+
+pub fn init_flux_surface_average(s: f64) {
+    let nth = 1000;
+    let dth = 2.0 * PI / nth as f64;
+    let (mut dvds, mut b0, mut eps) = (0.0, 0.0, 0.0);
+    let (mut bmin, mut bmax, mut th0) = (-1.0f64, 0.0f64, 0.0f64);
+    for k in 1..=nth {
+        let th = -PI + k as f64 * 2.0 * PI / nth as f64;
+        let (bmod, sqrtg, _bder, _hcov, _hctr) = do_magfie(&[s, 0.0, th]);
+        dvds += sqrtg.abs() * dth;
+        b0 += bmod * dth;
+        eps -= th.cos() * bmod * dth;
+        if bmin < 0.0 || bmod < bmin {
+            bmin = bmod;
+            th0 = th;
+        }
+        if bmod > bmax {
+            bmax = bmod;
+        }
+    }
+    dvds *= 2.0 * PI;
+    b0 /= 2.0 * PI;
+    eps /= b0 * PI;
+    set_eps(eps);
+    update(|d| {
+        d.dvds = dvds;
+        d.b0 = b0;
+        d.bmin = bmin;
+        d.bmax = bmax;
+        d.etatp = 1.0 / bmax;
+        d.etadt = 1.0 / bmin;
+        d.th0 = th0;
+    });
+}

--- a/port_rust/src/main.rs
+++ b/port_rust/src/main.rs
@@ -1,0 +1,203 @@
+//! NEO-RT Rust port driver: parse <case>.in, run the golden-path computation
+//! (mirrors neort_compute_at_s + compute_transport), write the 5 output files.
+//! Single-threaded (deterministic gate). Uses the same CVODE/LAPACK as C.
+
+use neo_rt_rust::driftorbit as dorb;
+use neo_rt_rust::field::{do_magfie, do_magfie_init, do_magfie_pert_amp, do_magfie_pert_init, set_bfac, set_inp_swi, with_field};
+use neo_rt_rust::magfie::init_flux_surface_average;
+use neo_rt_rust::orbit::set_s;
+use neo_rt_rust::profiles::{self, init_thermodynamic_forces, read_and_init_plasma_input, read_and_init_profile_input};
+use neo_rt_rust::freq::{init_canon_freq_passing_spline, init_canon_freq_trapped_spline};
+use neo_rt_rust::transport::compute_transport_integral;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+
+const PI: f64 = std::f64::consts::PI;
+
+#[derive(Default)]
+struct Config {
+    s: f64, epsmn: f64, bfac: f64, efac: f64,
+    m0: i32, mph: i32, inp_swi: i32, vsteps: i32,
+    comptorque: bool, magdrift: bool, nopassing: bool, noshear: bool, pertfile: bool, nonlin: bool,
+}
+
+fn read_config(path: &str) -> Config {
+    let mut c = Config { bfac: 1.0, efac: 1.0, comptorque: true, magdrift: true, ..Default::default() };
+    let f = File::open(path).unwrap_or_else(|_| panic!("cannot open {}", path));
+    for line in BufReader::new(f).lines().map(|l| l.unwrap()) {
+        let line = line.split('!').next().unwrap();
+        if let Some((k, v)) = line.split_once('=') {
+            let key = k.trim().to_lowercase();
+            let val = v.trim();
+            let b = || val.starts_with('t') || val.starts_with('T') || val.contains(".true.") || val.contains(".TRUE.");
+            match key.as_str() {
+                "s" => c.s = val.parse().unwrap_or(0.0),
+                "epsmn" => c.epsmn = val.parse().unwrap_or(0.0),
+                "bfac" => c.bfac = val.parse().unwrap_or(1.0),
+                "efac" => c.efac = val.parse().unwrap_or(1.0),
+                "m0" => c.m0 = val.parse().unwrap_or(0),
+                "mph" => c.mph = val.parse().unwrap_or(0),
+                "inp_swi" => c.inp_swi = val.parse().unwrap_or(0),
+                "vsteps" => c.vsteps = val.parse().unwrap_or(0),
+                "comptorque" => c.comptorque = b(),
+                "magdrift" => c.magdrift = b(),
+                "nopassing" => c.nopassing = b(),
+                "noshear" => c.noshear = b(),
+                "pertfile" => c.pertfile = b(),
+                "nonlin" => c.nonlin = b(),
+                _ => {}
+            }
+        }
+    }
+    c
+}
+
+#[derive(Clone, Copy, Default)]
+struct Harmonic {
+    mth: i32,
+    dresco: [f64; 2], dresctr: [f64; 2], drest: [f64; 2],
+    tresco: f64, tresctr: f64, trest: f64,
+    vminp_vth: f64, vmaxp_vth: f64, vmint_vth: f64, vmaxt_vth: f64,
+}
+
+fn set_trapped() {
+    let d = dorb::get();
+    dorb::update(|x| {
+        x.etamin = (1.0 + dorb::EPST) * d.etatp;
+        x.etamax = (1.0 - dorb::EPST) * d.etadt;
+    });
+}
+fn set_passing() {
+    let d = dorb::get();
+    dorb::update(|x| {
+        x.etamin = dorb::EPSP * d.etatp;
+        x.etamax = (1.0 - dorb::EPSP) * d.etatp;
+    });
+}
+
+fn main() {
+    let run = std::env::args().nth(1).expect("usage: neo_rt_rust <runname>");
+    let cfg = read_config(&format!("{}.in", run));
+    set_inp_swi(cfg.inp_swi);
+    set_bfac(cfg.bfac);
+    dorb::update(|d| {
+        d.epsmn = cfg.epsmn;
+        d.m0 = cfg.m0;
+        d.efac = cfg.efac;
+        d.comptorque = cfg.comptorque;
+        d.magdrift = cfg.magdrift;
+        d.nopassing = cfg.nopassing;
+        d.pertfile = cfg.pertfile;
+        d.nonlin = cfg.nonlin;
+        d.noshear = cfg.noshear;
+    });
+    let s = cfg.s;
+
+    do_magfie_init("in_file");
+    if cfg.pertfile {
+        do_magfie_pert_init("in_file_pert");
+        let mph = with_field(|f| f.pert_mph);
+        dorb::update(|d| d.mph = mph);
+    } else {
+        dorb::update(|d| d.mph = cfg.mph);
+    }
+    read_and_init_plasma_input("plasma.in", s);
+    let r0 = with_field(|f| f.r0);
+    read_and_init_profile_input("profile.in", s, r0, cfg.efac, cfg.bfac);
+    init_flux_surface_average(s);
+    set_s(s);
+    init_canon_freq_trapped_spline();
+    if !cfg.nopassing {
+        init_canon_freq_passing_spline();
+    }
+    dorb::update(|d| d.sign_vpar = 1.0);
+    set_trapped();
+    let (psi_pr, q) = with_field(|f| (f.psi_pr, f.q));
+    if cfg.comptorque {
+        init_thermodynamic_forces(psi_pr, q);
+    }
+
+    let mthmax = (2.0 * (dorb::get().mph as f64 * q).abs()).ceil() as i32;
+    let mthmin = -mthmax;
+    let mph = dorb::get().mph;
+    let _ = mph;
+    let mut harmonics: Vec<Harmonic> = Vec::new();
+    let mut dco = [0.0; 2];
+    let mut dctr = [0.0; 2];
+    let mut dt = [0.0; 2];
+    let (mut tco, mut tctr, mut tt) = (0.0, 0.0, 0.0);
+    let vth = profiles::get().vth;
+
+    for j in mthmin..=mthmax {
+        dorb::update(|d| d.mth = j);
+        let mut h = Harmonic { mth: j, ..Default::default() };
+        let (vminp, vmaxp) = (1.0e-6 * vth, 3.0 * vth);
+        if !cfg.nopassing {
+            dorb::update(|d| d.sign_vpar = 1.0);
+            set_passing();
+            let (dd, t) = compute_transport_integral(vminp, vmaxp, cfg.vsteps as usize);
+            h.dresco = dd; h.tresco = t;
+            dco[0] += dd[0]; dco[1] += dd[1]; tco += t;
+            dorb::update(|d| d.sign_vpar = -1.0);
+            set_passing();
+            let (dd, t) = compute_transport_integral(vminp, vmaxp, cfg.vsteps as usize);
+            h.dresctr = dd; h.tresctr = t;
+            dctr[0] += dd[0]; dctr[1] += dd[1]; tctr += t;
+        }
+        dorb::update(|d| d.sign_vpar = 1.0);
+        set_trapped();
+        let (dd, t) = compute_transport_integral(vminp, vmaxp, cfg.vsteps as usize);
+        h.drest = dd; h.trest = t;
+        dt[0] += dd[0]; dt[1] += dd[1]; tt += t;
+        h.vminp_vth = vminp / vth; h.vmaxp_vth = vmaxp / vth;
+        h.vmint_vth = vminp / vth; h.vmaxt_vth = vmaxp / vth;
+        harmonics.push(h);
+    }
+
+    let p = profiles::get();
+    let m_t = p.m_t;
+    let dvds = dorb::get().dvds;
+    let tot1 = dco[0] + dctr[0] + dt[0];
+    let tot2 = dco[1] + dctr[1] + dt[1];
+
+    let mut f = File::create(format!("{}.out", run)).unwrap();
+    writeln!(f, " # M_t D11co D11ctr D11t D11 D12co D12ctr D12t D12").unwrap();
+    writeln!(f, " {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e}",
+        m_t, dco[0], dctr[0], dt[0], tot1, dco[1], dctr[1], dt[1], tot2).unwrap();
+
+    if cfg.comptorque {
+        let mut f = File::create(format!("{}_torque.out", run)).unwrap();
+        writeln!(f, " # s dVds M_t Tco Tctr Tt").unwrap();
+        writeln!(f, " {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e}", s, dvds, m_t, tco, tctr, tt).unwrap();
+    }
+
+    let mut fi = File::create(format!("{}_integral.out", run)).unwrap();
+    let mut ft = File::create(format!("{}_torque_integral.out", run)).unwrap();
+    for h in &harmonics {
+        let t1 = h.dresco[0] + h.dresctr[0] + h.drest[0];
+        let t2 = h.dresco[1] + h.dresctr[1] + h.drest[1];
+        writeln!(fi, " {:.17e} {} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e}",
+            m_t, h.mth, h.dresco[0], h.dresctr[0], h.drest[0], t1, h.dresco[1], h.dresctr[1], h.drest[1], t2,
+            h.vminp_vth, h.vmaxp_vth, h.vmint_vth, h.vmaxt_vth).unwrap();
+        writeln!(ft, " {} {:.17e} {:.17e} {:.17e}", h.mth, h.tresco, h.tresctr, h.trest).unwrap();
+    }
+
+    // check_magfie -> _magfie.out
+    let mut fm = File::create(format!("{}_magfie.out", run)).unwrap();
+    let nth = 50;
+    let d = dorb::get();
+    for k in 0..nth {
+        let th = -PI + k as f64 * (2.0 * PI) / (nth - 1) as f64;
+        let (bmod, sqrtg, bder, hcovar, hctrvr) = do_magfie(&[s, 0.0, th]);
+        let (bnr, bni) = if cfg.pertfile {
+            let (ar, ai) = do_magfie_pert_amp(&[s, 0.0, th]);
+            (d.epsmn * ar / bmod, d.epsmn * ai / bmod)
+        } else {
+            (d.epsmn * (d.m0 as f64 * th).cos(), d.epsmn * (d.m0 as f64 * th).sin())
+        };
+        let (er, ei) = (d.epsmn * (d.m0 as f64 * th).cos(), d.epsmn * (d.m0 as f64 * th).sin());
+        writeln!(fm, " {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e} {:.17e}",
+            th, bmod, sqrtg, bder[0], bder[1], bder[2], hcovar[0], hcovar[1], hcovar[2],
+            hctrvr[0], hctrvr[1], hctrvr[2], 0.0, 0.0, 0.0, bnr, bni, er, ei).unwrap();
+    }
+}

--- a/port_rust/src/orbit.rs
+++ b/port_rust/src/orbit.rs
@@ -1,0 +1,256 @@
+//! Orbit bounce integration, literal port of neort_orbit (orbit.f90), using
+//! SUNDIALS CVODE (CV_ADAMS + fixed-point + root finding) -- the same library
+//! and algorithm as the C port, so trajectories are bit-identical to C.
+
+use crate::cvode::*;
+use crate::driftorbit as dorb;
+use crate::field::{do_magfie, with_field, SIGN_THETA};
+use crate::profiles;
+use std::cell::Cell;
+use std::os::raw::{c_int, c_long, c_void};
+use std::ptr;
+
+pub const NVAR: usize = 7;
+const PI: f64 = std::f64::consts::PI;
+
+thread_local! {
+    static ORBIT_S: Cell<f64> = Cell::new(0.0);
+}
+pub fn set_s(s: f64) {
+    ORBIT_S.with(|c| c.set(s));
+}
+pub fn get_s() -> f64 {
+    ORBIT_S.with(|c| c.get())
+}
+
+pub fn vpar(v: f64, eta: f64, bmod: f64) -> f64 {
+    let r = v * (1.0 - eta * bmod).sqrt();
+    if r.is_nan() {
+        0.0
+    } else {
+        r
+    }
+}
+pub fn vperp(v: f64, eta: f64, bmod: f64) -> f64 {
+    let r = v * (eta * bmod).sqrt();
+    if r.is_nan() {
+        0.0
+    } else {
+        r
+    }
+}
+
+fn evaluate_bfield_local() -> (f64, f64) {
+    let s = get_s();
+    let th0 = dorb::get().th0;
+    let (bmod, _sqrtg, _bder, _hcov, hctrvr) = do_magfie(&[s, 0.0, th0]);
+    (bmod, hctrvr[2])
+}
+
+pub fn poloidal_velocity(v: f64, eta: f64, bmod: f64, hthctr: f64, hderth: f64, v_par: f64, ydot: &mut [f64]) {
+    ydot[0] = v_par * hthctr;
+    ydot[1] = -v * v * eta / 2.0 * hthctr * hderth * bmod;
+}
+
+pub fn timestep_poloidal_motion(v: f64, eta: f64, _neq: usize, _t: f64, y: &[f64], ydot: &mut [f64]) {
+    let s = get_s();
+    let (bmod, _sqrtg, bder, _hcov, hctrvr) = do_magfie(&[s, 0.0, y[0]]);
+    poloidal_velocity(v, eta, bmod, hctrvr[2], bder[2], y[1], ydot);
+}
+
+pub fn timestep(v: f64, eta: f64, neq: usize, _t: f64, y: &[f64], ydot: &mut [f64]) {
+    let s = get_s();
+    let (bmod, _sqrtg, bder, _hcov, hctrvr) = do_magfie(&[s, 0.0, y[0]]);
+    let d = dorb::get();
+    let (q, dqds, psi_pr, bphcov, dbthcovds, dbphcovds) =
+        with_field(|f| (f.q, f.dqds, f.psi_pr, f.bphcov, f.dbthcovds, f.dbphcovds));
+    let p = profiles::get();
+    let shearterm = if d.noshear { 0.0 } else { bphcov * dqds };
+    let om_tb_v = p.mi * profiles::C * q / (2.0 * p.qi * SIGN_THETA * psi_pr * bmod)
+        * (-(2.0 - eta * bmod) * bmod * bder[0]
+            + 2.0 * (1.0 - eta * bmod) * hctrvr[2] * (dbthcovds + q * dbphcovds + shearterm));
+    ydot[0] = y[1] * hctrvr[2];
+    ydot[1] = -0.5 * v * v * eta * hctrvr[2] * bder[2] * bmod;
+    ydot[2] = om_tb_v;
+    for i in 3..neq {
+        ydot[i] = 0.0;
+    }
+}
+
+pub type TsFn = fn(f64, f64, usize, f64, &[f64], &mut [f64]);
+
+struct OdeCtx {
+    v: f64,
+    eta: f64,
+    neq: usize,
+    ts: TsFn,
+}
+
+extern "C" fn cv_rhs(t: f64, y: NVector, ydot: NVector, ud: *mut c_void) -> c_int {
+    let ctx = unsafe { &*(ud as *const OdeCtx) };
+    let yp = unsafe { N_VGetArrayPointer(y) };
+    let ydp = unsafe { N_VGetArrayPointer(ydot) };
+    let ys = unsafe { std::slice::from_raw_parts(yp, ctx.neq) };
+    let yds = unsafe { std::slice::from_raw_parts_mut(ydp, ctx.neq) };
+    (ctx.ts)(ctx.v, ctx.eta, ctx.neq, t, ys, yds);
+    0
+}
+
+extern "C" fn cv_roots(_t: f64, y: NVector, gout: *mut f64, _ud: *mut c_void) -> c_int {
+    let d = dorb::get();
+    let th = unsafe { *N_VGetArrayPointer(y) };
+    unsafe {
+        *gout = d.sign_vpar_htheta * (th - d.th0);
+        *gout.add(1) = d.sign_vpar_htheta * (2.0 * PI - (th - d.th0));
+    }
+    0
+}
+
+/// bounce_integral: integrate in dt chunks with root finding; returns (ti, y).
+fn bounce_integral(v: f64, eta: f64, neq: usize, y0: &[f64], dt: f64, ts: TsFn) -> (f64, Vec<f64>) {
+    let etatp = dorb::get().etatp;
+    let th0 = dorb::get().th0;
+    unsafe {
+        let mut ctx: SunContext = ptr::null_mut();
+        SUNContext_Create(sun_comm_null(), &mut ctx);
+        let y = N_VNew_Serial(neq as c_long, ctx);
+        let yv = N_VGetArrayPointer(y);
+        for i in 0..neq {
+            *yv.add(i) = y0[i];
+        }
+        let oc = Box::new(OdeCtx { v, eta, neq, ts });
+        let mem = CVodeCreate(CV_ADAMS, ctx);
+        CVodeInit(mem, cv_rhs, 0.0, y);
+        CVodeSStolerances(mem, 1.0e-9, 1.0e-10);
+        CVodeSetMaxNumSteps(mem, 50000);
+        CVodeSetUserData(mem, &*oc as *const OdeCtx as *mut c_void);
+        let nls = SUNNonlinSol_FixedPoint(y, 0, ctx);
+        CVodeSetNonlinearSolver(mem, nls);
+        CVodeRootInit(mem, 2, cv_roots);
+
+        let passing = eta < etatp;
+        let mut ti = 0.0f64;
+        let mut yold = vec![0.0f64; neq];
+        for _k in 2..=500 {
+            for i in 0..neq {
+                yold[i] = *yv.add(i);
+            }
+            let tout = ti + dt;
+            let flag = CVode(mem, tout, y, &mut ti, CV_NORMAL);
+            if flag < 0 {
+                eprintln!("CVODE error {} in bounce_integral", flag);
+                break;
+            }
+            if flag == CV_ROOT_RETURN && (passing || (yold[0] - th0) < 0.0) {
+                break;
+            }
+        }
+        let out: Vec<f64> = (0..neq).map(|i| *yv.add(i)).collect();
+        SUNNonlinSolFree(nls);
+        N_VDestroy(y);
+        let mut m = mem;
+        CVodeFree(&mut m);
+        SUNContext_Free(&mut ctx);
+        drop(oc);
+        (ti, out)
+    }
+}
+
+fn set_sign_vpar_htheta() -> f64 {
+    let (_bmod, htheta) = evaluate_bfield_local();
+    let d = dorb::get();
+    let svh = (if htheta >= 0.0 { 1.0 } else { -1.0 }) * d.sign_vpar;
+    dorb::update(|x| x.sign_vpar_htheta = svh);
+    svh
+}
+
+pub fn bounce_time(v: f64, eta: f64, taub_estimate: f64, have: bool) -> f64 {
+    let (bmod, _) = evaluate_bfield_local();
+    let svh = set_sign_vpar_htheta();
+    let th0 = dorb::get().th0;
+    let y0 = [th0, svh * vpar(v, eta, bmod)];
+    let taub = if have {
+        taub_estimate
+    } else {
+        let (iota, r0, eps) = with_field(|f| (f.iota, f.r0, f.eps));
+        2.0 * PI / (vperp(v, eta, bmod) * iota / r0 * (eps / 2.0).sqrt()).abs()
+    };
+    bounce_integral(v, eta, 2, &y0, taub, timestep_poloidal_motion).0
+}
+
+pub fn bounce_fast_ext(v: f64, eta: f64, taub: f64, ts: TsFn) -> ([f64; NVAR], i32) {
+    let (bmod, _) = evaluate_bfield_local();
+    let svh = set_sign_vpar_htheta();
+    let th0 = dorb::get().th0;
+    let mut y0 = [1.0e-15f64; NVAR];
+    y0[0] = th0;
+    y0[1] = svh * vpar(v, eta, bmod);
+    for i in 2..6 {
+        y0[i] = 0.0;
+    }
+    // integrate to taub without events (large dt, single chunk via CV_NORMAL)
+    let (_ti, y) = integrate_fixed(v, eta, NVAR, &y0, taub, ts);
+    let mut avg = [0.0f64; NVAR];
+    for i in 0..NVAR {
+        avg[i] = y[i] / taub;
+    }
+    (avg, 2)
+}
+
+pub fn bounce_fast(v: f64, eta: f64, taub: f64) -> [f64; NVAR] {
+    bounce_fast_ext(v, eta, taub, timestep).0
+}
+
+fn integrate_fixed(v: f64, eta: f64, neq: usize, y0: &[f64], taub: f64, ts: TsFn) -> (f64, Vec<f64>) {
+    unsafe {
+        let mut ctx: SunContext = ptr::null_mut();
+        SUNContext_Create(sun_comm_null(), &mut ctx);
+        let y = N_VNew_Serial(neq as c_long, ctx);
+        let yv = N_VGetArrayPointer(y);
+        for i in 0..neq {
+            *yv.add(i) = y0[i];
+        }
+        let oc = Box::new(OdeCtx { v, eta, neq, ts });
+        let mem = CVodeCreate(CV_ADAMS, ctx);
+        CVodeInit(mem, cv_rhs, 0.0, y);
+        CVodeSStolerances(mem, 1.0e-9, 1.0e-10);
+        CVodeSetMaxNumSteps(mem, 50000);
+        CVodeSetUserData(mem, &*oc as *const OdeCtx as *mut c_void);
+        let nls = SUNNonlinSol_FixedPoint(y, 0, ctx);
+        CVodeSetNonlinearSolver(mem, nls);
+        let mut tret = 0.0f64;
+        CVode(mem, taub, y, &mut tret, CV_NORMAL);
+        let out: Vec<f64> = (0..neq).map(|i| *yv.add(i)).collect();
+        SUNNonlinSolFree(nls);
+        N_VDestroy(y);
+        let mut m = mem;
+        CVodeFree(&mut m);
+        SUNContext_Free(&mut ctx);
+        drop(oc);
+        (tret, out)
+    }
+}
+
+pub fn bounce(v: f64, eta: f64, taub_estimate: f64, have: bool) -> (f64, [f64; NVAR]) {
+    let (bmod, _) = evaluate_bfield_local();
+    let svh = set_sign_vpar_htheta();
+    let th0 = dorb::get().th0;
+    let mut y0 = [1.0e-15f64; NVAR];
+    y0[0] = th0;
+    y0[1] = svh * vpar(v, eta, bmod);
+    for i in 2..6 {
+        y0[i] = 0.0;
+    }
+    let tb = if have {
+        taub_estimate
+    } else {
+        let (iota, r0, eps) = with_field(|f| (f.iota, f.r0, f.eps));
+        2.0 * PI / (vperp(v, eta, bmod) * iota / r0 * (eps / 2.0).sqrt()).abs()
+    };
+    let (taub, y) = bounce_integral(v, eta, NVAR, &y0, tb / 5.0, timestep);
+    let mut avg = [0.0f64; NVAR];
+    for i in 0..NVAR {
+        avg[i] = y[i] / taub;
+    }
+    (taub, avg)
+}

--- a/port_rust/src/profiles.rs
+++ b/port_rust/src/profiles.rs
@@ -1,0 +1,133 @@
+//! Plasma + rotation profiles, literal port of neort_profiles (profiles.f90).
+//! thread_local state; uses collis::loacol_nbi and the spline layer.
+
+use crate::collis::loacol_nbi;
+use crate::spline::{spline_coeff, spline_val_0};
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+pub const QE: f64 = 4.803204e-10;
+pub const MU: f64 = 1.660538e-24;
+pub const C: f64 = 2.997925e+10;
+pub const EV: f64 = 1.602176e-12;
+const SIGN_THETA: f64 = -1.0;
+
+#[derive(Default, Clone, Copy)]
+pub struct Profiles {
+    pub vth: f64,
+    pub dvthds: f64,
+    pub m_t: f64,
+    pub dm_tds: f64,
+    pub om_te: f64,
+    pub dom_teds: f64,
+    pub ni1: f64,
+    pub ni2: f64,
+    pub ti1: f64,
+    pub ti2: f64,
+    pub te: f64,
+    pub dni1ds: f64,
+    pub dti1ds: f64,
+    pub a1: f64,
+    pub a2: f64,
+    pub qi: f64,
+    pub mi: f64,
+}
+
+thread_local! {
+    static P: RefCell<Profiles> = RefCell::new(Profiles { qi: QE, mi: 2.014 * MU, ..Default::default() });
+}
+
+pub fn get() -> Profiles {
+    P.with(|c| *c.borrow())
+}
+
+fn read_rows(path: &str, skip: usize, ncol: usize) -> Vec<Vec<f64>> {
+    let f = File::open(path).unwrap_or_else(|_| panic!("cannot open {}", path));
+    let mut out = Vec::new();
+    for (i, line) in BufReader::new(f).lines().enumerate() {
+        let line = line.unwrap();
+        if i < skip {
+            continue;
+        }
+        let v: Vec<f64> = line.split_whitespace().filter_map(|t| t.parse().ok()).collect();
+        if v.len() >= ncol {
+            out.push(v[..ncol].to_vec());
+        }
+    }
+    out
+}
+
+pub fn read_and_init_plasma_input(path: &str, s: f64) {
+    // header: line0 "% N am1...", line1 "N am1 am2 Z1 Z2", line2 "% s ni...", rows
+    let f = File::open(path).unwrap_or_else(|_| panic!("cannot open {}", path));
+    let lines: Vec<String> = BufReader::new(f).lines().map(|l| l.unwrap()).collect();
+    let hdr: Vec<f64> = lines[1].split_whitespace().map(|t| t.parse().unwrap()).collect();
+    let nplasma = hdr[0] as usize;
+    let (am1, am2, z1, z2) = (hdr[1], hdr[2], hdr[3], hdr[4]);
+    let mut plasma = vec![vec![0.0f64; 6]; nplasma];
+    for k in 0..nplasma {
+        let v: Vec<f64> = lines[3 + k].split_whitespace().map(|t| t.parse().unwrap()).collect();
+        plasma[k] = v[..6].to_vec();
+    }
+    let x: Vec<f64> = (0..nplasma).map(|i| plasma[i][0]).collect();
+    let mut spl = Vec::with_capacity(5);
+    for kk in 0..5 {
+        let y: Vec<f64> = (0..nplasma).map(|i| plasma[i][kk + 1]).collect();
+        spl.push(spline_coeff(&x, &y));
+    }
+    let nseg = nplasma - 1;
+    let mut js = 1i32;
+    let ev0 = spline_val_0(&spl[0], nseg, s, &mut js);
+    let ev1 = spline_val_0(&spl[1], nseg, s, &mut js);
+    let ev2 = spline_val_0(&spl[2], nseg, s, &mut js);
+    let ev3 = spline_val_0(&spl[3], nseg, s, &mut js);
+    let ev4 = spline_val_0(&spl[4], nseg, s, &mut js);
+
+    let qi = z1 * QE;
+    let mi = am1 * MU;
+    let vth = (2.0 * ev2[0] * EV / mi).sqrt();
+    let dvthds = 0.5 * (2.0 * EV / (mi * ev2[0])).sqrt() * ev2[1];
+
+    let pmass = 1.6726e-24;
+    let v0 = vth;
+    let ebeam = 2.0 * pmass * v0 * v0 / (2.0 * EV);
+    loacol_nbi(2.0, am1, am2, 1.0, z1, z2, ev0[0], ev1[0], ev2[0], ev3[0], ev4[0], ebeam);
+
+    P.with(|c| {
+        let mut p = c.borrow_mut();
+        p.ni1 = ev0[0]; p.dni1ds = ev0[1];
+        p.ni2 = ev1[0];
+        p.ti1 = ev2[0]; p.dti1ds = ev2[1];
+        p.ti2 = ev3[0];
+        p.te = ev4[0];
+        p.qi = qi; p.mi = mi; p.vth = vth; p.dvthds = dvthds;
+    });
+}
+
+pub fn read_and_init_profile_input(path: &str, s: f64, r0: f64, efac: f64, bfac: f64) {
+    let rows = read_rows(path, 0, 3);
+    let n = rows.len();
+    let sx: Vec<f64> = rows.iter().map(|r| r[0]).collect();
+    let mt: Vec<f64> = rows.iter().map(|r| r[1]).collect();
+    let spl = spline_coeff(&sx, &mt);
+    let mut js = 1i32;
+    let sv = spline_val_0(&spl, n - 1, s, &mut js);
+    P.with(|c| {
+        let mut p = c.borrow_mut();
+        p.m_t = sv[0] * efac / bfac;
+        p.dm_tds = sv[1] * efac / bfac;
+        p.om_te = p.vth * p.m_t / r0;
+        p.dom_teds = p.vth * p.dm_tds / r0 + p.m_t * p.dvthds / r0;
+    });
+}
+
+pub fn init_thermodynamic_forces(psi_pr: f64, q: f64) {
+    P.with(|c| {
+        let mut p = c.borrow_mut();
+        p.a1 = p.dni1ds / p.ni1
+            - p.qi / (p.ti1 * EV) * SIGN_THETA * psi_pr / (q * C) * p.om_te
+            - 1.5 * p.dti1ds / p.ti1;
+        p.a2 = p.dti1ds / p.ti1;
+    });
+}

--- a/port_rust/src/resonance.rs
+++ b/port_rust/src/resonance.rs
@@ -1,0 +1,87 @@
+//! Resonance-line root finding, literal port of neort_resonance (resonance.f90).
+
+use crate::driftorbit as dorb;
+use crate::freq::{om_ph, om_th};
+
+/// Fill roots (flat ninterv x 3, stride 3) with sign-change intervals of
+/// res(eta)=mth*Om_th+mph*Om_ph; returns nroots.
+pub fn driftorbit_coarse(v: f64, eta_min: f64, eta_max: f64, roots: &mut [f64], ninterv: usize) -> usize {
+    let deta = (eta_max - eta_min) / ninterv as f64;
+    let d = dorb::get();
+    let mut resold = 0.0;
+    let mut nroots = 0usize;
+    for k in 0..=ninterv {
+        let eta = eta_min + k as f64 * deta;
+        let (omth, ..) = om_th(v, eta);
+        let (omph, ..) = om_ph(v, eta);
+        let res = d.mth as f64 * omth + d.mph as f64 * omph;
+        if k > 0 {
+            let snew = if res < 0.0 { -1.0 } else { 1.0 };
+            let sold = if resold < 0.0 { -1.0 } else { 1.0 };
+            if snew != sold {
+                roots[nroots * 3] = eta - deta;
+                roots[nroots * 3 + 1] = eta;
+                nroots += 1;
+            }
+        }
+        resold = res;
+    }
+    nroots
+}
+
+pub fn driftorbit_nroot(v: f64, eta_min: f64, eta_max: f64) -> usize {
+    let mut roots = vec![0.0f64; dorb::NLEV * 3];
+    driftorbit_coarse(v, eta_min, eta_max, &mut roots, dorb::NLEV)
+}
+
+/// Bisection root in [eta_min,eta_max]; returns (eta, dres/deta).
+pub fn driftorbit_root(v: f64, tol: f64, eta_min: f64, eta_max: f64) -> (f64, f64) {
+    let d = dorb::get();
+    let (mth, mph) = (d.mth as f64, d.mph as f64);
+    let maxit = 100;
+    let mut etamin2 = eta_min;
+    let mut etamax2 = eta_max;
+    let mut eta = etamin2;
+
+    let (omth, _, _) = om_th(v, eta);
+    let (omph, _, _) = om_ph(v, eta);
+    let resmin = mph * omph + mth * omth;
+    eta = etamax2;
+    let (omth, _, _) = om_th(v, eta);
+    let (omph, _, _) = om_ph(v, eta);
+    let resmax = mph * omph + mth * omth;
+    let slope_pos = resmax - resmin > 0.0;
+
+    if driftorbit_nroot(v, etamin2, etamax2) == 0 {
+        let (_, _, deth) = om_th(v, eta);
+        let (_, _, deph) = om_ph(v, eta);
+        return (eta, mph * deph + mth * deth);
+    }
+
+    let mut out_eta = eta;
+    let mut out_d = 0.0;
+    let mut state = -2;
+    for _ in 1..=maxit {
+        let (omth, _, deth) = om_th(v, eta);
+        let (omph, _, deph) = om_ph(v, eta);
+        let res = mph * omph + mth * omth;
+        out_eta = eta;
+        if res.abs() < tol {
+            state = 1;
+            out_d = mph * deph + mth * deth;
+            break;
+        } else if (slope_pos && res > 0.0) || (!slope_pos && res < 0.0) {
+            etamax2 = eta;
+            eta = (eta + etamin2) / 2.0;
+        } else {
+            etamin2 = eta;
+            eta = (eta + etamax2) / 2.0;
+        }
+    }
+    if state < 0 {
+        let (_, _, deth) = om_th(v, out_eta);
+        let (_, _, deph) = om_ph(v, out_eta);
+        out_d = mph * deph + mth * deth;
+    }
+    (out_eta, out_d)
+}

--- a/port_rust/src/spline.rs
+++ b/port_rust/src/spline.rs
@@ -1,0 +1,109 @@
+//! Cubic spline per Sormann, literal port of itpplasma/spline (spline.f90),
+//! matching the C port. Coefficient layout: (n-1) rows x 5, row-major:
+//! [x_i, y_i, c1, c2, c3]. Uses LAPACK dptsv for the tridiagonal solve so the
+//! coefficients are bit-identical to the Fortran path.
+
+extern "C" {
+    fn dptsv_(
+        n: *const i32,
+        nrhs: *const i32,
+        d: *mut f64,
+        e: *mut f64,
+        b: *mut f64,
+        ldb: *const i32,
+        info: *mut i32,
+    );
+}
+
+/// Build spline coefficients for knots (x, y). Returns a flat (n-1)*5 vector.
+pub fn spline_coeff(x: &[f64], y: &[f64]) -> Vec<f64> {
+    let n = x.len();
+    let m = n - 1; // segments
+    let mut h = vec![0.0f64; m];
+    let mut r = vec![0.0f64; m];
+    for i in 0..m {
+        h[i] = x[i + 1] - x[i];
+        r[i] = y[i + 1] - y[i];
+    }
+
+    let sys = n - 2;
+    let mut d = vec![0.0f64; sys];
+    let mut dl = vec![0.0f64; if sys > 1 { sys - 1 } else { 1 }];
+    let mut c = vec![0.0f64; sys];
+    for k in 0..sys {
+        d[k] = 2.0 * (h[k] + h[k + 1]);
+        c[k] = 3.0 * (r[k + 1] / h[k + 1] - r[k] / h[k]);
+    }
+    for k in 0..sys.saturating_sub(1) {
+        dl[k] = h[k + 1];
+    }
+    let (nn, nrhs, ldb) = (sys as i32, 1i32, sys as i32);
+    let mut info = 0i32;
+    unsafe {
+        dptsv_(&nn, &nrhs, d.as_mut_ptr(), dl.as_mut_ptr(), c.as_mut_ptr(), &ldb, &mut info);
+    }
+
+    let mut coeff = vec![0.0f64; m * 5];
+    let cset = |co: &mut [f64], i: usize, k: usize, v: f64| co[i * 5 + k] = v;
+    for i in 0..m {
+        cset(&mut coeff, i, 0, x[i]);
+        cset(&mut coeff, i, 1, y[i]);
+    }
+    // column 3 (index 2)
+    coeff[0 * 5 + 2] = r[0] / h[0] - h[0] / 3.0 * c[0];
+    for i in 1..=(n - 3) {
+        coeff[i * 5 + 2] = r[i] / h[i] - h[i] / 3.0 * (c[i] + 2.0 * c[i - 1]);
+    }
+    coeff[(m - 1) * 5 + 2] = r[m - 1] / h[m - 1] - h[m - 1] / 3.0 * (2.0 * c[sys - 1]);
+    // column 4 (index 3)
+    coeff[0 * 5 + 3] = 0.0;
+    for i in 1..=(m - 1) {
+        coeff[i * 5 + 3] = c[i - 1];
+    }
+    // column 5 (index 4)
+    coeff[0 * 5 + 4] = 1.0 / (3.0 * h[0]) * c[0];
+    for i in 1..=(n - 3) {
+        coeff[i * 5 + 4] = 1.0 / (3.0 * h[i]) * (c[i] - c[i - 1]);
+    }
+    coeff[(m - 1) * 5 + 4] = 1.0 / (3.0 * h[m - 1]) * (-c[sys - 1]);
+    coeff
+}
+
+/// Evaluate the spline at `x`. Returns [value, 1st deriv, 2nd deriv]. `j_start`
+/// carries the saved interval guess between calls (value-independent; x clamped).
+pub fn spline_val_0(coeff: &[f64], nseg: usize, x: f64, j_start: &mut i32) -> [f64; 3] {
+    let n = nseg + 1;
+    let mut j = *j_start;
+    if j < 1 || j >= n as i32 {
+        j = 1;
+    }
+    if n <= 1 {
+        return [0.0, 0.0, 0.0];
+    }
+    let c = |i: usize, k: usize| coeff[i * 5 + k];
+    let mut ji = (j - 1) as usize;
+    if x < c(ji, 0) {
+        while ji > 0 {
+            if x < c(ji, 0) {
+                ji -= 1;
+            } else {
+                break;
+            }
+        }
+    } else {
+        while ji < n - 2 {
+            if x >= c(ji + 1, 0) {
+                ji += 1;
+            } else {
+                break;
+            }
+        }
+    }
+    *j_start = ji as i32 + 1;
+    let z = x - c(ji, 0);
+    [
+        ((c(ji, 4) * z + c(ji, 3)) * z + c(ji, 2)) * z + c(ji, 1),
+        (3.0 * c(ji, 4) * z + 2.0 * c(ji, 3)) * z + c(ji, 2),
+        6.0 * c(ji, 4) * z + 2.0 * c(ji, 3),
+    ]
+}

--- a/port_rust/src/transport.rs
+++ b/port_rust/src/transport.rs
@@ -1,0 +1,125 @@
+//! Velocity-space transport integration, literal port of neort_transport
+//! (transport.f90). Produces D11/D12 and torque density for one harmonic.
+
+use crate::driftorbit as dorb;
+use crate::field::{do_magfie, do_magfie_pert_amp, with_field, SIGN_THETA};
+use crate::orbit::{bounce_fast_ext, get_s, poloidal_velocity, NVAR};
+use crate::profiles;
+use crate::freq::om_th;
+use crate::resonance::{driftorbit_coarse, driftorbit_root};
+use std::cell::Cell;
+
+const PI: f64 = std::f64::consts::PI;
+
+thread_local! {
+    static OMTH: Cell<f64> = Cell::new(0.0);
+}
+
+fn d11int(ux: f64, taub: f64, hmn2: f64) -> f64 {
+    let d = dorb::get();
+    let q = with_field(|f| f.q);
+    let psi_pr = with_field(|f| f.psi_pr);
+    let p = profiles::get();
+    PI.powf(1.5) * (d.mph * d.mph) as f64 * profiles::C * profiles::C * q * p.vth
+        / (p.qi * p.qi * d.dvds * psi_pr.abs())
+        * ux * ux * ux * (-ux * ux).exp() * taub * hmn2
+}
+fn d12int(ux: f64, taub: f64, hmn2: f64) -> f64 {
+    d11int(ux, taub, hmn2) * ux * ux
+}
+fn tphi_int(ux: f64, taub: f64, hmn2: f64) -> f64 {
+    let d = dorb::get();
+    let (q, psi_pr) = with_field(|f| (f.q, f.psi_pr));
+    let p = profiles::get();
+    let sgn = if psi_pr * q * SIGN_THETA >= 0.0 { 1.0 } else { -1.0 };
+    sgn * PI.powf(1.5) * (d.mph * d.mph) as f64 * p.ni1 * profiles::C * p.vth / p.qi
+        * ux * ux * ux * (-ux * ux).exp() * taub * hmn2 * (p.a1 + p.a2 * ux * ux)
+}
+
+pub fn timestep_transport(v: f64, eta: f64, neq: usize, t: f64, y: &[f64], ydot: &mut [f64]) {
+    let _ = neq;
+    let s = get_s();
+    let (bmod, _sqrtg, bder, _hcov, hctrvr) = do_magfie(&[s, 0.0, y[0]]);
+    poloidal_velocity(v, eta, bmod, hctrvr[2], bder[2], y[1], ydot);
+    let d = dorb::get();
+    let q = with_field(|f| f.q);
+    let omth = OMTH.with(|c| c.get());
+
+    // epsn (complex)
+    let (er, ei) = if d.pertfile {
+        let (ar, ai) = do_magfie_pert_amp(&[s, 0.0, y[0]]);
+        (d.epsmn * ar / bmod, d.epsmn * ai / bmod)
+    } else {
+        (d.epsmn * (d.m0 as f64 * y[0]).cos(), d.epsmn * (d.m0 as f64 * y[0]).sin())
+    };
+    // phase
+    let ph = if eta > d.etatp {
+        q * d.mph as f64 * y[0] - d.mth as f64 * t * omth
+    } else {
+        q * d.mph as f64 * y[0] - (d.mth as f64 + q * d.mph as f64) * t * omth
+    };
+    let (cr, ci) = (ph.cos(), ph.sin());
+    let amp = 2.0 - eta * bmod;
+    // Hn = amp * epsn * exp(i ph)
+    let hr = amp * (er * cr - ei * ci);
+    let hi = amp * (er * ci + ei * cr);
+    ydot[2] = hr;
+    ydot[3] = hi;
+    if d.nonlin {
+        ydot[4] = 1.0 / bmod;
+        ydot[5] = bmod;
+    } else {
+        ydot[4] = 0.0;
+        ydot[5] = 0.0;
+    }
+    ydot[6] = 0.0;
+}
+
+/// Midpoint integral over v: returns (D[2], T).
+pub fn compute_transport_integral(vmin: f64, vmax: f64, vsteps: usize) -> ([f64; 2], f64) {
+    let p = profiles::get();
+    let vth = p.vth;
+    let d0 = dorb::get();
+    let mut roots = vec![0.0f64; dorb::NLEV * 3];
+    let mut d = [0.0f64; 2];
+    let mut t = 0.0f64;
+    let du = (vmax - vmin) / (vsteps as f64 * vth);
+    let mut ux = vmin / vth + du / 2.0;
+    let om_te = p.om_te;
+    let mi = p.mi;
+
+    for _ku in 1..=vsteps {
+        let v = ux * vth;
+        let nroots = driftorbit_coarse(v, d0.etamin, d0.etamax, &mut roots, dorb::NLEV);
+        for kr in 0..nroots {
+            let (eta, dres) = driftorbit_root(v, 1.0e-8 * om_te.abs(), roots[kr * 3], roots[kr * 3 + 1]);
+            let (omth, _dv, _de) = om_th(v, eta);
+            OMTH.with(|c| c.set(omth));
+            let taub = 2.0 * PI / omth.abs();
+            let (bavg, _ist): ([f64; NVAR], i32) = bounce_fast_ext(v, eta, taub, timestep_transport);
+            let hmn2 = (bavg[2] * bavg[2] + bavg[3] * bavg[3]) * (mi * (ux * vth) * (ux * vth) / 2.0).powi(2);
+            let atten = if d0.nonlin {
+                panic!("nonlinear attenuation path not ported (outside golden gate)");
+            } else {
+                1.0
+            };
+            let dd11 = du * d11int(ux, taub, hmn2) / dres.abs();
+            let dd12 = du * d12int(ux, taub, hmn2) / dres.abs();
+            d[0] += dd11 * atten;
+            d[1] += dd12 * atten;
+            if d0.comptorque {
+                let dt = du * tphi_int(ux, taub, hmn2) / dres.abs();
+                t += dt * atten;
+            }
+        }
+        ux += du;
+    }
+
+    let (r0, iota) = with_field(|f| (f.r0, f.iota));
+    let a = with_field(|f| f.a);
+    let d_plateau = PI * vth.powi(3) / (16.0 * r0 * iota * (p.qi * d0.b0 / (mi * profiles::C)).powi(2));
+    let dsdreff = 2.0 / a * get_s().sqrt();
+    d[0] = dsdreff.powi(-2) * d[0] / d_plateau;
+    d[1] = dsdreff.powi(-2) * d[1] / d_plateau;
+    (d, t)
+}


### PR DESCRIPTION
This draft PR publishes the existing committed state of `port/rust` so the local branch/worktree can be retired after review.

Checks were not run in this cleanup operation; the branch-specific CI should provide validation.